### PR TITLE
Make the restore-screen paste-seed shortcut available in all non-AppStore builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [Ironwood] Warn before confirming a send that has to spend Orchard funds: the confirmation screen now shows a sheet recommending migration first, with the option to continue or cancel.
 
 ### Changed
+- The paste-seed shortcut on the Secret Recovery Phrase screen (long-press the title) now works in internal and testnet builds — including TestFlight — instead of debug builds only. It stays excluded from the App Store build.
 - [MOB-1678] Coinholder Polling now loads its trusted configuration through the resilient voting config gateway, so a GitHub outage no longer blocks configuration loading while the mirrored copy is available.
 - [MOB-1466] Starting a migration now holds you on a "Scheduling…" screen while the schedule is confirmed and the first step is prepared, instead of leaving you on the plan under a spinning button for up to half a minute. The summary fills in with your real numbers the moment it is ready.
 - [MOB-1466] The migration split details sheet now scrolls when a split has more than five steps, so long splits stay readable and the sheet's total and "Got it" button stay reachable. Shorter splits are unchanged.

--- a/Scripts/validate-partner-keys.sh
+++ b/Scripts/validate-partner-keys.sh
@@ -20,7 +20,8 @@ SRCROOT="${SRCROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 PLIST="${SRCROOT}/secant/Resources/PartnerKeys.plist"
 
 # Each key must be present, of type String, and non-empty. testSeed is
-# gated to non-AppStore builds (#if !SECANT_DISTRIB) and intentionally excluded from archive validation.
+# gated to non-AppStore builds (#if !SECANT_DISTRIB) and intentionally
+# excluded from archive validation.
 REQUIRED_KEYS="flexaPublishableKey flexaPublishableTestKey nearKey cmcKey nearFeeDepositAddress nearAPIKey"
 
 errors=()

--- a/Scripts/validate-partner-keys.sh
+++ b/Scripts/validate-partner-keys.sh
@@ -20,7 +20,7 @@ SRCROOT="${SRCROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 PLIST="${SRCROOT}/secant/Resources/PartnerKeys.plist"
 
 # Each key must be present, of type String, and non-empty. testSeed is
-# #if DEBUG-only and intentionally excluded from archive validation.
+# gated to non-AppStore builds (#if !SECANT_DISTRIB) and intentionally excluded from archive validation.
 REQUIRED_KEYS="flexaPublishableKey flexaPublishableTestKey nearKey cmcKey nearFeeDepositAddress nearAPIKey"
 
 errors=()

--- a/secant/Sources/Dependencies/PartnerKeys/PartnerKeys.swift
+++ b/secant/Sources/Dependencies/PartnerKeys/PartnerKeys.swift
@@ -17,7 +17,7 @@ struct PartnerKeys {
         static let nearKey = "nearKey"
         static let cmcKey = "cmcKey"
         static let nearFeeDepositAddress = "nearFeeDepositAddress"
-#if DEBUG
+#if !SECANT_DISTRIB
         static let testSeed = "testSeed"
 #endif
     }
@@ -46,7 +46,7 @@ struct PartnerKeys {
         PartnerKeys.value(for: Constants.nearFeeDepositAddress)
     }
     
-#if DEBUG
+#if !SECANT_DISTRIB
     static var testSeed: String? {
         PartnerKeys.value(for: Constants.testSeed)
     }

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowStore.swift
@@ -69,7 +69,7 @@ struct RestoreWalletCoordFlow {
         case suggestedWordTapped(String)
         case suggestionsRequested(Int, Bool)
         case updateKeyboardFlag(Bool)
-        #if DEBUG
+        #if !SECANT_DISTRIB
         case debugPasteSeed
         #endif
         
@@ -179,7 +179,7 @@ struct RestoreWalletCoordFlow {
                 state.isKeyboardVisible = value
                 return .none
                 
-#if DEBUG
+#if !SECANT_DISTRIB
             case .debugPasteSeed:
                 do {
                     var testSeed = ""

--- a/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/RestoreWalletCoordFlowView.swift
@@ -205,7 +205,7 @@ struct RecoverySeedPhraseEntryView: View {
                             .zFont(.semiBold, size: 24, style: Design.Text.primary)
                             .padding(.top, 20)
                             .onLongPressGesture {
-#if DEBUG
+#if !SECANT_DISTRIB
                                 store.send(.debugPasteSeed)
 #endif
                             }

--- a/zodlTests/RestoreWalletTests/RestoreWalletPasteSeedTests.swift
+++ b/zodlTests/RestoreWalletTests/RestoreWalletPasteSeedTests.swift
@@ -4,12 +4,12 @@
 //
 //  The paste-seed shortcut — long-pressing the "Secret Recovery Phrase" title on the
 //  seed-entry screen sends `.debugPasteSeed`, which fills the 24 word fields from the
-//  pasteboard, falling back to `PartnerKeys.testSeed` when the pasteboard content is not
-//  a valid mnemonic. These tests characterize that reducer path; they guard it while its
-//  compile-time gate moves from `#if DEBUG` to `#if !SECANT_DISTRIB`. The gate itself
-//  cannot be unit-tested from a Debug test build — it is proven by building the
-//  Release-AppStore configuration (feature compiled out) and the Release-Testflight
-//  configuration (feature compiled in).
+//  pasteboard, falling back to `PartnerKeys.testSeed` when the pasteboard is empty or its
+//  content is not a valid mnemonic. These tests characterize that reducer path; they
+//  guard it while its compile-time gate moves from `#if DEBUG` to `#if !SECANT_DISTRIB`.
+//  The gate itself cannot be unit-tested from a Debug test build — it is proven by
+//  building the Release-AppStore configuration (feature compiled out) and the
+//  Release-Testflight configuration (feature compiled in).
 //
 //  RestoreWalletCoordFlow.State is not Equatable (it holds a non-Equatable StackState and
 //  an Action-typed AlertState), so TestStore will not compile against it. These tests
@@ -17,10 +17,12 @@
 //  as RestoreWalletAnnouncementFlagTests in this directory. Initial state is set up
 //  before Store creation (store.state is get-only on a plain Store).
 //
-//  PartnerKeys is a static bundle-plist lookup that cannot be injected, and
-//  PartnerKeys.plist is gitignored, so the fallback test computes its expectation from
-//  PartnerKeys.testSeed at runtime: with the plist absent it expects the untouched-fields
-//  path, with a testSeed present it expects that seed to be applied.
+//  PartnerKeys is a static bundle-plist lookup that cannot be injected and
+//  PartnerKeys.plist is gitignored, so which fallback branch is reachable depends on the
+//  machine — the testSeed-application test runs only where a testSeed exists
+//  (`.enabled(if:)`), the untouched-fields tests only where it does not
+//  (`.disabled(if:)`); a skipped test is visible in the report, unlike a silently-taken
+//  default branch.
 //
 //  .debugPasteSeed does all its work synchronously inside the reducer body and returns
 //  .none, so no waiting is needed after `send`.
@@ -52,7 +54,8 @@ import ComposableArchitecture
         #expect(store.state.isKeyboardVisible == false)
     }
 
-    @Test func pasteInvalidSeedFallsBackToPartnerKeysTestSeed() {
+    @Test(.enabled(if: PartnerKeys.testSeed != nil))
+    func pasteInvalidSeedAppliesTestSeed() {
         let store = Store(initialState: RestoreWalletCoordFlow.State()) {
             RestoreWalletCoordFlow()
         } withDependencies: {
@@ -62,14 +65,46 @@ import ComposableArchitecture
 
         store.send(.debugPasteSeed)
 
-        if let testSeed = PartnerKeys.testSeed {
-            // A local PartnerKeys.plist provides a fallback seed; the shortcut applies it.
-            #expect(store.state.words == testSeed.components(separatedBy: " "))
-            #expect(store.state.isValidSeed == true)
-        } else {
-            // No PartnerKeys.plist (it is gitignored): the shortcut leaves the fields untouched.
-            #expect(store.state.words == Array(repeating: "", count: 24))
-            #expect(store.state.isValidSeed == false)
+        let testSeed = PartnerKeys.testSeed ?? ""
+        #expect(store.state.words == testSeed.components(separatedBy: " "))
+        #expect(store.state.isValidSeed == true)
+    }
+
+    @Test(.disabled(if: PartnerKeys.testSeed != nil))
+    func pasteInvalidSeedWithoutTestSeedLeavesWordsAndMarksInvalid() {
+        var initialState = RestoreWalletCoordFlow.State()
+        initialState.words[3] = "hello"
+        initialState.isValidSeed = true
+
+        let store = Store(initialState: initialState) {
+            RestoreWalletCoordFlow()
+        } withDependencies: {
+            $0.pasteboard.getString = { "definitely not a seed".redacted }
+            $0.mnemonic.isValid = { _ in throw InvalidSeed() }
         }
+
+        store.send(.debugPasteSeed)
+
+        #expect(store.state.words[3] == "hello")
+        #expect(store.state.isValidSeed == false)
+    }
+
+    @Test(.disabled(if: PartnerKeys.testSeed != nil))
+    func emptyPasteboardWithoutTestSeedLeavesWordsAndMarksInvalid() {
+        var initialState = RestoreWalletCoordFlow.State()
+        initialState.words[3] = "hello"
+        initialState.isValidSeed = true
+
+        let store = Store(initialState: initialState) {
+            RestoreWalletCoordFlow()
+        } withDependencies: {
+            $0.pasteboard.getString = { nil }
+            $0.mnemonic.isValid = { _ in throw InvalidSeed() }
+        }
+
+        store.send(.debugPasteSeed)
+
+        #expect(store.state.words[3] == "hello")
+        #expect(store.state.isValidSeed == false)
     }
 }

--- a/zodlTests/RestoreWalletTests/RestoreWalletPasteSeedTests.swift
+++ b/zodlTests/RestoreWalletTests/RestoreWalletPasteSeedTests.swift
@@ -1,0 +1,75 @@
+//
+//  RestoreWalletPasteSeedTests.swift
+//  zodlTests
+//
+//  The paste-seed shortcut — long-pressing the "Secret Recovery Phrase" title on the
+//  seed-entry screen sends `.debugPasteSeed`, which fills the 24 word fields from the
+//  pasteboard, falling back to `PartnerKeys.testSeed` when the pasteboard content is not
+//  a valid mnemonic. These tests characterize that reducer path; they guard it while its
+//  compile-time gate moves from `#if DEBUG` to `#if !SECANT_DISTRIB`. The gate itself
+//  cannot be unit-tested from a Debug test build — it is proven by building the
+//  Release-AppStore configuration (feature compiled out) and the Release-Testflight
+//  configuration (feature compiled in).
+//
+//  RestoreWalletCoordFlow.State is not Equatable (it holds a non-Equatable StackState and
+//  an Action-typed AlertState), so TestStore will not compile against it. These tests
+//  drive a plain Store and read state directly after sending actions — the same approach
+//  as RestoreWalletAnnouncementFlagTests in this directory. Initial state is set up
+//  before Store creation (store.state is get-only on a plain Store).
+//
+//  PartnerKeys is a static bundle-plist lookup that cannot be injected, and
+//  PartnerKeys.plist is gitignored, so the fallback test computes its expectation from
+//  PartnerKeys.testSeed at runtime: with the plist absent it expects the untouched-fields
+//  path, with a testSeed present it expects that seed to be applied.
+//
+//  .debugPasteSeed does all its work synchronously inside the reducer body and returns
+//  .none, so no waiting is needed after `send`.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+@MainActor struct RestoreWalletPasteSeedTests {
+    struct InvalidSeed: Error { }
+
+    @Test func pasteValidSeedFillsAllWordFields() {
+        let seedWords = (1...24).map { "word\($0)" }
+        var initialState = RestoreWalletCoordFlow.State()
+        initialState.isKeyboardVisible = true
+
+        let store = Store(initialState: initialState) {
+            RestoreWalletCoordFlow()
+        } withDependencies: {
+            $0.pasteboard.getString = { seedWords.joined(separator: " ").redacted }
+            $0.mnemonic.isValid = { _ in }
+        }
+
+        store.send(.debugPasteSeed)
+
+        #expect(store.state.words == seedWords)
+        #expect(store.state.isValidSeed == true)
+        #expect(store.state.isKeyboardVisible == false)
+    }
+
+    @Test func pasteInvalidSeedFallsBackToPartnerKeysTestSeed() {
+        let store = Store(initialState: RestoreWalletCoordFlow.State()) {
+            RestoreWalletCoordFlow()
+        } withDependencies: {
+            $0.pasteboard.getString = { "definitely not a seed".redacted }
+            $0.mnemonic.isValid = { _ in throw InvalidSeed() }
+        }
+
+        store.send(.debugPasteSeed)
+
+        if let testSeed = PartnerKeys.testSeed {
+            // A local PartnerKeys.plist provides a fallback seed; the shortcut applies it.
+            #expect(store.state.words == testSeed.components(separatedBy: " "))
+            #expect(store.state.isValidSeed == true)
+        } else {
+            // No PartnerKeys.plist (it is gitignored): the shortcut leaves the fields untouched.
+            #expect(store.state.words == Array(repeating: "", count: 24))
+            #expect(store.state.isValidSeed == false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The paste-seed shortcut (long-press the **Secret Recovery Phrase** title on the seed-entry screen to fill the 24 word fields from the pasteboard, falling back to the `testSeed` from `PartnerKeys.plist`) was gated with `#if DEBUG`, so TestFlight builds — which archive with the `Release-Testflight` configuration — never had it. This PR moves the gate to `#if !SECANT_DISTRIB`:

- **Available** in every configuration of `zodl-internal` and `zodl-testnet`, including TestFlight archives.
- **Compiled out** of the App Store build: `SECANT_DISTRIB` is defined in exactly one (target, configuration) pair — `zodl-production` × `Release-AppStore`, the configuration the `zodl-AppStore` scheme archives with.

`#if !SECANT_DISTRIB` is the codebase's established idiom for this exact semantics (`AdvancedSettingsView`, `GlobalNavBar`, `SecantApp`).

## Changes

- `RestoreWalletCoordFlowStore.swift` / `RestoreWalletCoordFlowView.swift`: the three feature gates (action case, reducer handler, view send) flip from `#if DEBUG` to `#if !SECANT_DISTRIB`.
- `PartnerKeys.swift`: `testSeed` (constant + accessor) moves to the same gate — the reducer references it, and compiling the handler in Release configurations requires the member to exist there. The accessor still returns `nil` gracefully when the plist or key is absent.
- `Scripts/validate-partner-keys.sh`: comment updated to match (`testSeed` remains deliberately excluded from archive validation; no logic change).
- New `RestoreWalletPasteSeedTests` suite characterizes the reducer path: pasteboard fill, invalid-content fallback, and empty-pasteboard fallback. The fallback tests are environment-gated with `.enabled(if:)`/`.disabled(if:)` on `PartnerKeys.testSeed` so machines without the gitignored plist report a visible skip instead of silently asserting default state, and they start from non-default state so the assertions prove the reducer acted.
- `CHANGELOG.md` entry under Unreleased/Changed.

## Verification

- `xcodebuild build` of `zodl-AppStore` × `Release-AppStore`: **BUILD SUCCEEDED** — proves the feature compiles out cleanly (a missed gate site would fail this build).
- `xcodebuild build` of `zodl-internal` × `Release-Testflight`: **BUILD SUCCEEDED** — this code had never compiled without `DEBUG` before; this build is what surfaced the `PartnerKeys.testSeed` gate requirement.
- Full `zodlTests` suite on the final tree: **1309 tests in 190 suites passed** (2 pre-existing known issues).

Note: both proof builds ran with `ARCHS=arm64` because the local SDK checkout's `libzcashlc.xcframework` currently ships no x86_64 simulator slice (pre-existing on the branch base, unrelated to this change).

---

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Does the code abide by the [Coding Guidelines](../blob/main/docs/CODING_GUIDELINES.md)?
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/main/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage before and after your changes and when possible, leave it in a better place. [Learn More...](../blob/main/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/main/README.md), [LICENSE.md](../blob/main/LICENSE.md), and [Architecture.md](../blob/main/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)