### PR TITLE
[MOB-1753] Explain vote submission duration on the submission progress panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Added
+- [MOB-1753] The vote submission screen now explains that submitting can take a few minutes and that wallets with more voting weight take longer to process.
 - [MOB-1466] Advanced Settings now offers "Restart Migration" while a migration is running. It shows how much has already migrated and how much is left, warns that restarting cancels the current plan for good, and asks for a separate confirmation before anything happens. Transfers that already went out are untouched — they stay migrated — and once the plan is cancelled you set up a new one for the remaining balance the same way you did the first time.
 - [MOB-1466] With a privacy migration in progress, keeping the app open now advances the migration automatically — transfers send on schedule without reopening the app.
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -2860,6 +2860,23 @@
         }
       }
     },
+    "coinVote.confirmSubmission.progressExplainer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This can take a few minutes. Wallets with more voting weight take longer to process."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto puede tardar unos minutos. Las billeteras con más peso de votación tardan más en procesarse."
+          }
+        }
+      }
+    },
     "coinVote.confirmSubmission.progressSubmittingVoteCount" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
+++ b/secant/Sources/Features/Voting/ConfirmSubmission/ConfirmSubmissionView.swift
@@ -340,8 +340,14 @@ struct ConfirmSubmissionView: View {
             )
             VStack(spacing: Design.Spacing._lg) {
                 VStack(alignment: .leading, spacing: Design.Spacing._lg) {
-                    Text(progressInfo.title)
-                        .zFont(.semiBold, size: 15, style: Design.Text.primary)
+                    VStack(alignment: .leading, spacing: Design.Spacing._xs) {
+                        Text(progressInfo.title)
+                            .zFont(.semiBold, size: 15, style: Design.Text.primary)
+
+                        Text(localizable: .coinVoteConfirmSubmissionProgressExplainer)
+                            .zFont(size: 14, style: Design.Text.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
 
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {


### PR DESCRIPTION
Adds an explainer under the progress title on the vote submission bottom panel: "This can take a few minutes. Wallets with more voting weight take longer to process."

- New localizable key `coinVote.confirmSubmission.progressExplainer` in EN and ES (ES is machine-translated — no human translation available).
- Changelog entry under Unreleased / Added.

Build gate: `zodl-internal` scheme, iPhone 17 Pro simulator — BUILD SUCCEEDED. Manually tested on device by @LukasKorba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)