### PR TITLE
[MOB-1802] Back the voting Keystone QR with a white plate so dark mode stays scannable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] Swiping back off the very first screen shown when re-opening an in-progress migration now closes the migration flow, instead of leaving a blank, stuck screen with no way forward except quitting the app.
 - The Confirm button on a migration transfer plan now keeps its loading indicator up until your transfers are prepared and presigned (the first delivery kicked off), then opens the Migration Scheduled screen — one tap, no dead first tap, and the Home banner reflects the committed run when you return. The Confirm button still can no longer be tapped again after a successful commit.
 - [Ironwood] Accepting a migration plan on a large wallet no longer stalls for tens of minutes — plan commit completes promptly.
+- [MOB-1802] Keystone voting signing QR is now drawn on a white plate like the send-flow QR, so Keystone devices can scan it in dark mode.
 
 ## 3.7.3 build 1 (20026-07-12)
 

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -191,8 +191,22 @@ struct DelegationSigningView: View {
                 if let pczt = store.roundCache[roundId]?.pendingUnsignedDelegationPczt,
                    let encoder = sdkSynchronizer.urEncoderForPCZT(pczt),
                    !isQRCodeEnlarged {
-                    AnimatedQRCode(urEncoder: encoder, size: 216)
+                    // CIQRCodeGenerator emits only a 1-module quiet zone, so the QR is
+                    // scannable only on a light surround. Match SignWithKeystoneView's
+                    // proven composition: 250pt code on a bone (always-white) plate —
+                    // bgPrimary is midnight in dark mode and Keystone cameras cannot
+                    // lock onto the code without the white margin.
+                    AnimatedQRCode(urEncoder: encoder, size: 250)
                         .frame(width: 216, height: 216)
+                        .padding(24)
+                        .background {
+                            RoundedRectangle(cornerRadius: Design.Radius._xl)
+                                .fill(Asset.Colors.ZDesign.Base.bone.color)
+                                .background {
+                                    RoundedRectangle(cornerRadius: Design.Radius._xl)
+                                        .stroke(Design.Surfaces.strokeSecondary.color(colorScheme))
+                                }
+                        }
                         .onTapGesture {
                             withAnimation(.easeInOut) {
                                 isQRCodeEnlarged = true
@@ -221,7 +235,7 @@ struct DelegationSigningView: View {
                     .padding(24)
                 }
         }
-        .frame(width: 248, height: 248)
+        .frame(width: 264, height: 264)
         .background {
             RoundedRectangle(cornerRadius: Design.Radius._3xl)
                 .fill(Design.Surfaces.bgPrimary.color(colorScheme))


### PR DESCRIPTION
## Root cause

Keystone devices could not scan the coinholder-polling signing QR when the phone was in **dark mode** (reported as "no progress" / "stuck at 7%", MOB-1802 / MOB-1798 thread; reproduced locally in dark mode).

- `CIQRCodeGenerator` (used by `AnimatedQRCode`) emits only a **1-module quiet zone**; the QR spec requires 4 modules, so our codes are scannable only when the surrounding UI supplies the light border.
- Every other Keystone QR surface (send flow `SignWithKeystoneView`, migration `MigrationKeystoneSignView`, and Android's voting QR) backs the code with an always-white plate.
- The voting `DelegationSigningView` was the one exception: it drew the QR at 216pt directly on `Design.Surfaces.bgPrimary`, which is midnight `#231F20` in dark mode — leaving a ~2pt effective quiet zone against near-black. Phone cameras tolerate that; Keystone's embedded scanner does not. The send-flow QR kept working on the same phones because of its white plate, which is what made the reports look device- and wallet-specific.

## Fix

Replicate the send flow's proven composition in `qrCodeSection`'s `.awaitingSignature` branch: `AnimatedQRCode` at 250pt in a 216pt layout box with 24pt padding on an `Asset.Colors.ZDesign.Base.bone` (always-white) plate with the standard stroke, and widen the container card 248→264 so the plate fills it. All other states of the card and the tap-to-enlarge overlay (already white-backed) are unchanged.

## Verification

- Build succeeds (`zodl-internal`, arm64 iOS Simulator destination, `-skipMacroValidation`, repo-local DerivedData) with zero SwiftLint violations. Note: a `generic/platform=iOS Simulator` build fails at link on this machine because the locally built `libzcashlc.xcframework` carries no x86_64 simulator slice — pre-existing, confirmed identical on unmodified `main`.
- Pure view-layer styling change replicating the proven send-flow layout; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)