### PR TITLE
Fix voting submission recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ directly impact users rather than highlighting other crucial architectural updat
 - [MOB-1466] The "Updating…" label and the "Balances as of ~N min ago" line have been removed from the Migration Progress screen. Both described how fresh ZODL's own reads were rather than anything you can act on, and neither was part of the design.
 
 ### Fixed
+- Coinholder Polling now recovers an ambiguously submitted delegation or vote by checking its exact transaction hash, and reopening a poll no longer discards persisted delegation setup needed to retry safely.
 - [MOB-1630] The migration banner no longer offers a migration when the account's Orchard balance is below 0.01 ZEC/TAZ — the smallest amount a migration can move. Such an offer could never be fulfilled: tapping it always ended on a failure screen, and the "Migration Required" banner never went away.
 - [MOB-1581] A sent transaction no longer stays stuck showing "Sending…" after it has confirmed. ZODL no longer misses the confirmation signal when it arrives alongside other synchronizer events, keeps refreshing the transaction list after the app returns from the background (previously a single background/foreground cycle silently stopped the automatic refresh until the app was relaunched), and additionally re-checks pending transactions every 30 seconds as a safety net.
 - [MOB-1670] "Split Balance" rows in the migration plan and Migration Progress timelines now always show the coins-swap icon instead of sometimes borrowing a transfer's step number. A split row could previously appear as "1" — while its transaction was confirming, once its window had passed, or for the second and later rows of a balance that splits in several steps — which read as though it were the first transfer rather than the preparation step that comes before them.
@@ -1113,4 +1114,3 @@ issue for more details.
 --------
 - Added SwiftGen templates for generating asset helper files.
 - Added Code Review Guides, Changelog, pull request and issue templates, SwiftLint Rules
-

--- a/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingAPIClient/VotingAPIClientLiveKey.swift
@@ -44,7 +44,6 @@ enum SvAPIError: LocalizedError {
     case httpError(statusCode: Int, message: String)
     case invalidResponse(String)
     case noActiveVotingSession
-    case txFailed(code: UInt32, log: String)
 
     var errorDescription: String? {
         switch self {
@@ -54,8 +53,6 @@ enum SvAPIError: LocalizedError {
             return "Invalid API response: \(detail)"
         case .noActiveVotingSession:
             return "No active voting round"
-        case .txFailed(let code, let log):
-            return "Transaction failed (code \(code)): \(log)"
         }
     }
 }
@@ -100,8 +97,8 @@ enum SvAPIResponseParser {
                 (candidate["error"] as? String) ??
                 ""
 
-            if code != 0 {
-                throw SvAPIError.txFailed(code: code, log: log)
+            if code == 0, txHash.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw SvAPIError.invalidResponse("successful tx response is missing tx_hash")
             }
             return TxResult(txHash: txHash, code: code, log: log)
         }
@@ -333,15 +330,20 @@ private func postJSON(_ path: String, body: [String: Any], baseURL base: String)
         throw SvAPIError.invalidResponse("not an HTTP response")
     }
     guard http.statusCode == 200 else {
-        // 422 = chain processed the request but rejected the TX (non-zero CheckTx code).
-        // Parse the structured body for code/log instead of returning a raw HTTP error.
-        if http.statusCode == 422,
-           let json = try? SvAPIResponseParser.parseJSONObject(data, response: http, context: "POST \(path)") {
-            let code = (json["code"] as? NSNumber)?.uint32Value ?? 0
-            let log = json["log"] as? String ?? ""
-            if code != 0 {
-                throw SvAPIError.txFailed(code: code, log: log)
+        // A deterministic CheckTx rejection still carries the hash of the
+        // submitted bytes. Preserve it so the caller can verify whether that
+        // exact transaction was accepted by an earlier broadcast attempt.
+        if http.statusCode == 422 {
+            let json = try SvAPIResponseParser.parseJSONObject(
+                data,
+                response: http,
+                context: "POST \(path)"
+            )
+            let result = try SvAPIResponseParser.parseTxResult(json)
+            guard result.code != 0 else {
+                throw SvAPIError.invalidResponse("HTTP 422 tx response has code 0")
             }
+            return json
         }
         let body = String(data: data, encoding: .utf8) ?? ""
         throw SvAPIError.httpError(statusCode: http.statusCode, message: body)
@@ -606,7 +608,7 @@ func resubmitSharePayload(
     return []
 }
 
-/// Parse a broadcast TX response into TxResult. Throws on non-zero code.
+/// Parse a broadcast TX response into TxResult, preserving deterministic rejections.
 private func parseTxResult(_ json: [String: Any]) throws -> TxResult {
     try SvAPIResponseParser.parseTxResult(json)
 }

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -915,7 +915,8 @@ extension VotingCoordFlow {
                             }
                         }
 
-                        if recoveredBundleCount >= existingBundleCount {
+                        let delegationReady = recoveredBundleCount >= existingBundleCount
+                        if delegationReady {
                             try await votingCrypto.clearRecoveryState(roundId)
                         }
 
@@ -931,13 +932,28 @@ extension VotingCoordFlow {
                             return
                         }
                         await send(.earlyEligibilityConfirmed(roundId: roundId))
+                        let witnesses: [WitnessData]
+                        if delegationReady {
+                            witnesses = []
+                        } else {
+                            witnesses = try await Self.completeDeterministicRoundSetup(
+                                roundId: roundId,
+                                snapshotHeight: snapshotHeight,
+                                walletDbPath: walletDbPath,
+                                networkId: networkId,
+                                notes: notes,
+                                bundleCount: existingBundleCount,
+                                votingCrypto: votingCrypto,
+                                sdkSynchronizer: sdkSynchronizer
+                            )
+                        }
                         await send(.votingWeightLoaded(
                             roundId: roundId,
                             weight: eligibleWeight,
                             notes: notes,
-                            witnesses: [],
+                            witnesses: witnesses,
                             bundleCount: existingBundleCount,
-                            delegationReady: recoveredBundleCount >= existingBundleCount
+                            delegationReady: delegationReady
                         ))
                     } else {
                         if isKeystoneUser {
@@ -3342,8 +3358,8 @@ extension VotingCoordFlow {
         return (bundleResult.eligibleWeight, UInt32(bundleResult.bundles.count))
     }
 
-    /// Bundle rows contain non-reproducible delegation randomness. Once any
-    /// exist, restart recovery must resume them instead of clearing the round.
+    /// Once bundle rows exist, the round may contain non-reproducible
+    /// delegation material. Restart recovery must preserve the entire round.
     static func shouldResumePersistedRound(existingBundleCount: UInt32) -> Bool {
         existingBundleCount > 0
     }
@@ -3415,6 +3431,40 @@ extension VotingCoordFlow {
         // (the slow part of the pipeline) completes.
         await send(.earlyEligibilityConfirmed(roundId: roundId))
 
+        let allWitnesses = try await completeDeterministicRoundSetup(
+            roundId: roundId,
+            snapshotHeight: snapshotHeight,
+            walletDbPath: walletDbPath,
+            networkId: networkId,
+            notes: notes,
+            bundleCount: bundleCount,
+            votingCrypto: votingCrypto,
+            sdkSynchronizer: sdkSynchronizer
+        )
+
+        await send(.votingWeightLoaded(
+            roundId: roundId,
+            weight: eligibleWeight,
+            notes: notes,
+            witnesses: allWitnesses,
+            bundleCount: bundleCount,
+            delegationReady: false
+        ))
+        return true
+    }
+
+    /// Completes only deterministic tree-state and witness work for a persisted
+    /// round. This must not clear the round or rebuild delegation authorization.
+    static func completeDeterministicRoundSetup(
+        roundId: String,
+        snapshotHeight: UInt64,
+        walletDbPath: String,
+        networkId: UInt32,
+        notes: [NoteInfo],
+        bundleCount: UInt32,
+        votingCrypto: VotingCryptoClient,
+        sdkSynchronizer: SDKSynchronizerClient
+    ) async throws -> [WitnessData] {
         let treeStateBytes = try await sdkSynchronizer.getTreeState(snapshotHeight)
         try await votingCrypto.storeTreeState(roundId, treeStateBytes)
 
@@ -3437,16 +3487,7 @@ extension VotingCoordFlow {
             )
             allWitnesses.append(contentsOf: witnesses)
         }
-
-        await send(.votingWeightLoaded(
-            roundId: roundId,
-            weight: eligibleWeight,
-            notes: notes,
-            witnesses: allWitnesses,
-            bundleCount: bundleCount,
-            delegationReady: false
-        ))
-        return true
+        return allWitnesses
     }
 
     /// Look up the live `VotingSession` for a round id by scoping into

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -868,8 +868,10 @@ extension VotingCoordFlow {
                     }
 
                     let heldZatoshi = notes.reduce(UInt64(0)) { $0 + $1.value }
-                    let existingState = try? await votingCrypto.getRoundState(roundId)
-                    let existingBundleCount = (try? await votingCrypto.getBundleCount(roundId)) ?? 0
+                    let (existingState, existingBundleCount) = try await Self.loadExistingRoundSetup(
+                        roundId: roundId,
+                        votingCrypto: votingCrypto
+                    )
                     var preClearKeystoneSignatures: [KeystoneBundleSignatureInfo] = []
                     var resolvedBundleCount: UInt32 = 0
                     var shouldRestoreKeystoneSignatures = isKeystoneUser
@@ -953,7 +955,7 @@ extension VotingCoordFlow {
                             send: send
                         ) else { return }
                         didPrepareFreshRound = true
-                        resolvedBundleCount = (try? await votingCrypto.getBundleCount(roundId)) ?? 0
+                        resolvedBundleCount = try await votingCrypto.getBundleCount(roundId)
                     }
 
                     // 3. Hotkey: load or generate the per-account hotkey
@@ -3344,6 +3346,23 @@ extension VotingCoordFlow {
     /// exist, restart recovery must resume them instead of clearing the round.
     static func shouldResumePersistedRound(existingBundleCount: UInt32) -> Bool {
         existingBundleCount > 0
+    }
+
+    /// Distinguish an absent round from a failed database read. A read failure
+    /// must propagate so the caller cannot mistake it for an empty round and
+    /// authorize `prepareFreshRound` to clear persisted recovery material.
+    static func loadExistingRoundSetup(
+        roundId: String,
+        votingCrypto: VotingCryptoClient
+    ) async throws -> (state: RoundStateInfo?, bundleCount: UInt32) {
+        let rounds = try await votingCrypto.listRounds()
+        guard rounds.contains(where: { $0.roundId == roundId }) else {
+            return (nil, 0)
+        }
+
+        let state = try await votingCrypto.getRoundState(roundId)
+        let bundleCount = try await votingCrypto.getBundleCount(roundId)
+        return (state, bundleCount)
     }
 
     private static func votingWeight(for notes: [NoteInfo], bundleCount: UInt32) -> UInt64 {

--- a/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/VotingCoordFlow/VotingCoordFlowCoordinator.swift
@@ -892,7 +892,7 @@ extension VotingCoordFlow {
                             bundleCount: bundleCount,
                             delegationReady: true
                         ))
-                    } else if existingBundleCount > 0 {
+                    } else if Self.shouldResumePersistedRound(existingBundleCount: existingBundleCount) {
                         resolvedBundleCount = existingBundleCount
                         var recoveredBundleCount: UInt32 = 0
                         var recoveredBundleIndices: Set<UInt32> = []
@@ -917,45 +917,26 @@ extension VotingCoordFlow {
                             try await votingCrypto.clearRecoveryState(roundId)
                         }
 
-                        if recoveredBundleCount > 0 {
-                            if isKeystoneUser {
-                                await send(.delegationBundlesRecovered(
-                                    roundId: roundId,
-                                    bundleIndices: recoveredBundleIndices
-                                ))
-                            }
-                            let eligibleWeight = Self.votingWeight(for: notes, bundleCount: existingBundleCount)
-                            guard eligibleWeight > 0 else {
-                                await send(.ineligibleForRound(roundId: roundId, heldZatoshi: heldZatoshi))
-                                return
-                            }
-                            await send(.earlyEligibilityConfirmed(roundId: roundId))
-                            await send(.votingWeightLoaded(
+                        if isKeystoneUser, !recoveredBundleIndices.isEmpty {
+                            await send(.delegationBundlesRecovered(
                                 roundId: roundId,
-                                weight: eligibleWeight,
-                                notes: notes,
-                                witnesses: [],
-                                bundleCount: existingBundleCount,
-                                delegationReady: recoveredBundleCount >= existingBundleCount
+                                bundleIndices: recoveredBundleIndices
                             ))
-                        } else {
-                            if isKeystoneUser {
-                                preClearKeystoneSignatures = try await votingCrypto.loadKeystoneBundleSignatures(roundId)
-                            }
-                            guard try await Self.prepareFreshRound(
-                                roundId: roundId,
-                                session: session,
-                                snapshotHeight: snapshotHeight,
-                                walletDbPath: walletDbPath,
-                                networkId: networkId,
-                                notes: notes,
-                                votingCrypto: votingCrypto,
-                                sdkSynchronizer: sdkSynchronizer,
-                                send: send
-                            ) else { return }
-                            didPrepareFreshRound = true
-                            resolvedBundleCount = (try? await votingCrypto.getBundleCount(roundId)) ?? 0
                         }
+                        let eligibleWeight = Self.votingWeight(for: notes, bundleCount: existingBundleCount)
+                        guard eligibleWeight > 0 else {
+                            await send(.ineligibleForRound(roundId: roundId, heldZatoshi: heldZatoshi))
+                            return
+                        }
+                        await send(.earlyEligibilityConfirmed(roundId: roundId))
+                        await send(.votingWeightLoaded(
+                            roundId: roundId,
+                            weight: eligibleWeight,
+                            notes: notes,
+                            witnesses: [],
+                            bundleCount: existingBundleCount,
+                            delegationReady: recoveredBundleCount >= existingBundleCount
+                        ))
                     } else {
                         if isKeystoneUser {
                             preClearKeystoneSignatures = try await votingCrypto.loadKeystoneBundleSignatures(roundId)
@@ -1922,6 +1903,9 @@ extension VotingCoordFlow {
 
                         await send(.voteSubmissionStepUpdated(roundId: roundId, step: .confirming))
                         let txResult = try await votingAPI.submitVoteCommitment(builtBundle, castVoteSig)
+                        guard try await Self.isAcceptedVotingTransaction(txResult, votingAPI: votingAPI) else {
+                            throw VotingFlowError.voteCommitmentTxFailed(code: txResult.code, log: txResult.log)
+                        }
                         try await votingCrypto.storeVoteTxHash(roundId, bundleIndex, proposalId, txResult.txHash)
 
                         let voteDeadline = Date().addingTimeInterval(90)
@@ -2962,6 +2946,9 @@ extension VotingCoordFlow {
                         throw VotingFlowError.invalidDelegationSignature
                     }
                     let delegTxResult = try await votingAPI.submitDelegation(registration)
+                    guard try await Self.isAcceptedVotingTransaction(delegTxResult, votingAPI: votingAPI) else {
+                        throw VotingFlowError.delegationTxFailed(code: delegTxResult.code, log: delegTxResult.log)
+                    }
                     try await votingCrypto.storeDelegationTxHash(roundId, bundleIdx, delegTxResult.txHash)
                     let vanPosition = try await Self.requireKeystoneDelegationVanPosition(
                         txHash: delegTxResult.txHash,
@@ -3353,6 +3340,12 @@ extension VotingCoordFlow {
         return (bundleResult.eligibleWeight, UInt32(bundleResult.bundles.count))
     }
 
+    /// Bundle rows contain non-reproducible delegation randomness. Once any
+    /// exist, restart recovery must resume them instead of clearing the round.
+    static func shouldResumePersistedRound(existingBundleCount: UInt32) -> Bool {
+        existingBundleCount > 0
+    }
+
     private static func votingWeight(for notes: [NoteInfo], bundleCount: UInt32) -> UInt64 {
         let allBundles = notes.smartBundles().bundles
         guard bundleCount > 0, Int(bundleCount) < allBundles.count else {
@@ -3511,6 +3504,36 @@ extension VotingCoordFlow {
     }
 
     // MARK: - Crash recovery for in-flight votes
+
+    /// Accept a successful broadcast directly. A spent-nullifier rejection is
+    /// accepted only when its exact transaction hash resolves on-chain with code 0.
+    static func isAcceptedVotingTransaction(
+        _ result: TxResult,
+        votingAPI: VotingAPIClient,
+        maxRecoveryAttempts: Int = 3,
+        retryDelay: Duration = .seconds(1)
+    ) async throws -> Bool {
+        let txHash = result.txHash.trimmingCharacters(in: .whitespacesAndNewlines)
+        if result.code == 0 {
+            return !txHash.isEmpty
+        }
+        guard maxRecoveryAttempts > 0,
+              !txHash.isEmpty,
+              VotingErrorMapper.isNullifierAlreadySpent(result.log)
+        else {
+            return false
+        }
+
+        for attempt in 0..<maxRecoveryAttempts {
+            if let confirmation = try await votingAPI.fetchTxConfirmation(txHash) {
+                return confirmation.code == 0
+            }
+            if attempt + 1 < maxRecoveryAttempts {
+                try await Task.sleep(for: retryDelay)
+            }
+        }
+        return false
+    }
 
     /// If we have a cached vote TX hash for `(roundId, bundleIndex, proposalId)`
     /// that confirmed on-chain, finish the share delegation step without
@@ -3767,6 +3790,9 @@ extension VotingCoordFlow {
                 )
             }
             let delegTxResult = try await votingAPI.submitDelegation(registration)
+            guard try await isAcceptedVotingTransaction(delegTxResult, votingAPI: votingAPI) else {
+                throw VotingFlowError.delegationTxFailed(code: delegTxResult.code, log: delegTxResult.log)
+            }
             LoggerProxy.info("Delegation TX \(bundleIndex) submitted: \(delegTxResult.txHash)")
 
             try await votingCrypto.storeDelegationTxHash(roundId, bundleIndex, delegTxResult.txHash)

--- a/secant/Sources/Features/Voting/VotingHelpers.swift
+++ b/secant/Sources/Features/Voting/VotingHelpers.swift
@@ -423,8 +423,7 @@ enum VotingErrorMapper {
         // Mirrors Android (`VotingErrorMapper.kt`): both substrings,
         // case-insensitive — robust to wording variants like
         // "Nullifier was already spent" vs "nullifier already spent".
-        if rawError.localizedCaseInsensitiveContains("nullifier")
-            && rawError.localizedCaseInsensitiveContains("spent") {
+        if isNullifierAlreadySpent(rawError) {
             return String(localizable: .coinVoteStoreUserErrorNullifierAlreadySpent)
         }
         if rawError.contains("vote round is not active") {
@@ -512,6 +511,11 @@ enum VotingErrorMapper {
             return String(localizable: .coinVoteStoreUserErrorLightwalletdUnavailable)
         }
         return rawError
+    }
+
+    static func isNullifierAlreadySpent(_ rawError: String) -> Bool {
+        rawError.localizedCaseInsensitiveContains("nullifier")
+            && rawError.localizedCaseInsensitiveContains("spent")
     }
 }
 

--- a/zodlTests/VotingTests/VotingAPIResponseParserTests.swift
+++ b/zodlTests/VotingTests/VotingAPIResponseParserTests.swift
@@ -83,6 +83,29 @@ import Testing
         #expect(result == TxResult(txHash: "ABC123", code: 0, log: ""))
     }
 
+    @Test func parseTxResultPreservesRejectedTransactionHash() throws {
+        let result = try SvAPIResponseParser.parseTxResult([
+            "tx_hash": "DUPLICATE123",
+            "code": 1,
+            "log": "nullifier already spent: abc123"
+        ])
+
+        #expect(result == TxResult(
+            txHash: "DUPLICATE123",
+            code: 1,
+            log: "nullifier already spent: abc123"
+        ))
+    }
+
+    @Test func parseTxResultRejectsSuccessfulResponseWithoutHash() {
+        #expect(throws: (any Error).self) {
+            _ = try SvAPIResponseParser.parseTxResult([
+                "code": 0,
+                "log": ""
+            ])
+        }
+    }
+
     private func makeResponse() throws -> HTTPURLResponse {
         let url = try #require(URL(string: "https://vote-chain-primary.valargroup.org/shielded-vote/v1/delegate-vote"))
         let response = try #require(

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -726,6 +726,156 @@ import Testing
         #expect(!isDelegationSigningTop(state))
     }
 
+    @Test func persistedBundlesResumeInsteadOfPreparingFreshRound() {
+        #expect(VotingCoordFlow.shouldResumePersistedRound(existingBundleCount: 1))
+        #expect(!VotingCoordFlow.shouldResumePersistedRound(existingBundleCount: 0))
+    }
+
+    @Test func acceptedVotingTransactionDoesNotQueryRecovery() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingAPI = VotingAPIClient()
+        votingAPI.fetchTxConfirmation = { txHash in
+            await recorder.record("fetch:\(txHash)")
+            return nil
+        }
+
+        let accepted = try await VotingCoordFlow.isAcceptedVotingTransaction(
+            TxResult(txHash: "accepted-tx", code: 0),
+            votingAPI: votingAPI,
+            maxRecoveryAttempts: 1,
+            retryDelay: .zero
+        )
+
+        #expect(accepted)
+        #expect(await recorder.events().isEmpty)
+    }
+
+    @Test func spentNullifierRecoversWhenExactTransactionIsConfirmed() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingAPI = VotingAPIClient()
+        votingAPI.fetchTxConfirmation = { txHash in
+            await recorder.record("fetch:\(txHash)")
+            return TxConfirmation(height: 12, code: 0)
+        }
+
+        let accepted = try await VotingCoordFlow.isAcceptedVotingTransaction(
+            TxResult(
+                txHash: "duplicate-tx",
+                code: 1,
+                log: "nullifier already spent: abc123"
+            ),
+            votingAPI: votingAPI,
+            maxRecoveryAttempts: 1,
+            retryDelay: .zero
+        )
+
+        #expect(accepted)
+        #expect(await recorder.events() == ["fetch:duplicate-tx"])
+    }
+
+    @Test func spentNullifierFailsWhenExactTransactionIsNotConfirmed() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingAPI = VotingAPIClient()
+        votingAPI.fetchTxConfirmation = { txHash in
+            await recorder.record("fetch:\(txHash)")
+            return nil
+        }
+
+        let accepted = try await VotingCoordFlow.isAcceptedVotingTransaction(
+            TxResult(
+                txHash: "missing-tx",
+                code: 1,
+                log: "Nullifier was already spent"
+            ),
+            votingAPI: votingAPI,
+            maxRecoveryAttempts: 1,
+            retryDelay: .zero
+        )
+
+        #expect(!accepted)
+        #expect(await recorder.events() == ["fetch:missing-tx"])
+    }
+
+    @Test func spentNullifierFailsWhenExactTransactionHasNonzeroCode() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingAPI = VotingAPIClient()
+        votingAPI.fetchTxConfirmation = { txHash in
+            await recorder.record("fetch:\(txHash)")
+            return TxConfirmation(height: 12, code: 7, log: "execution failed")
+        }
+
+        let accepted = try await VotingCoordFlow.isAcceptedVotingTransaction(
+            TxResult(
+                txHash: "rejected-tx",
+                code: 1,
+                log: "nullifier already spent"
+            ),
+            votingAPI: votingAPI,
+            maxRecoveryAttempts: 1,
+            retryDelay: .zero
+        )
+
+        #expect(!accepted)
+        #expect(await recorder.events() == ["fetch:rejected-tx"])
+    }
+
+    @Test func spentNullifierWithoutHashDoesNotQueryRecovery() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingAPI = VotingAPIClient()
+        votingAPI.fetchTxConfirmation = { txHash in
+            await recorder.record("fetch:\(txHash)")
+            return TxConfirmation(height: 12, code: 0)
+        }
+
+        let accepted = try await VotingCoordFlow.isAcceptedVotingTransaction(
+            TxResult(txHash: "", code: 1, log: "nullifier already spent"),
+            votingAPI: votingAPI,
+            maxRecoveryAttempts: 1,
+            retryDelay: .zero
+        )
+
+        #expect(!accepted)
+        #expect(await recorder.events().isEmpty)
+    }
+
+    @Test func spentNullifierRetriesWhileExactTransactionIsBeingIndexed() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingAPI = VotingAPIClient()
+        votingAPI.fetchTxConfirmation = { txHash in
+            let attempt = await recorder.recordAndCount("fetch:\(txHash)")
+            return attempt == 2 ? TxConfirmation(height: 12, code: 0) : nil
+        }
+
+        let accepted = try await VotingCoordFlow.isAcceptedVotingTransaction(
+            TxResult(txHash: "indexing-tx", code: 1, log: "nullifier already spent"),
+            votingAPI: votingAPI,
+            maxRecoveryAttempts: 3,
+            retryDelay: .zero
+        )
+
+        #expect(accepted)
+        #expect(await recorder.events() == ["fetch:indexing-tx", "fetch:indexing-tx"])
+    }
+
+    @Test func unrelatedTransactionRejectionDoesNotQueryRecovery() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingAPI = VotingAPIClient()
+        votingAPI.fetchTxConfirmation = { txHash in
+            await recorder.record("fetch:\(txHash)")
+            return TxConfirmation(height: 12, code: 0)
+        }
+
+        let accepted = try await VotingCoordFlow.isAcceptedVotingTransaction(
+            TxResult(txHash: "failed-tx", code: 1, log: "invalid proof"),
+            votingAPI: votingAPI,
+            maxRecoveryAttempts: 1,
+            retryDelay: .zero
+        )
+
+        #expect(!accepted)
+        #expect(await recorder.events().isEmpty)
+    }
+
     @Test func delegationPipelineRecoversConfirmedCachedTxBeforeSkippingBundle() async throws {
         let recorder = RecoveryOrderRecorder()
         var votingCrypto = VotingCryptoClient()
@@ -1592,6 +1742,11 @@ private actor RecoveryOrderRecorder {
 
     func record(_ event: String) {
         recordedEvents.append(event)
+    }
+
+    func recordAndCount(_ event: String) -> Int {
+        recordedEvents.append(event)
+        return recordedEvents.filter { $0 == event }.count
     }
 
     func events() -> [String] {

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -731,6 +731,72 @@ import Testing
         #expect(!VotingCoordFlow.shouldResumePersistedRound(existingBundleCount: 0))
     }
 
+    @Test func interruptedPersistedSetupRetriesOnlyDeterministicWork() async throws {
+        let recorder = RecoveryOrderRecorder()
+        let cachedNotes = [note(value: ballotDivisor, position: 0)]
+        let treeState = Data([0xAA])
+        let expectedWitness = WitnessData(
+            noteCommitment: cachedNotes[0].commitment,
+            position: cachedNotes[0].position,
+            root: Data([0xBB]),
+            authPath: []
+        )
+
+        var votingCrypto = VotingCryptoClient()
+        votingCrypto.storeTreeState = { storedRoundId, data in
+            await recorder.record("store-tree:\(storedRoundId):\(data == treeState)")
+        }
+        votingCrypto.generateNoteWitnesses = { storedRoundId, bundleIndex, walletDbPath, notes, networkId in
+            let attempt = await recorder.recordAndCount(
+                "witness:\(storedRoundId):\(bundleIndex):\(walletDbPath):\(notes.count):\(networkId)"
+            )
+            if attempt == 1 {
+                throw TestError.proofFailed
+            }
+            return [expectedWitness]
+        }
+
+        var sdkSynchronizer = SDKSynchronizerClient.noOp
+        sdkSynchronizer.getTreeState = { height in
+            await recorder.record("get-tree:\(height)")
+            return treeState
+        }
+
+        await #expect(throws: TestError.self) {
+            _ = try await VotingCoordFlow.completeDeterministicRoundSetup(
+                roundId: roundId,
+                snapshotHeight: 123,
+                walletDbPath: "/wallet.db",
+                networkId: 1,
+                notes: cachedNotes,
+                bundleCount: 1,
+                votingCrypto: votingCrypto,
+                sdkSynchronizer: sdkSynchronizer
+            )
+        }
+
+        let witnesses = try await VotingCoordFlow.completeDeterministicRoundSetup(
+            roundId: roundId,
+            snapshotHeight: 123,
+            walletDbPath: "/wallet.db",
+            networkId: 1,
+            notes: cachedNotes,
+            bundleCount: 1,
+            votingCrypto: votingCrypto,
+            sdkSynchronizer: sdkSynchronizer
+        )
+
+        #expect(witnesses == [expectedWitness])
+        #expect(await recorder.events() == [
+            "get-tree:123",
+            "store-tree:round-1:true",
+            "witness:round-1:0:/wallet.db:1:1",
+            "get-tree:123",
+            "store-tree:round-1:true",
+            "witness:round-1:0:/wallet.db:1:1"
+        ])
+    }
+
     @Test func absentRoundLoadsAsFreshSetup() async throws {
         let recorder = RecoveryOrderRecorder()
         var votingCrypto = VotingCryptoClient()

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -731,6 +731,108 @@ import Testing
         #expect(!VotingCoordFlow.shouldResumePersistedRound(existingBundleCount: 0))
     }
 
+    @Test func absentRoundLoadsAsFreshSetup() async throws {
+        let recorder = RecoveryOrderRecorder()
+        var votingCrypto = VotingCryptoClient()
+        votingCrypto.listRounds = {
+            await recorder.record("list")
+            return []
+        }
+        votingCrypto.getRoundState = { _ in
+            await recorder.record("state")
+            throw TestError.votingDatabaseReadFailed
+        }
+        votingCrypto.getBundleCount = { _ in
+            await recorder.record("count")
+            throw TestError.votingDatabaseReadFailed
+        }
+
+        let setup = try await VotingCoordFlow.loadExistingRoundSetup(
+            roundId: roundId,
+            votingCrypto: votingCrypto
+        )
+
+        #expect(setup.state == nil)
+        #expect(setup.bundleCount == 0)
+        #expect(await recorder.events() == ["list"])
+    }
+
+    @Test func existingRoundLoadsStateAndBundleCount() async throws {
+        let recorder = RecoveryOrderRecorder()
+        let state = RoundStateInfo(
+            roundId: roundId,
+            phase: .delegationProved,
+            snapshotHeight: 100,
+            hotkeyAddress: nil,
+            delegatedWeight: nil,
+            proofGenerated: false
+        )
+        var votingCrypto = VotingCryptoClient()
+        votingCrypto.listRounds = {
+            await recorder.record("list")
+            return [RoundSummaryInfo(
+                roundId: roundId,
+                phase: .delegationProved,
+                snapshotHeight: 100,
+                createdAt: 1
+            )]
+        }
+        votingCrypto.getRoundState = { _ in
+            await recorder.record("state")
+            return state
+        }
+        votingCrypto.getBundleCount = { _ in
+            await recorder.record("count")
+            return 2
+        }
+
+        let setup = try await VotingCoordFlow.loadExistingRoundSetup(
+            roundId: roundId,
+            votingCrypto: votingCrypto
+        )
+
+        #expect(setup.state == state)
+        #expect(setup.bundleCount == 2)
+        #expect(await recorder.events() == ["list", "state", "count"])
+    }
+
+    @Test func existingRoundDatabaseFailureDoesNotBecomeFreshSetup() async {
+        let recorder = RecoveryOrderRecorder()
+        var votingCrypto = VotingCryptoClient()
+        votingCrypto.listRounds = {
+            await recorder.record("list")
+            return [RoundSummaryInfo(
+                roundId: roundId,
+                phase: .delegationConstructed,
+                snapshotHeight: 100,
+                createdAt: 1
+            )]
+        }
+        votingCrypto.getRoundState = { _ in
+            await recorder.record("state")
+            return RoundStateInfo(
+                roundId: roundId,
+                phase: .delegationConstructed,
+                snapshotHeight: 100,
+                hotkeyAddress: nil,
+                delegatedWeight: nil,
+                proofGenerated: false
+            )
+        }
+        votingCrypto.getBundleCount = { _ in
+            await recorder.record("count")
+            throw TestError.votingDatabaseReadFailed
+        }
+
+        await #expect(throws: TestError.self) {
+            _ = try await VotingCoordFlow.loadExistingRoundSetup(
+                roundId: roundId,
+                votingCrypto: votingCrypto
+            )
+        }
+        #expect(await recorder.events() == ["list", "state", "count"])
+    }
+
     @Test func acceptedVotingTransactionDoesNotQueryRecovery() async throws {
         let recorder = RecoveryOrderRecorder()
         var votingAPI = VotingAPIClient()
@@ -1786,6 +1888,7 @@ private enum TestError: LocalizedError {
     case shareRecordWriteFailed
     case delegationSetupMissing
     case delegationProofMissing
+    case votingDatabaseReadFailed
 
     var errorDescription: String? {
         switch self {
@@ -1799,6 +1902,8 @@ private enum TestError: LocalizedError {
             return "simulated missing persisted delegation setup"
         case .delegationProofMissing:
             return "simulated missing persisted delegation proof"
+        case .votingDatabaseReadFailed:
+            return "simulated voting database read failure"
         }
     }
 }


### PR DESCRIPTION
Before, a retry after a lost response failed on a spent-nullifier rejection without checking whether that exact submitted transaction had landed. Restart recovery could also clear persisted delegation setup when no transaction hash had been stored or when a database read failure was mistaken for an empty round.

After, spent-nullifier responses query `result.tx_hash` and proceed only when that exact hash returns code 0. Because signing may produce different transaction bytes on retry, a mismatch still errors; critically, the original bundle setup remains intact instead of being wiped. Database read failures also fail closed. This is an app-only patch with no dependency changes.