### PR TITLE
Preserve the voting database before anything opens it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ directly impact users rather than highlighting other crucial architectural updat
 ## [Unreleased]
 
 ### Added
+- [Ironwood] Before opening the voting database, ZODL now preserves a copy of it under `voting_recovery`. If an earlier version already discarded a poll's delegation, that copy keeps what is needed to restore it later — even if you upgrade long after the poll was affected. It is taken only once, so the earliest and most complete copy is the one kept; it is included in device backups so it survives a migration, and is removed when the wallet is reset.
 - [MOB-1466] Advanced Settings now offers "Restart Migration" while a migration is running. It shows how much has already migrated and how much is left, warns that restarting cancels the current plan for good, and asks for a separate confirmation before anything happens. Transfers that already went out are untouched — they stay migrated — and once the plan is cancelled you set up a new one for the remaining balance the same way you did the first time.
 - [MOB-1466] With a privacy migration in progress, keeping the app open now advances the migration automatically — transfers send on schedule without reopening the app.
 - [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
@@ -635,6 +635,13 @@ private actor DatabaseActor {
     private var _backend: VotingRustBackend?
 
     func open(path: String, networkId: UInt32) throws {
+        // Before anything touches the database. Closing the previous backend
+        // below drops the last connection, which makes SQLite checkpoint and
+        // unlink the WAL — and the WAL is the only place a cleared round's
+        // original secrets still exist. Once this line has run, the evidence
+        // is safe whatever the rest of the flow does.
+        VotingDatabaseSnapshot.capture(databasePath: path)
+
         // If already open, close the old backend before opening a fresh one.
         // This makes re-initialization safe (e.g. onAppear firing twice).
         if let old = _backend {

--- a/secant/Sources/Dependencies/VotingDatabaseSnapshot/VotingDatabaseSnapshot.swift
+++ b/secant/Sources/Dependencies/VotingDatabaseSnapshot/VotingDatabaseSnapshot.swift
@@ -1,0 +1,172 @@
+#if VOTING_ENABLED
+import Foundation
+@preconcurrency import ZcashLightClientKit
+
+/// Preserves the voting database's three files before anything opens them.
+///
+/// A cleared round's original secrets survive only in superseded write-ahead
+/// log frames, and those frames are destroyed by the next checkpoint — which
+/// SQLite runs when the last connection closes. Opening the database is
+/// therefore the act that loses the evidence, so this copy has to happen
+/// first, on bytes, with no connection involved.
+///
+/// The logic is deliberately simple: **if `voting_recovery/voting.sqlite3`
+/// holds no data, copy `voting.sqlite3`, `voting.sqlite3-wal` and
+/// `voting.sqlite3-shm` into it.** That makes the capture idempotent — once a
+/// copy exists it is never replaced — and keeps the first capture, which is
+/// the one taken closest to the incident and before any launch checkpointed
+/// the WAL.
+///
+/// This ships ahead of any restore path on purpose: a build that only takes
+/// the copy already makes recovery possible later, even for users who upgrade
+/// long after the round was wiped.
+enum VotingDatabaseSnapshot {
+    /// Directory under Documents holding the preserved set.
+    static let directoryName = "voting_recovery"
+
+    /// The copies keep the canonical names. Only one set is ever kept, so
+    /// there is nothing to disambiguate, and SQLite resolves sidecars as
+    /// `<database>-wal` / `-shm` — so preserving the names is what keeps the
+    /// trio openable as a database. The capture time is recorded separately by
+    /// `markerName`.
+    static let databaseName = "voting.sqlite3"
+
+    /// Records when the set was taken, with the timestamp in the filename.
+    static func markerName(_ date: Date) -> String { "captured-\(timestamp(date)).txt" }
+
+    enum SnapshotError: Error {
+        case documentsFolder
+    }
+
+    struct Snapshot: Equatable, Sendable {
+        let directory: URL
+        let databaseURL: URL
+        let walURL: URL
+        let shmURL: URL
+        let markerURL: URL
+    }
+
+    /// Copies the voting database trio into `voting_recovery/` if that
+    /// directory does not already hold data.
+    ///
+    /// Returns `nil` when a copy already exists, when the source database is
+    /// missing, or when there is no WAL to preserve — in that last case the
+    /// superseded frames are already gone and a copy would only cost space.
+    ///
+    /// Never throws into the caller's path: preserving evidence must not be
+    /// able to stop the voting flow from opening. Failures are logged.
+    @discardableResult
+    static func capture(databasePath: String, now: Date = Date()) -> Snapshot? {
+        do {
+            return try captureThrowing(databasePath: databasePath, now: now, root: nil)
+        } catch {
+            LoggerProxy.error("Voting database snapshot failed: \(error)")
+            return nil
+        }
+    }
+
+    /// `root` overrides the destination directory; tests pass a scratch path so
+    /// they do not depend on the simulator's Documents container.
+    static func captureThrowing(
+        databasePath: String,
+        now: Date,
+        root overrideRoot: URL? = nil
+    ) throws -> Snapshot? {
+        let fileManager = FileManager.default
+        let source = URL(fileURLWithPath: databasePath)
+        let wal = URL(fileURLWithPath: databasePath + "-wal")
+        let shm = URL(fileURLWithPath: databasePath + "-shm")
+
+        guard fileManager.fileExists(atPath: source.path) else { return nil }
+
+        // No WAL means a clean close already checkpointed and unlinked it, so
+        // there are no superseded frames left to rescue.
+        guard fileManager.fileExists(atPath: wal.path) else { return nil }
+
+        let root = try overrideRoot ?? recoveryDirectory()
+        let destination = Snapshot(
+            directory: root,
+            databaseURL: root.appendingPathComponent(databaseName),
+            walURL: root.appendingPathComponent("\(databaseName)-wal"),
+            shmURL: root.appendingPathComponent("\(databaseName)-shm"),
+            markerURL: root.appendingPathComponent(markerName(now))
+        )
+
+        guard !holdsData(at: destination.databaseURL) else { return nil }
+
+        // Replace any empty or half-written leftover from an interrupted run.
+        for url in [destination.databaseURL, destination.walURL, destination.shmURL] {
+            try? fileManager.removeItem(at: url)
+        }
+
+        // The WAL first: it is the volatile, high-value artifact, and the one
+        // the next open would checkpoint away. The database file only loses its
+        // old page images once that checkpoint runs.
+        try fileManager.copyItem(at: wal, to: destination.walURL)
+        if fileManager.fileExists(atPath: shm.path) {
+            try? fileManager.copyItem(at: shm, to: destination.shmURL)
+        }
+        try fileManager.copyItem(at: source, to: destination.databaseURL)
+        try? Data(timestamp(now).utf8).write(to: destination.markerURL)
+
+        for url in [
+            destination.walURL, destination.shmURL, destination.databaseURL, destination.markerURL
+        ] where fileManager.fileExists(atPath: url.path) {
+            try? fileManager.setAttributes(
+                [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                ofItemAtPath: url.path
+            )
+        }
+
+        // Deliberately left eligible for system backups, like the database it
+        // copies: these bytes are the only remaining route to a lost vote, so
+        // they must survive a device migration.
+        LoggerProxy.info("Preserved voting database into \(directoryName) at \(timestamp(now))")
+        return destination
+    }
+
+    /// Whether a preserved database is present and non-empty.
+    ///
+    /// Emptiness is judged on file size, never by querying: opening the copy
+    /// through SQLite would checkpoint its WAL and destroy the frames the whole
+    /// exercise exists to keep.
+    static func holdsData(at url: URL) -> Bool {
+        guard let size = try? FileManager.default
+            .attributesOfItem(atPath: url.path)[.size] as? NSNumber
+        else {
+            return false
+        }
+        return size.intValue > 0
+    }
+
+    /// Removes the preserved set. Wallet-reset scope only.
+    static func reset() {
+        guard let root = try? recoveryDirectory() else { return }
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    static func recoveryDirectory() throws -> URL {
+        guard let documents = FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)
+            .first
+        else {
+            throw SnapshotError.documentsFolder
+        }
+
+        let root = documents.appendingPathComponent(directoryName, isDirectory: true)
+        if !FileManager.default.fileExists(atPath: root.path) {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        }
+        return root
+    }
+
+    /// UTC, second resolution, lexicographically sortable and filesystem safe.
+    static func timestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter.string(from: date)
+    }
+}
+#endif

--- a/secant/Sources/Dependencies/VotingDatabaseSnapshot/VotingDatabaseSnapshot.swift
+++ b/secant/Sources/Dependencies/VotingDatabaseSnapshot/VotingDatabaseSnapshot.swift
@@ -2,7 +2,7 @@
 import Foundation
 @preconcurrency import ZcashLightClientKit
 
-/// Preserves the voting database's three files before anything opens them.
+/// Preserves the voting database files before anything opens them.
 ///
 /// A cleared round's original secrets survive only in superseded write-ahead
 /// log frames, and those frames are destroyed by the next checkpoint — which
@@ -11,11 +11,11 @@ import Foundation
 /// first, on bytes, with no connection involved.
 ///
 /// The logic is deliberately simple: **if `voting_recovery/voting.sqlite3`
-/// holds no data, copy `voting.sqlite3`, `voting.sqlite3-wal` and
-/// `voting.sqlite3-shm` into it.** That makes the capture idempotent — once a
-/// copy exists it is never replaced — and keeps the first capture, which is
-/// the one taken closest to the incident and before any launch checkpointed
-/// the WAL.
+/// holds no data, copy `voting.sqlite3` and any existing `voting.sqlite3-wal`
+/// and `voting.sqlite3-shm` sidecars into it.** That makes the capture
+/// idempotent — once a copy exists it is never replaced — and keeps the first
+/// capture, which is the one taken closest to the incident and before any
+/// launch checkpointed the WAL.
 ///
 /// This ships ahead of any restore path on purpose: a build that only takes
 /// the copy already makes recovery possible later, even for users who upgrade
@@ -46,12 +46,12 @@ enum VotingDatabaseSnapshot {
         let markerURL: URL
     }
 
-    /// Copies the voting database trio into `voting_recovery/` if that
+    /// Copies the voting database files into `voting_recovery/` if that
     /// directory does not already hold data.
     ///
-    /// Returns `nil` when a copy already exists, when the source database is
-    /// missing, or when there is no WAL to preserve — in that last case the
-    /// superseded frames are already gone and a copy would only cost space.
+    /// Returns `nil` when a copy already exists or the source database is
+    /// missing. A main database without a WAL is still captured because
+    /// deleted records can remain recoverable in its freed pages.
     ///
     /// Never throws into the caller's path: preserving evidence must not be
     /// able to stop the voting flow from opening. Failures are logged.
@@ -79,10 +79,6 @@ enum VotingDatabaseSnapshot {
 
         guard fileManager.fileExists(atPath: source.path) else { return nil }
 
-        // No WAL means a clean close already checkpointed and unlinked it, so
-        // there are no superseded frames left to rescue.
-        guard fileManager.fileExists(atPath: wal.path) else { return nil }
-
         let root = try overrideRoot ?? recoveryDirectory()
         let destination = Snapshot(
             directory: root,
@@ -102,7 +98,9 @@ enum VotingDatabaseSnapshot {
         // The WAL first: it is the volatile, high-value artifact, and the one
         // the next open would checkpoint away. The database file only loses its
         // old page images once that checkpoint runs.
-        try fileManager.copyItem(at: wal, to: destination.walURL)
+        if fileManager.fileExists(atPath: wal.path) {
+            try fileManager.copyItem(at: wal, to: destination.walURL)
+        }
         if fileManager.fileExists(atPath: shm.path) {
             try? fileManager.copyItem(at: shm, to: destination.shmURL)
         }

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -745,6 +745,10 @@ extension Root {
             .first {
             let votingDbURL = documents.appendingPathComponent("voting.sqlite3")
             try? FileManager.default.removeItem(at: votingDbURL)
+            // Preserved copies of the previous wallet's voting database are
+            // the same wallet-scoped material, and must not cross the reset
+            // boundary either.
+            VotingDatabaseSnapshot.reset()
         }
         // Belt-and-suspenders: voting drafts and vote records live in
         // the encrypted per-account `votingMetadata` file now, which

--- a/zodlTests/VotingTests/VotingDatabaseSnapshotTests.swift
+++ b/zodlTests/VotingTests/VotingDatabaseSnapshotTests.swift
@@ -132,19 +132,24 @@ import Foundation
         #expect(VotingDatabaseSnapshot.holdsData(at: scratch.databaseURL))
     }
 
-    /// No WAL means a clean close already checkpointed and unlinked it, so
-    /// there are no superseded frames left worth the disk space.
-    @Test func skipsWhenThereIsNoWriteAheadLogToPreserve() throws {
+    /// A checkpoint can unlink the WAL while leaving deleted record bytes in
+    /// freed main-database pages, so the main database remains evidence.
+    @Test func capturesTheMainDatabaseWhenThereIsNoWriteAheadLog() throws {
         let scratch = try Scratch()
         try FileManager.default.removeItem(at: scratch.walURL)
 
-        let snapshot = try VotingDatabaseSnapshot.captureThrowing(
-            databasePath: scratch.databaseURL.path,
-            now: Date(),
-            root: scratch.destination
+        let snapshot = try #require(
+            VotingDatabaseSnapshot.captureThrowing(
+                databasePath: scratch.databaseURL.path,
+                now: Date(),
+                root: scratch.destination
+            )
         )
 
-        #expect(snapshot == nil)
+        #expect(try Data(contentsOf: snapshot.databaseURL)
+            == Data(contentsOf: scratch.databaseURL))
+        #expect(FileManager.default.fileExists(atPath: snapshot.walURL.path) == false)
+        #expect(try Data(contentsOf: snapshot.shmURL) == Data(contentsOf: scratch.shmURL))
     }
 
     @Test func skipsWhenTheDatabaseDoesNotExist() throws {

--- a/zodlTests/VotingTests/VotingDatabaseSnapshotTests.swift
+++ b/zodlTests/VotingTests/VotingDatabaseSnapshotTests.swift
@@ -1,0 +1,195 @@
+#if VOTING_ENABLED
+import Testing
+import Foundation
+@testable import zodl_internal
+
+/// The snapshot ships ahead of any restore path, so its contract is narrow and
+/// worth pinning: copy all three files byte-for-byte, put a timestamp in the
+/// name, keep the trio mutually resolvable, and never run twice.
+///
+/// These exercise `captureThrowing` against a scratch directory rather than the
+/// real Documents folder, so they do not depend on simulator container state.
+@Suite struct VotingDatabaseSnapshotTests {
+    @Test func timestampIsSortableUTCAndFilesystemSafe() {
+        let stamp = VotingDatabaseSnapshot.timestamp(Date(timeIntervalSince1970: 1_787_675_522))
+
+        #expect(stamp == "20260825-163202")
+        #expect(stamp.contains(":") == false)
+        #expect(stamp.contains("/") == false)
+    }
+
+    /// Ordering matters for a set of snapshots, so the format must sort the
+    /// same way the clock does.
+    @Test func timestampsSortChronologically() {
+        let earlier = VotingDatabaseSnapshot.timestamp(Date(timeIntervalSince1970: 1_000_000))
+        let later = VotingDatabaseSnapshot.timestamp(Date(timeIntervalSince1970: 2_000_000))
+
+        #expect(earlier < later)
+    }
+
+    /// The copies keep the canonical names, so the preserved set stays
+    /// openable as a database: SQLite resolves sidecars as `<database>-wal`.
+    /// The capture time lives in the marker filename instead.
+    @Test func preservedSetKeepsCanonicalNamesAndRecordsTheTime() throws {
+        let scratch = try Scratch()
+        let snapshot = try #require(
+            VotingDatabaseSnapshot.captureThrowing(
+                databasePath: scratch.databaseURL.path,
+                now: Date(timeIntervalSince1970: 1_787_675_522),
+                root: scratch.destination
+            )
+        )
+
+        #expect(snapshot.databaseURL.lastPathComponent == "voting.sqlite3")
+        #expect(snapshot.walURL.path == snapshot.databaseURL.path + "-wal")
+        #expect(snapshot.shmURL.path == snapshot.databaseURL.path + "-shm")
+        #expect(snapshot.markerURL.lastPathComponent == "captured-20260825-163202.txt")
+    }
+
+    @Test func copiesAllThreeFilesByteForByte() throws {
+        let scratch = try Scratch()
+        let snapshot = try #require(
+            VotingDatabaseSnapshot.captureThrowing(
+                databasePath: scratch.databaseURL.path,
+                now: Date(),
+                root: scratch.destination
+            )
+        )
+
+        #expect(try Data(contentsOf: snapshot.databaseURL) == Data(contentsOf: scratch.databaseURL))
+        #expect(try Data(contentsOf: snapshot.walURL) == Data(contentsOf: scratch.walURL))
+        #expect(try Data(contentsOf: snapshot.shmURL) == Data(contentsOf: scratch.shmURL))
+    }
+
+    /// The originals are evidence. Capturing must not disturb them.
+    @Test func leavesTheSourceFilesUntouched() throws {
+        let scratch = try Scratch()
+        let before = try [scratch.databaseURL, scratch.walURL, scratch.shmURL].map {
+            try Data(contentsOf: $0)
+        }
+
+        _ = try VotingDatabaseSnapshot.captureThrowing(
+            databasePath: scratch.databaseURL.path,
+            now: Date(),
+            root: scratch.destination
+        )
+
+        let after = try [scratch.databaseURL, scratch.walURL, scratch.shmURL].map {
+            try Data(contentsOf: $0)
+        }
+        #expect(before == after)
+    }
+
+    /// The whole guard: if the recovery copy already holds data, do nothing.
+    /// The first capture is the valuable one — taken before any launch
+    /// checkpoints the WAL — so a later one must not replace it.
+    @Test func doesNothingOnceTheRecoveryCopyHoldsData() throws {
+        let scratch = try Scratch()
+
+        let first = try VotingDatabaseSnapshot.captureThrowing(
+            databasePath: scratch.databaseURL.path,
+            now: Date(timeIntervalSince1970: 1_000_000),
+            root: scratch.destination
+        )
+        let preserved = try Data(contentsOf: try #require(first).databaseURL)
+
+        try Data("the-app-moved-on".utf8).write(to: scratch.databaseURL)
+        let second = try VotingDatabaseSnapshot.captureThrowing(
+            databasePath: scratch.databaseURL.path,
+            now: Date(timeIntervalSince1970: 2_000_000),
+            root: scratch.destination
+        )
+
+        #expect(second == nil, "a later, already-checkpointed copy must not replace the first")
+        #expect(try Data(contentsOf: try #require(first).databaseURL) == preserved)
+    }
+
+    /// An empty leftover from an interrupted run is not "data": the guard must
+    /// let the capture proceed rather than preserving a zero-byte file forever.
+    @Test func replacesAnEmptyLeftoverFromAnInterruptedRun() throws {
+        let scratch = try Scratch()
+        try Data().write(to: scratch.destination.appendingPathComponent("voting.sqlite3"))
+
+        let snapshot = try VotingDatabaseSnapshot.captureThrowing(
+            databasePath: scratch.databaseURL.path,
+            now: Date(),
+            root: scratch.destination
+        )
+
+        #expect(snapshot != nil)
+        #expect(try Data(contentsOf: try #require(snapshot).databaseURL)
+            == Data(contentsOf: scratch.databaseURL))
+    }
+
+    @Test func holdsDataDistinguishesMissingEmptyAndPopulated() throws {
+        let scratch = try Scratch()
+        let missing = scratch.destination.appendingPathComponent("absent.sqlite3")
+        let empty = scratch.destination.appendingPathComponent("empty.sqlite3")
+        try Data().write(to: empty)
+
+        #expect(VotingDatabaseSnapshot.holdsData(at: missing) == false)
+        #expect(VotingDatabaseSnapshot.holdsData(at: empty) == false)
+        #expect(VotingDatabaseSnapshot.holdsData(at: scratch.databaseURL))
+    }
+
+    /// No WAL means a clean close already checkpointed and unlinked it, so
+    /// there are no superseded frames left worth the disk space.
+    @Test func skipsWhenThereIsNoWriteAheadLogToPreserve() throws {
+        let scratch = try Scratch()
+        try FileManager.default.removeItem(at: scratch.walURL)
+
+        let snapshot = try VotingDatabaseSnapshot.captureThrowing(
+            databasePath: scratch.databaseURL.path,
+            now: Date(),
+            root: scratch.destination
+        )
+
+        #expect(snapshot == nil)
+    }
+
+    @Test func skipsWhenTheDatabaseDoesNotExist() throws {
+        let scratch = try Scratch()
+
+        let snapshot = try VotingDatabaseSnapshot.captureThrowing(
+            databasePath: scratch.directory.appendingPathComponent("absent.sqlite3").path,
+            now: Date(),
+            root: scratch.destination
+        )
+
+        #expect(snapshot == nil)
+    }
+}
+
+// MARK: - Scratch layout
+
+extension VotingDatabaseSnapshotTests {
+    /// A throwaway `voting.sqlite3` trio plus an empty destination, each in its
+    /// own directory so the suite is safe under parallel execution.
+    final class Scratch {
+        let directory: URL
+        let destination: URL
+        let databaseURL: URL
+        let walURL: URL
+        let shmURL: URL
+
+        init() throws {
+            directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("voting-snapshot-\(UUID().uuidString)", isDirectory: true)
+            destination = directory.appendingPathComponent("snapshots", isDirectory: true)
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+
+            databaseURL = directory.appendingPathComponent("voting.sqlite3")
+            walURL = directory.appendingPathComponent("voting.sqlite3-wal")
+            shmURL = directory.appendingPathComponent("voting.sqlite3-shm")
+
+            try Data("database-bytes".utf8).write(to: databaseURL)
+            try Data("wal-bytes".utf8).write(to: walURL)
+            try Data("shm-bytes".utf8).write(to: shmURL)
+        }
+
+        deinit {
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Preserves the voting database before anything opens it. Split out of #2018 so
it can ship on its own, ahead of any restore path.

## Why this is urgent and standalone

An earlier build could delete and recreate a poll whose delegation had already
been broadcast, discarding `van_comm_rand` — a 32-byte blinding factor sampled
from `OsRng` in the Rust core, never derived from the seed, and unwritable
through the FFI. Once gone, the poll is permanently unvotable.

In WAL mode, frames written before the wipe can still contain the intact row.
After checkpointing removes the WAL, deleted record bytes can also remain in
freed pages of the main database until SQLite overwrites them. Both files are
therefore evidence worth preserving.

The capture runs before `old.close()` and before opening a new SQLite
connection, because those lifecycle operations can checkpoint or unlink the
WAL.

## The logic

> If `voting_recovery/voting.sqlite3` holds no data, copy `voting.sqlite3` and
> any existing `voting.sqlite3-wal` and `voting.sqlite3-shm` sidecars into it.

`VotingDatabaseSnapshot.capture` runs at the very top of
`DatabaseActor.open`. It performs byte copies without opening either the source
or destination through SQLite.

The recovered main database is the idempotence guard: once a non-empty copy
exists it is never replaced, preserving the earliest capture. A zero-byte
leftover does not count as data and is replaced on the next attempt. Emptiness
is determined from file size, never by querying SQLite.

When a WAL exists it is copied first because it is the most volatile artifact.
The main database is still captured when there is no WAL because freed pages
may contain the deleted bundle record required by the later forensic recovery
path. SHM is copied when present.

The copies retain SQLite's canonical names so the trio remains mutually
resolvable. Capture time is recorded by a
`captured-<yyyyMMdd-HHmmss>.txt` marker.

Failures are currently logged and swallowed so capture cannot stop the voting
flow from opening. The copies remain eligible for system backups, like the
source voting database, and are removed with wallet-scoped voting state during
wallet reset.

## Validation

Tested against the affected database shared by the team:

- the first run captured the trio and later runs skipped;
- scanning the preserved WAL reproduced all three bundles' original
  `van_comm_rand`, `gov_comm`, `alpha`, `rk`, and `pczt_sighash`;
- the source trio remained byte-for-byte unchanged.

Unit coverage also pins capture of a main database when no WAL exists. Swift
parsing and diff hygiene pass locally. GitHub CI currently fails during package
resolution before compilation.

That affected database contains live voting material and is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
