### PR TITLE
Scripted release branch management, and a check that releases are merged back

### DIFF
--- a/.claude/skills/make-builds/SKILL.md
+++ b/.claude/skills/make-builds/SKILL.md
@@ -210,7 +210,7 @@ Example — a local SDK checkout sitting on a tagged commit, app not yet tagged:
 ```
 _iOS TestFlight Build (internal)_ — 3.10.1 (1)
 
-App: `release/3.10.1@54812f81`
+App: `candidate/3.10.1@54812f81`
 SDK: `candidate/4.1.0@cafca07a (tag: 4.1.0-rc.1)`
 ```
 

--- a/.claude/skills/make-builds/scripts/build-refs.py
+++ b/.claude/skills/make-builds/scripts/build-refs.py
@@ -12,7 +12,7 @@ live) or as a pinned remote package. The two are reported in the same shape:
     <branch-or-version>@<sha8>[ (tag: X)][ (dirty)]
 
 Usage:
-    build-refs.py --ref release/3.10.1 --sha 54812f81 [--repo /path/to/repo]
+    build-refs.py --ref candidate/3.10.1 --sha 54812f81 [--repo /path/to/repo]
 
 Prints one or two lines to stdout, ready to paste into the reply. The SDK line
 is omitted entirely when no SDK reference can be resolved; the reason goes to

--- a/.claude/skills/update-whatsnew/SKILL.md
+++ b/.claude/skills/update-whatsnew/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: update-whatsnew
-description: Prepare a ZODL release changelog. Reads the version from the zodl-production target, writes the release entry into every whatsNew*.json file (one per language) — prepending it, or replacing the existing entry if that version is already there — and prints the App Store changelog text for each language. Manual only — invoke with /update-whatsnew and paste the multi-language changelog.
+description: Prepare a ZODL release changelog. Takes the release version from the invocation, or reads it from the zodl-production target, writes the release entry into every whatsNew*.json file (one per language) — prepending it, or replacing the existing entry if that version is already there — and prints the App Store changelog text for each language. Manual only — invoke with /update-whatsnew and paste the multi-language changelog.
 disable-model-invocation: true
-argument-hint: <paste the multi-language changelog (language blocks with Added/Changed/Fixed sections)>
+argument-hint: [X.Y.Z] <paste the multi-language changelog (language blocks with Added/Changed/Fixed sections)>
 ---
 
 # Update What's New + App Store changelog
@@ -35,7 +35,9 @@ user's message:
 
 ARGUMENTS: $ARGUMENTS
 
-It is one block per language. Each block starts with a language name
+The argument may open with the release version (`X.Y.Z`) before the first
+language block; step 1 says how it is used. The changelog itself is one block
+per language. Each block starts with a language name
 (`English`, `Español`, …) and contains sections — a short header line ending in
 `:` (`Added:`, `Changed:`, `Fixed:`, `Removed:`, and their localized forms like
 `Añadido:`, `Cambiado:`, `Corregido:`) followed by one or more items.
@@ -47,10 +49,15 @@ changelog isn't in the argument or the message, ask the user to paste it.
 
 ## Workflow
 
-### 1. Read the release version
+### 1. Determine the release version
 
-Read `MARKETING_VERSION` from the **zodl-production** target (this is what ships
-to the App Store). It takes ~20s — that's normal:
+A version named in the invocation wins: a leading `X.Y.Z` before the changelog
+(`/update-whatsnew 3.11.0 …`), or one stated in the user's message, is the
+release version exactly as given.
+
+Only when no version was named, read `MARKETING_VERSION` from the
+**zodl-production** target (this is what ships to the App Store). It takes
+~20s — that's normal:
 
 ```bash
 xcodebuild -project secant.xcodeproj -target zodl-production \
@@ -64,6 +71,14 @@ version, so this is reliable in practice, just not target-specific):
 ```bash
 grep -m1 'MARKETING_VERSION' secant.xcodeproj/project.pbxproj | sed 's/.*= *//; s/;.*//'
 ```
+
+A checkout-derived version needs a cross-check: during a release cycle only
+`candidate/X.Y.Z` carries the new version, so every other checkout — `main`
+included — still reads the **previous** release. On a `candidate/X.Y.Z` or
+`release/X.Y.Z` branch (`git branch --show-current`), the version read must
+equal the version in the branch name — stop and report a mismatch. On any
+other checkout the version cannot be confirmed here; step 4's dry-run is the
+tripwire.
 
 ### 2. Determine date and timestamp — once, shared by all languages
 
@@ -122,10 +137,17 @@ Read what each dry-run reports:
 
 - **`would add`** — the version is new; it gets prepended.
 - **`would replace`** — the version already has an entry and it will be
-  overwritten in place. This is normal for an amended changelog; just carry on.
-  The entry keeps its original `date`/`timestamp` so an amendment doesn't look
-  like a re-release. **Mention the replacement to the user** when you report, and
-  if they want the date bumped to today, re-run that file with `--refresh-date`.
+  overwritten in place. When the version was named in the invocation, or was
+  read on the release's own candidate branch, this is normal for an amended
+  changelog; just carry on. The entry keeps its original `date`/`timestamp` so
+  an amendment doesn't look like a re-release. **Mention the replacement to the
+  user** when you report, and if they want the date bumped to today, re-run
+  that file with `--refresh-date`. But when the version was derived from a
+  checkout that is **not** the release's candidate branch, an existing entry
+  is the stale-checkout signature — a freshly cut release never already has
+  one, so this is almost certainly the previous release's version about to be
+  clobbered with the new copy. **Stop and ask the user to confirm the
+  version** before writing anything.
 - **`Unchanged`** — the on-disk entry already matches the payload byte for byte;
   nothing will be written. Expected when re-running with an unedited changelog.
 - **A language with no file yet** is a new language. Do **not** guess the

--- a/.claude/skills/update-whatsnew/evals/evals.json
+++ b/.claude/skills/update-whatsnew/evals/evals.json
@@ -9,12 +9,12 @@
       "files": [],
       "assertions": [
         "Both files updated; the new entry is at index 0 of releases (newest-first)",
-        "version equals zodl-production MARKETING_VERSION; date is DD-MM-YYYY; timestamp is an integer epoch",
+        "version equals zodl-production MARKETING_VERSION (no version was named in the invocation); date is DD-MM-YYYY; timestamp is an integer epoch",
         "Section titles are kept verbatim per language (Added:/Changed:/Fixed: and Añadido:/Cambiado:/Corregido:), not translated",
         "The 'Fixed:'/'Corregido:' section has two bulletpoints; the others have one",
         "Existing entries (3.6.0 and older) are byte-for-byte unchanged; output is valid JSON",
         "App Store text: one block per language, section title line then '* ' bullets, blank line between sections",
-        "If an entry for the version already exists, nothing is written and the user is warned (stop-and-warn)"
+        "If an entry for the version already exists, nothing is written and the user is asked to confirm the version first — with no version named and the checkout not on the release's candidate branch, an existing entry is the stale-checkout signature; replace-in-place without asking is right only for an explicit version or one read on its own candidate branch"
       ]
     }
   ]

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Check that every tagged release/ branch has been merged back into its
+# maintenance line, and forward down to main.
+#
+# Usage: check-release-merged-back.sh [pr-base] [pr-ref]
+#
+#   pr-base   branch a pending change targets; that branch is then evaluated
+#             as it would be with the change applied. Omit to check the
+#             branches as they stand.
+#   pr-ref    the pending change; defaults to HEAD (refs/pull/N/merge in CI).
+#
+# A release/ branch counts as released only when a tag points at its tip, so
+# in-flight release branches are skipped. The maintenance line comes from the
+# TAG, not the branch name: in the Swift SDK, release/3.0.0 is tagged 2.8.0-rc.1
+# and belongs to maint/v2.8.x.
+#
+# Branches resolve under refs/remotes/$REMOTE, which defaults to origin -- what
+# CI checks out. Set REMOTE to run this against a local clone whose canonical
+# remote has another name, and run `git fetch` first.
+#
+# Exits 1 when a tagged release is missing from a branch it should be in.
+
+set -euo pipefail
+
+PR_BASE="${1:-}"
+PR_REF="${2:-HEAD}"
+REMOTE="${REMOTE:-origin}"
+
+say() {
+  printf '%s\n' "$*"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"; fi
+}
+
+# Maintenance lines in version order, then main. v:refname sorts v2.10.x after
+# v2.9.x.
+CHAIN=()
+while IFS= read -r ref; do
+  CHAIN+=("$ref")
+done < <(
+  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
+    "refs/remotes/${REMOTE}/maint/v*"
+)
+CHAIN+=('main')
+
+# Resolve a chain branch, substituting the pending change when it targets it.
+resolve() {
+  if [ -n "$PR_BASE" ] && [ "$1" = "$PR_BASE" ]; then
+    git rev-parse "$PR_REF"
+  else
+    printf '%s/%s\n' "$REMOTE" "$1"
+  fi
+}
+
+say '## Release branches merged back'
+say ''
+
+failed=0
+checked=0
+
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  ref="${REMOTE}/${rel}"
+
+  tags="$(git tag --points-at "$ref" | tr '\n' ' ')"
+  tags="${tags% }"
+  if [ -z "$tags" ]; then
+    say ":grey_question: \`${rel}\` has no tag at its tip; not a released branch, skipped."
+    continue
+  fi
+
+  # [v]MAJOR.MINOR.PATCH[-anything] -> maint/vMAJOR.MINOR.x. The optional
+  # trailing part covers both a pre-release suffix (2.8.0-rc.1) and the build
+  # number some repos append (3.9.3-2393).
+  tag="${tags%% *}"
+  ver="${tag#v}"
+  major="${ver%%.*}"
+  rest="${ver#*.}"
+  minor="${rest%%.*}"
+  maint="maint/v${major}.${minor}.x"
+
+  # Its own line is the obligation. Anything downstream of it is merge-forward
+  # lag, which the merge-forward jobs already track, so it warns rather than
+  # fails; otherwise the merge-back PR itself would report red for main.
+  # A retired line is simply absent from the chain.
+  own=''
+  downstream=()
+  seen=0
+  for b in "${CHAIN[@]}"; do
+    if [ "$b" = "$maint" ]; then seen=1; own="$b"; continue; fi
+    if [ "$seen" -eq 1 ]; then downstream+=("$b"); fi
+  done
+  if [ "$seen" -eq 0 ]; then
+    own='main'
+    downstream=()
+    say ":grey_question: \`${rel}\` (\`${tag}\`) belongs to \`${maint}\`, which no longer exists; checking main only."
+  fi
+
+  checked=$((checked + 1))
+
+  lagging=()
+  for b in ${downstream[@]+"${downstream[@]}"}; do
+    if ! git merge-base --is-ancestor "$ref" "$(resolve "$b")"; then
+      lagging+=("$b")
+    fi
+  done
+
+  if ! git merge-base --is-ancestor "$ref" "$(resolve "$own")"; then
+    failed=1
+    say ":x: \`${rel}\` (\`${tag}\`) is **not** merged back into \`${own}\`."
+  elif [ "${#lagging[@]}" -ne 0 ]; then
+    list="$(printf '%s, ' "${lagging[@]}")"
+    say ":warning: \`${rel}\` (\`${tag}\`) is in \`${own}\` but has not reached ${list%, } yet."
+  else
+    say ":white_check_mark: \`${rel}\` (\`${tag}\`) is in \`${own}\` and downstream."
+  fi
+done < <(
+  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
+    "refs/remotes/${REMOTE}/release/*"
+)
+
+say ''
+
+if [ "$checked" -eq 0 ]; then
+  say 'No tagged release branches to check.'
+  exit 0
+fi
+
+if [ "$failed" -eq 0 ]; then
+  say "All ${checked} tagged release branches are merged back into their line."
+  exit 0
+fi
+
+say 'Advisory only. Merge the release branch back into its maintenance line and'
+say 'let it flow forward, rather than cherry-picking, so the tag stays reachable.'
+exit 1

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -10,12 +10,15 @@
 #             branches as they stand.
 #   pr-ref    the pending change; defaults to HEAD (refs/pull/N/merge in CI).
 #
-# A release/X.Y.Z branch counts as released only once a release-shaped tag
-# (X.Y.Z) points at its tip that is not older than the version in the branch
-# name. A branch prepare-release.sh has freshly cut still points at the
+# A release/X.Y.Z branch counts as released once a release-shaped tag (X.Y.Z)
+# not older than the version in the branch name is reachable from its tip --
+# reachable, not at the tip, so commits landing after the tag do not unmark
+# the branch. A branch prepare-release.sh has freshly cut reaches only the
 # PREVIOUS release's tag, so it is skipped as in-flight until its own tag
-# lands. The maintenance line comes from the tag rather than the branch name,
-# and both maint/X.Y.x and maint/vX.Y.x spellings of a line are recognised.
+# lands. A release/ branch with no version in its name is released only while
+# a release tag points at its tip. The maintenance line comes from the tag
+# rather than the branch name, and both maint/X.Y.x and maint/vX.Y.x
+# spellings of a line are recognised.
 #
 # Branches resolve under refs/remotes/$REMOTE, which defaults to origin -- what
 # CI checks out. Set REMOTE to run this against a local clone whose canonical
@@ -135,19 +138,31 @@ while IFS= read -r rel; do
   # Only release-shaped tags mark a release: the repo also multi-tags commits
   # with build tags (0.0.1-42-mainnet) and the odd pre-release, and those must
   # not elect a maintenance line. Of several, the newest wins.
-  tag="$(git tag --points-at "$ref" | { grep -E "$RELEASE_TAG_RE" || true; } | version_sort | tail -1)"
-  if [ -z "$tag" ]; then
-    say ":grey_question: \`${rel}\` has no release tag at its tip; not a released branch, skipped."
-    continue
-  fi
-
-  # A branch prepare-release.sh has cut but not yet released still points at
-  # the previous release's tag: every release tag at its tip is older than the
-  # version in its own name. It has released nothing yet, so skip it.
   branch_ver="${rel#release/}"
   if printf '%s\n' "$branch_ver" | grep -qE "$RELEASE_TAG_RE"; then
+    # A version-named branch is released once its release tag is reachable
+    # from the tip. Reachable, not at the tip: a commit landing after the tag
+    # must not unmark the branch -- an unreachable tag behind a moved tip is
+    # exactly the state this check exists to catch.
+    tag="$(release_tags_merged_into "$ref" | tail -1)"
+    if [ -z "$tag" ]; then
+      say ":grey_question: \`${rel}\` has no release tag in its history; not yet released, skipped."
+      continue
+    fi
+    # A branch prepare-release.sh has cut but not yet released reaches only
+    # the previous release's tag, older than the version in its own name. It
+    # has released nothing yet, so skip it.
     if [ "$tag" != "$branch_ver" ] && version_le "$tag" "$branch_ver"; then
       say ":grey_question: \`${rel}\` is freshly cut from \`${tag}\` and not yet released; skipped."
+      continue
+    fi
+  else
+    # A branch with no version in its name has no tag of its own to wait for;
+    # only a release tag at its tip marks it released. Reachability would let
+    # any branch cut above a release inherit that release's obligation.
+    tag="$(git tag --points-at "$ref" | { grep -E "$RELEASE_TAG_RE" || true; } | version_sort | tail -1)"
+    if [ -z "$tag" ]; then
+      say ":grey_question: \`${rel}\` has no release tag at its tip; not a released branch, skipped."
       continue
     fi
   fi

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -10,10 +10,12 @@
 #             branches as they stand.
 #   pr-ref    the pending change; defaults to HEAD (refs/pull/N/merge in CI).
 #
-# A release/ branch counts as released only when a tag points at its tip, so
-# in-flight release branches are skipped. The maintenance line comes from the
-# TAG, not the branch name: in the Swift SDK, release/3.0.0 is tagged 2.8.0-rc.1
-# and belongs to maint/v2.8.x.
+# A release/X.Y.Z branch counts as released only once a release-shaped tag
+# (X.Y.Z) points at its tip that is not older than the version in the branch
+# name. A branch prepare-release.sh has freshly cut still points at the
+# PREVIOUS release's tag, so it is skipped as in-flight until its own tag
+# lands. The maintenance line comes from the tag rather than the branch name,
+# and both maint/X.Y.x and maint/vX.Y.x spellings of a line are recognised.
 #
 # Branches resolve under refs/remotes/$REMOTE, which defaults to origin -- what
 # CI checks out. Set REMOTE to run this against a local clone whose canonical
@@ -27,21 +29,49 @@ PR_BASE="${1:-}"
 PR_REF="${2:-HEAD}"
 REMOTE="${REMOTE:-origin}"
 
+# RELEASE_TAG_RE, version_sort and version_le come from the release library,
+# so the tag shapes this check recognises are the ones the release tooling
+# actually cuts.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=Scripts/lib/release-lib.sh
+. "${SCRIPT_DIR}/../../Scripts/lib/release-lib.sh"
+
 say() {
   printf '%s\n' "$*"
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"; fi
 }
 
-# Maintenance lines in version order, then main. v:refname sorts v2.10.x after
-# v2.9.x.
+# Maintenance lines in version order, then main. The repo has carried both
+# maint/X.Y.x and maint/vX.Y.x spellings, so every maint/* branch is collected
+# and ordered by the version it carries, v or no v.
 CHAIN=()
 while IFS= read -r ref; do
   CHAIN+=("$ref")
 done < <(
-  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
-    "refs/remotes/${REMOTE}/maint/v*"
+  git for-each-ref --format='%(refname:lstrip=3)' "refs/remotes/${REMOTE}/maint/*" |
+    while IFS= read -r b; do
+      key="${b#maint/}"
+      key="${key#v}"
+      printf '%s %s\n' "$key" "$b"
+    done | sort -k1,1 -V | cut -d' ' -f2
 )
 CHAIN+=('main')
+
+# The chain entry that is the maintenance line for X.Y ($1), whichever
+# spelling the branch uses; the canonical maint/vX.Y.x when the line is gone.
+line_for() {
+  local want="$1" b key
+  for b in ${CHAIN[@]+"${CHAIN[@]}"}; do
+    case "$b" in maint/*) ;; *) continue ;; esac
+    key="${b#maint/}"
+    key="${key#v}"
+    if [ "$key" = "${want}.x" ]; then
+      printf '%s\n' "$b"
+      return 0
+    fi
+  done
+  printf 'maint/v%s.x\n' "$want"
+}
 
 # Resolve a chain branch, substituting the pending change when it targets it.
 resolve() {
@@ -62,22 +92,32 @@ while IFS= read -r rel; do
   [ -n "$rel" ] || continue
   ref="${REMOTE}/${rel}"
 
-  tags="$(git tag --points-at "$ref" | tr '\n' ' ')"
-  tags="${tags% }"
-  if [ -z "$tags" ]; then
-    say ":grey_question: \`${rel}\` has no tag at its tip; not a released branch, skipped."
+  # Only release-shaped tags mark a release: the repo also multi-tags commits
+  # with build tags (0.0.1-42-mainnet) and the odd pre-release, and those must
+  # not elect a maintenance line. Of several, the newest wins.
+  tag="$(git tag --points-at "$ref" | { grep -E "$RELEASE_TAG_RE" || true; } | version_sort | tail -1)"
+  if [ -z "$tag" ]; then
+    say ":grey_question: \`${rel}\` has no release tag at its tip; not a released branch, skipped."
     continue
   fi
 
-  # [v]MAJOR.MINOR.PATCH[-anything] -> maint/vMAJOR.MINOR.x. The optional
-  # trailing part covers both a pre-release suffix (2.8.0-rc.1) and the build
-  # number some repos append (3.9.3-2393).
-  tag="${tags%% *}"
+  # A branch prepare-release.sh has cut but not yet released still points at
+  # the previous release's tag: every release tag at its tip is older than the
+  # version in its own name. It has released nothing yet, so skip it.
+  branch_ver="${rel#release/}"
+  if printf '%s\n' "$branch_ver" | grep -qE "$RELEASE_TAG_RE"; then
+    if [ "$tag" != "$branch_ver" ] && version_le "$tag" "$branch_ver"; then
+      say ":grey_question: \`${rel}\` is freshly cut from \`${tag}\` and not yet released; skipped."
+      continue
+    fi
+  fi
+
+  # [v]MAJOR.MINOR.PATCH[-anything] -> its maintenance line.
   ver="${tag#v}"
   major="${ver%%.*}"
   rest="${ver#*.}"
   minor="${rest%%.*}"
-  maint="maint/v${major}.${minor}.x"
+  maint="$(line_for "${major}.${minor}")"
 
   # Its own line is the obligation. Anything downstream of it is merge-forward
   # lag, which the merge-forward jobs already track, so it warns rather than

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -17,8 +17,9 @@
 # PREVIOUS release's tag, so it is skipped as in-flight until its own tag
 # lands. A release/ branch with no version in its name is released only while
 # a release tag points at its tip. The maintenance line comes from the tag
-# rather than the branch name, and both maint/X.Y.x and maint/vX.Y.x
-# spellings of a line are recognised.
+# rather than the branch name and is always maint/vX.Y.x -- the shape the
+# release tooling names; a maint/ branch of any other shape is reported and
+# ignored.
 #
 # Branches resolve under refs/remotes/$REMOTE, which defaults to origin -- what
 # CI checks out. Set REMOTE to run this against a local clone whose canonical
@@ -35,9 +36,10 @@ PR_BASE="${1:-}"
 PR_REF="${2:-HEAD}"
 REMOTE="${REMOTE:-origin}"
 
-# RELEASE_TAG_RE, version_sort and version_le come from the release library,
-# so the tag shapes this check recognises are the ones the release tooling
-# actually cuts.
+# RELEASE_TAG_RE, version_sort, version_le, release_tags_merged_into and
+# maint_line_for_version come from the release library, so the tag shapes this
+# check recognises are the ones the release tooling actually cuts, and the
+# maintenance line it enforces is the branch that tooling names.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=Scripts/lib/release-lib.sh
 . "${SCRIPT_DIR}/../../Scripts/lib/release-lib.sh"
@@ -75,42 +77,31 @@ if [ -n "$PR_BASE" ]; then
   fi
 fi
 
-# Maintenance lines in version order, then main. The repo has carried both
-# maint/X.Y.x and maint/vX.Y.x spellings, so every maint/* branch is collected
-# and ordered by the version it carries, v or no v.
+# Maintenance lines in version order, then main. A line is always named
+# maint/vX.Y.x; a maint/ branch of any other shape is set aside and reported
+# below, never silently dropped.
 # Enumerated through a checked substitution: a for-each-ref failure must be a
 # loud infrastructure error, not an empty chain.
 if ! maint_refs="$(git for-each-ref --format='%(refname:lstrip=3)' "refs/remotes/${REMOTE}/maint/*")"; then
   infra_fail "listing refs/remotes/${REMOTE}/maint/* failed"
 fi
-sorted_maint="$(printf '%s\n' "$maint_refs" | while IFS= read -r b; do
+UNRECOGNISED=()
+pairs=()
+while IFS= read -r b; do
   [ -n "$b" ] || continue
-  key="${b#maint/}"
-  key="${key#v}"
-  printf '%s %s\n' "$key" "$b"
-done | sort -k1,1 -V | cut -d' ' -f2)"
+  if printf '%s\n' "$b" | grep -qE '^maint/v[0-9]+\.[0-9]+\.x$'; then
+    pairs+=("${b#maint/v} ${b}")
+  else
+    UNRECOGNISED+=("$b")
+  fi
+done <<< "$maint_refs"
+sorted_maint="$(printf '%s\n' ${pairs[@]+"${pairs[@]}"} | sort -k1,1 -V | cut -d' ' -f2)"
 CHAIN=()
 while IFS= read -r ref; do
   [ -n "$ref" ] || continue
   CHAIN+=("$ref")
 done <<< "$sorted_maint"
 CHAIN+=('main')
-
-# The chain entry that is the maintenance line for X.Y ($1), whichever
-# spelling the branch uses; the canonical maint/vX.Y.x when the line is gone.
-line_for() {
-  local want="$1" b key
-  for b in ${CHAIN[@]+"${CHAIN[@]}"}; do
-    case "$b" in maint/*) ;; *) continue ;; esac
-    key="${b#maint/}"
-    key="${key#v}"
-    if [ "$key" = "${want}.x" ]; then
-      printf '%s\n' "$b"
-      return 0
-    fi
-  done
-  printf 'maint/v%s.x\n' "$want"
-}
 
 # Resolve a chain branch, substituting the pending change when it targets it.
 resolve() {
@@ -127,6 +118,10 @@ fi
 
 say '## Release branches merged back'
 say ''
+
+for b in ${UNRECOGNISED[@]+"${UNRECOGNISED[@]}"}; do
+  say ":grey_question: \`${b}\` does not match maint/vX.Y.x; not a maintenance line, ignored."
+done
 
 failed=0
 checked=0
@@ -167,11 +162,10 @@ while IFS= read -r rel; do
     fi
   fi
 
-  # X.Y.Z -> its maintenance line.
-  major="${tag%%.*}"
-  rest="${tag#*.}"
-  minor="${rest%%.*}"
-  maint="$(line_for "${major}.${minor}")"
+  # X.Y.Z -> its maintenance line, named by the same library function that
+  # tells the operator where to merge, so the branch this check enforces is
+  # the branch the tooling instructed.
+  maint="$(maint_line_for_version "$tag")"
 
   # Its own line is the obligation. Anything downstream of it is merge-forward
   # lag, which the merge-forward jobs already track, so it warns rather than

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -21,7 +21,10 @@
 # CI checks out. Set REMOTE to run this against a local clone whose canonical
 # remote has another name, and run `git fetch` first.
 #
-# Exits 1 when a tagged release is missing from a branch it should be in.
+# Exit codes: 0 = every checked branch is merged back; 1 = advisory findings
+# (a tagged release missing from a branch it should be in); 2 = the check
+# could not run at all -- refs unreadable, git failing -- which callers must
+# not report as a clean result.
 
 set -euo pipefail
 
@@ -41,20 +44,53 @@ say() {
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"; fi
 }
 
+# An infrastructure failure: the check could not run. Distinct from findings
+# (exit 1) so a caller that treats findings as advisory does not also
+# swallow a broken run as green.
+infra_fail() {
+  say ":stop_sign: the merged-back check could not run: $1"
+  echo "error: $1" >&2
+  exit 2
+}
+
+# Is $1 an ancestor of $2? Status 1 means genuinely not an ancestor; anything
+# above 1 means git could not answer (an unresolvable ref, a broken repo),
+# which must not be mistaken for a finding.
+in_branch() {
+  local rc=0
+  git merge-base --is-ancestor "$1" "$2" || rc=$?
+  [ "$rc" -le 1 ] || infra_fail "git merge-base --is-ancestor '$1' '$2' failed (exit ${rc})"
+  return "$rc"
+}
+
+# The pending change, resolved once up front: a bad ref argument is an
+# infrastructure problem, not a property of any release branch.
+PR_SHA=''
+if [ -n "$PR_BASE" ]; then
+  if ! PR_SHA="$(git rev-parse -q --verify "${PR_REF}^{commit}")"; then
+    infra_fail "cannot resolve pr-ref '${PR_REF}'"
+  fi
+fi
+
 # Maintenance lines in version order, then main. The repo has carried both
 # maint/X.Y.x and maint/vX.Y.x spellings, so every maint/* branch is collected
 # and ordered by the version it carries, v or no v.
+# Enumerated through a checked substitution: a for-each-ref failure must be a
+# loud infrastructure error, not an empty chain.
+if ! maint_refs="$(git for-each-ref --format='%(refname:lstrip=3)' "refs/remotes/${REMOTE}/maint/*")"; then
+  infra_fail "listing refs/remotes/${REMOTE}/maint/* failed"
+fi
+sorted_maint="$(printf '%s\n' "$maint_refs" | while IFS= read -r b; do
+  [ -n "$b" ] || continue
+  key="${b#maint/}"
+  key="${key#v}"
+  printf '%s %s\n' "$key" "$b"
+done | sort -k1,1 -V | cut -d' ' -f2)"
 CHAIN=()
 while IFS= read -r ref; do
+  [ -n "$ref" ] || continue
   CHAIN+=("$ref")
-done < <(
-  git for-each-ref --format='%(refname:lstrip=3)' "refs/remotes/${REMOTE}/maint/*" |
-    while IFS= read -r b; do
-      key="${b#maint/}"
-      key="${key#v}"
-      printf '%s %s\n' "$key" "$b"
-    done | sort -k1,1 -V | cut -d' ' -f2
-)
+done <<< "$sorted_maint"
 CHAIN+=('main')
 
 # The chain entry that is the maintenance line for X.Y ($1), whichever
@@ -76,11 +112,15 @@ line_for() {
 # Resolve a chain branch, substituting the pending change when it targets it.
 resolve() {
   if [ -n "$PR_BASE" ] && [ "$1" = "$PR_BASE" ]; then
-    git rev-parse "$PR_REF"
+    printf '%s\n' "$PR_SHA"
   else
     printf '%s/%s\n' "$REMOTE" "$1"
   fi
 }
+
+if ! release_refs="$(git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' "refs/remotes/${REMOTE}/release/*")"; then
+  infra_fail "listing refs/remotes/${REMOTE}/release/* failed"
+fi
 
 say '## Release branches merged back'
 say ''
@@ -139,12 +179,12 @@ while IFS= read -r rel; do
 
   lagging=()
   for b in ${downstream[@]+"${downstream[@]}"}; do
-    if ! git merge-base --is-ancestor "$ref" "$(resolve "$b")"; then
+    if ! in_branch "$ref" "$(resolve "$b")"; then
       lagging+=("$b")
     fi
   done
 
-  if ! git merge-base --is-ancestor "$ref" "$(resolve "$own")"; then
+  if ! in_branch "$ref" "$(resolve "$own")"; then
     failed=1
     say ":x: \`${rel}\` (\`${tag}\`) is **not** merged back into \`${own}\`."
   elif [ "${#lagging[@]}" -ne 0 ]; then
@@ -153,10 +193,7 @@ while IFS= read -r rel; do
   else
     say ":white_check_mark: \`${rel}\` (\`${tag}\`) is in \`${own}\` and downstream."
   fi
-done < <(
-  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
-    "refs/remotes/${REMOTE}/release/*"
-)
+done <<< "$release_refs"
 
 say ''
 

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -139,7 +139,9 @@ while IFS= read -r rel; do
     # from the tip. Reachable, not at the tip: a commit landing after the tag
     # must not unmark the branch -- an unreachable tag behind a moved tip is
     # exactly the state this check exists to catch.
-    tag="$(release_tags_merged_into "$ref" | tail -1)"
+    if ! tag="$(release_tags_merged_into "$ref" | tail -1)"; then
+      infra_fail "listing release tags merged into '${ref}' failed"
+    fi
     if [ -z "$tag" ]; then
       say ":grey_question: \`${rel}\` has no release tag in its history; not yet released, skipped."
       continue
@@ -155,7 +157,9 @@ while IFS= read -r rel; do
     # A branch with no version in its name has no tag of its own to wait for;
     # only a release tag at its tip marks it released. Reachability would let
     # any branch cut above a release inherit that release's obligation.
-    tag="$(git tag --points-at "$ref" | { grep -E "$RELEASE_TAG_RE" || true; } | version_sort | tail -1)"
+    if ! tag="$(git tag --points-at "$ref" | { grep -E "$RELEASE_TAG_RE" || true; } | version_sort | tail -1)"; then
+      infra_fail "listing tags at the tip of '${ref}' failed"
+    fi
     if [ -z "$tag" ]; then
       say ":grey_question: \`${rel}\` has no release tag at its tip; not a released branch, skipped."
       continue

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -170,7 +170,7 @@ while IFS= read -r rel; do
   # Its own line is the obligation. Anything downstream of it is merge-forward
   # lag, which the merge-forward jobs already track, so it warns rather than
   # fails; otherwise the merge-back PR itself would report red for main.
-  # A line absent from the chain is handled below: main is checked, warning only.
+  # When the line does not exist, main takes over as the obligation below.
   own=''
   downstream=()
   seen=0
@@ -181,14 +181,17 @@ while IFS= read -r rel; do
   checked=$((checked + 1))
 
   if [ "$seen" -eq 0 ]; then
-    # The line was never created, or has been retired. There is no own-line
-    # obligation to enforce; whether the release has flowed to main is
-    # merge-forward lag, which is a warning by policy, never a failure.
+    # The line was never created, or has been retired. With no line, main is
+    # the one permanent branch that can keep the tag reachable, so reaching
+    # main is this release's obligation -- the unreachable-tag hazard itself,
+    # not merge-forward lag. Every release that opens a new minor line passes
+    # through this state, since cutting a release creates no maint branch.
     say ":grey_question: \`${rel}\` (\`${tag}\`) belongs to \`${maint}\`, which does not exist; checking main only."
     if in_branch "$ref" "$(resolve main)"; then
       say ":white_check_mark: \`${rel}\` (\`${tag}\`) is in \`main\`."
     else
-      say ":warning: \`${rel}\` (\`${tag}\`) has not reached \`main\` yet; create \`${maint}\` (or merge the release back) so the tag stays reachable."
+      failed=1
+      say ":x: \`${rel}\` (\`${tag}\`) has no maintenance line and has not reached \`main\`; create \`${maint}\` from it (or merge it into \`main\`) so the tag stays reachable."
     fi
     continue
   fi
@@ -219,7 +222,7 @@ if [ "$checked" -eq 0 ]; then
 fi
 
 if [ "$failed" -eq 0 ]; then
-  say "All ${checked} tagged release branches are merged back into their line."
+  say "All ${checked} tagged release branches are merged back."
   exit 0
 fi
 

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -161,7 +161,7 @@ while IFS= read -r rel; do
   # Its own line is the obligation. Anything downstream of it is merge-forward
   # lag, which the merge-forward jobs already track, so it warns rather than
   # fails; otherwise the merge-back PR itself would report red for main.
-  # A retired line is simply absent from the chain.
+  # A line absent from the chain is handled below: main is checked, warning only.
   own=''
   downstream=()
   seen=0
@@ -169,13 +169,20 @@ while IFS= read -r rel; do
     if [ "$b" = "$maint" ]; then seen=1; own="$b"; continue; fi
     if [ "$seen" -eq 1 ]; then downstream+=("$b"); fi
   done
-  if [ "$seen" -eq 0 ]; then
-    own='main'
-    downstream=()
-    say ":grey_question: \`${rel}\` (\`${tag}\`) belongs to \`${maint}\`, which no longer exists; checking main only."
-  fi
-
   checked=$((checked + 1))
+
+  if [ "$seen" -eq 0 ]; then
+    # The line was never created, or has been retired. There is no own-line
+    # obligation to enforce; whether the release has flowed to main is
+    # merge-forward lag, which is a warning by policy, never a failure.
+    say ":grey_question: \`${rel}\` (\`${tag}\`) belongs to \`${maint}\`, which does not exist; checking main only."
+    if in_branch "$ref" "$(resolve main)"; then
+      say ":white_check_mark: \`${rel}\` (\`${tag}\`) is in \`main\`."
+    else
+      say ":warning: \`${rel}\` (\`${tag}\`) has not reached \`main\` yet; create \`${maint}\` (or merge the release back) so the tag stays reachable."
+    fi
+    continue
+  fi
 
   lagging=()
   for b in ${downstream[@]+"${downstream[@]}"}; do

--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -112,10 +112,9 @@ while IFS= read -r rel; do
     fi
   fi
 
-  # [v]MAJOR.MINOR.PATCH[-anything] -> its maintenance line.
-  ver="${tag#v}"
-  major="${ver%%.*}"
-  rest="${ver#*.}"
+  # X.Y.Z -> its maintenance line.
+  major="${tag%%.*}"
+  rest="${tag#*.}"
   minor="${rest%%.*}"
   maint="$(line_for "${major}.${minor}")"
 
@@ -126,7 +125,7 @@ while IFS= read -r rel; do
   own=''
   downstream=()
   seen=0
-  for b in "${CHAIN[@]}"; do
+  for b in ${CHAIN[@]+"${CHAIN[@]}"}; do
     if [ "$b" = "$maint" ]; then seen=1; own="$b"; continue; fi
     if [ "$seen" -eq 1 ]; then downstream+=("$b"); fi
   done

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -29,8 +29,11 @@ env:
 jobs:
   validate_sdk_pin:
     # Cheap gate: an invalid .sdk-pin fails here in seconds instead of
-    # burning two macOS jobs. Same draft guard as unit_tests.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    # burning two macOS jobs. Same draft guard as unit_tests, except release
+    # PRs: their candidate content ships to users before the PR merges, so a
+    # draft release PR gets full CI on every push while its draft state
+    # keeps guarding the merge.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || startsWith(github.base_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -123,8 +126,10 @@ jobs:
   # xcodebuild + SPM resolve in each phase job, paying ~7 min twice.
   build:
     # Skip draft PRs — the e2e/smoke suite is expensive (up to 75-min runs
-    # that spend real mainnet funds). Manual `workflow_dispatch` runs carry
-    # no pull_request context, so the guard lets them through.
+    # that spend real mainnet funds). Release PRs are the exception: their
+    # candidate content ships before the PR merges, which outweighs a few
+    # extra runs per cycle. Manual `workflow_dispatch` runs carry no
+    # pull_request context, so the guard lets them through.
     needs: [validate_sdk_pin, build_ffi]
     # build_ffi is skipped in remote mode; accept success OR skipped. The draft/dispatch guard lives on validate_sdk_pin and propagates through needs.
     if: ${{ !cancelled() && needs.validate_sdk_pin.result == 'success' && (needs.build_ffi.result == 'success' || needs.build_ffi.result == 'skipped') }}
@@ -321,9 +326,9 @@ jobs:
     # !cancelled() + the explicit build result replace the implicit success(),
     # which a transitively skipped build_ffi (remote SDK mode) poisons even
     # when build itself succeeds — without this the whole matrix silently
-    # skips on every remote-mode PR. Draft PRs still skip: validate_sdk_pin
-    # skips on drafts, so build never reaches 'success'.
-    if: ${{ !cancelled() && needs.build.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+    # skips on every remote-mode PR. Draft PRs still skip (release PRs
+    # excepted): validate_sdk_pin skips them, so build never reaches 'success'.
+    if: ${{ !cancelled() && needs.build.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false || startsWith(github.base_ref, 'release/')) }}
     runs-on: macos-26
     # Cold-cache phase 2 runs spend ~25-30 min on the
     # restore-existing-wallet sync alone (chain-tip catchup from the

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,8 +26,11 @@ env:
 jobs:
   validate_sdk_pin:
     # Cheap gate: an invalid .sdk-pin fails here in seconds instead of
-    # burning two macOS jobs. Same draft guard as unit_tests.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    # burning two macOS jobs. Same draft guard as unit_tests, except release
+    # PRs: their candidate content ships to users before the PR merges, so a
+    # draft release PR gets full CI on every push while its draft state
+    # keeps guarding the merge.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false || startsWith(github.base_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -116,7 +119,8 @@ jobs:
           if-no-files-found: error
 
   unit_tests:
-    # Skip draft PRs — no tests run until a PR is marked ready for review
+    # Skip draft PRs — no tests run until a PR is marked ready for review —
+    # except release PRs, which are tested while still draft
     # (matches the e2e/smoke suite guard in e2e-smoke.yml).
     needs: [validate_sdk_pin, build_ffi]
     # build_ffi is skipped in remote mode; accept success OR skipped. The draft guard lives on validate_sdk_pin and propagates through needs.

--- a/.github/workflows/release-merged-back.yml
+++ b/.github/workflows/release-merged-back.yml
@@ -1,0 +1,58 @@
+# Checks that every tagged release/ branch has been merged back into its
+# maintenance line, and flowed forward to main. A release that is only
+# cherry-picked back leaves its tag unreachable from any live branch, so the
+# released commit stops being part of the history it shipped from.
+#
+# Advisory only: continue-on-error keeps this from blocking. Read the detail in
+# the run summary.
+#
+# Only missing from its OWN maint line fails; not having reached main yet is a
+# warning, since the merge-forward jobs already track that.
+#
+# Run locally with:
+#   ./.github/scripts/check-release-merged-back.sh
+# or, when the canonical remote in your clone is not named origin:
+#   REMOTE=upstream ./.github/scripts/check-release-merged-back.sh
+
+name: Release Merged Back
+
+on:
+  pull_request:
+    branches:
+      # `maint/**` rather than `maint/v*` so the check also runs on pull
+      # requests into a maintenance branch cut before the maint/vX.Y.x naming
+      # was settled on.
+      - 'maint/**'
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release_merged_back:
+    name: release branches merged back
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Read-only job, and the tag fetch below works unauthenticated against
+          # this public repository, so the credential is not needed past
+          # checkout and should not be left in .git/config.
+          persist-credentials: false
+      - name: Check release branches
+        timeout-minutes: 5
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Tags are what mark a release branch as released, so fetch them.
+          git fetch --quiet --tags origin '+refs/heads/*:refs/remotes/origin/*'
+          ./.github/scripts/check-release-merged-back.sh "${BASE_REF}"

--- a/.github/workflows/release-merged-back.yml
+++ b/.github/workflows/release-merged-back.yml
@@ -3,8 +3,11 @@
 # cherry-picked back leaves its tag unreachable from any live branch, so the
 # released commit stops being part of the history it shipped from.
 #
-# Advisory only: the check step carries continue-on-error, so findings never
-# block. Read the detail in the run summary.
+# Advisory only for findings: the check step maps the script's findings exit
+# (1) to success, so findings never block -- read them in the run summary.
+# An infrastructure failure (exit 2: refs unreadable, script broken) does
+# fail the job, because a check that could not run must not pass as a green
+# run that checked nothing.
 #
 # Only missing from its OWN maint line fails; not having reached main yet is a
 # warning, since the merge-forward jobs already track that.
@@ -51,10 +54,17 @@ jobs:
           persist-credentials: false
       - name: Check release branches
         timeout-minutes: 5
-        # Advisory: findings must never block a PR -- but only findings. On
-        # the job this would also swallow a broken checkout or a fetch
-        # failure, leaving a green run that checked nothing.
-        continue-on-error: true
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: ./.github/scripts/check-release-merged-back.sh "${BASE_REF}"
+        # Findings (exit 1) are advisory and map to success -- read them in
+        # the run summary. Anything else non-zero means the check itself
+        # broke, and must fail the job rather than pass as a green run that
+        # checked nothing. (continue-on-error would swallow both alike.)
+        run: |
+          rc=0
+          ./.github/scripts/check-release-merged-back.sh "${BASE_REF}" || rc=$?
+          if [ "$rc" -eq 1 ]; then
+            echo "advisory findings reported; see the run summary"
+            exit 0
+          fi
+          exit "$rc"

--- a/.github/workflows/release-merged-back.yml
+++ b/.github/workflows/release-merged-back.yml
@@ -22,9 +22,9 @@ name: Release Merged Back
 on:
   pull_request:
     branches:
-      # `maint/**` rather than `maint/v*` so the check also runs on pull
-      # requests into a maintenance branch cut before the maint/vX.Y.x naming
-      # was settled on.
+      # `maint/**` rather than `maint/v*`: a pull request into a wrongly-named
+      # maintenance branch still runs the check, which reports the branch as
+      # unrecognised instead of silently skipping it.
       - 'maint/**'
       - main
 

--- a/.github/workflows/release-merged-back.yml
+++ b/.github/workflows/release-merged-back.yml
@@ -3,8 +3,8 @@
 # cherry-picked back leaves its tag unreachable from any live branch, so the
 # released commit stops being part of the history it shipped from.
 #
-# Advisory only: continue-on-error keeps this from blocking. Read the detail in
-# the run summary.
+# Advisory only: the check step carries continue-on-error, so findings never
+# block. Read the detail in the run summary.
 #
 # Only missing from its OWN maint line fails; not having reached main yet is a
 # warning, since the merge-forward jobs already track that.
@@ -35,7 +35,6 @@ jobs:
   release_merged_back:
     name: release branches merged back
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -43,16 +42,19 @@ jobs:
         timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Full history plus tags: with fetch-depth 0 this checkout fetches
+          # +refs/heads/*:refs/remotes/origin/* and +refs/tags/*:refs/tags/*,
+          # which is everything the check reads.
           fetch-depth: 0
-          # Read-only job, and the tag fetch below works unauthenticated against
-          # this public repository, so the credential is not needed past
-          # checkout and should not be left in .git/config.
+          # Read-only job against a public repository; the credential is not
+          # needed past checkout and should not be left in .git/config.
           persist-credentials: false
       - name: Check release branches
         timeout-minutes: 5
+        # Advisory: findings must never block a PR -- but only findings. On
+        # the job this would also swallow a broken checkout or a fetch
+        # failure, leaving a green run that checked nothing.
+        continue-on-error: true
         env:
           BASE_REF: ${{ github.base_ref }}
-        run: |
-          # Tags are what mark a release branch as released, so fetch them.
-          git fetch --quiet --tags origin '+refs/heads/*:refs/remotes/origin/*'
-          ./.github/scripts/check-release-merged-back.sh "${BASE_REF}"
+        run: ./.github/scripts/check-release-merged-back.sh "${BASE_REF}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,46 +7,16 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ## [Unreleased]
 
+## [3.10.3] - 2026-08-31
+
 ### Added
-- [Ironwood] Before opening the voting database, ZODL now preserves a copy of it under `voting_recovery`. If an earlier version already discarded a poll's delegation, that copy keeps what is needed to restore it later — even if you upgrade long after the poll was affected. It is taken only once, so the earliest and most complete copy is the one kept; it is included in device backups so it survives a migration, and is removed when the wallet is reset.
 - [MOB-1749] When a wallet that already holds Ironwood funds still has a small spendable amount of ZEC sitting in the Orchard pool — less than 0.01 ZEC but more than 0.0001 ZEC, typically after restoring a wallet that was migrated on another device or after moving funds yourself — the home screen shows a "… ZEC left in Orchard" banner once the wallet is fully synced (never over a figure that has not been verified). The banner ranks directly below the migration banners themselves — only connectivity and sync-error alerts and an actual migration outrank it — and it retires for good after two taps (lock or migrate), so the reminders it briefly covers return; an outstanding shielding reminder also no longer hides the reminders ranked below it. Tapping More opens a screen that shows what is in Ironwood, what is left in Orchard, what is still pending, and — when an earlier visit locked part of it — what is already locked, and lets you lock the leftover balance (recommended: moving an amount that specific could link your Ironwood funds back to your Orchard history) or migrate it anyway. Migrating anyway from an unlocked balance moves only the spendable leftover and never touches an amount you locked before; on a locked balance the same button is the way back — it unlocks the funds and moves them after all. A completed migration's screen always reports that run's own leftover, even when an earlier amount is still locked, and leaving the flow with a back-swipe is immediate. A migration that is still running, or a Migration Complete screen you have not reviewed yet, always takes precedence, and the banner disappears by itself once the balance is locked or migrated.
 - [MOB-1753] The vote submission screen now explains that submitting can take a few minutes and that wallets with more voting weight take longer to process.
-- [MOB-1466] Advanced Settings now offers "Restart Migration" while a migration is running. It shows how much has already migrated and how much is left, warns that restarting cancels the current plan for good, and asks for a separate confirmation before anything happens. Transfers that already went out are untouched — they stay migrated — and once the plan is cancelled you set up a new one for the remaining balance the same way you did the first time.
-- [MOB-1466] With a privacy migration in progress, keeping the app open now advances the migration automatically — transfers send on schedule without reopening the app.
-- [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
-- [Ironwood] Once ZODL sees that the Ironwood network upgrade is live on the network, it shows a short one-time screen introducing the change, with a link to a support article. It appears once per device — after you continue past it, it never comes back.
-- [MOB-1535] Tapping your balance on the home screen now opens a "Total Balance Across Pools" breakdown showing how much ZEC sits in each Zcash pool — Orchard, Sapling, Transparent and Ironwood — so you can see exactly where your funds are. When currency conversion is turned on, each pool also shows its value in your selected currency. Pools you hold nothing in are still listed, and with balances hidden every amount stays masked.
-- The hidden database debug screen (Settings → What's New → long-press the logo) now accepts a special "print_notifs" query that lists the migration reminder notifications currently scheduled on the device — their identifiers, fire times and accounts — instead of running SQL.
-- [Ironwood] Warn before confirming a send that has to spend Orchard funds: the confirmation screen now shows a sheet recommending migration first, with the option to continue or cancel.
 - [Internal] On the Send screen, in internal and testnet builds only, the Amount field now has a "Max" button that fills in the maximum amount you can send, net of the network fee — computed for the exact payment being set up, including its memo. The button is available only with a spendable balance and a valid recipient address, a result for an outdated address is discarded, and a toast tells you when the amount could not be fetched.
 - [Internal] On the Swap and Pay screens, in internal and testnet builds only, the amount field now has a "Max" button too. On Swap it fills in the largest amount of ZEC you can swap, net of the network fee (or its value in USD when you have switched the field to USD); on Pay it fills in what that amount is worth in the token you are paying with, and updates the accompanying USD value alongside it. The button is unavailable while your balance is still confirming or empty, or while a quote is being fetched, and a toast tells you when the amount could not be fetched or converted.
 
 ### Changed
 - The paste-seed shortcut on the Secret Recovery Phrase screen (long-press the title) now works in internal and testnet builds — including TestFlight — instead of debug builds only. It stays excluded from the App Store build.
-- [MOB-1678] Coinholder Polling now loads its trusted configuration through the resilient voting config gateway, so a GitHub outage no longer blocks configuration loading while the mirrored copy is available.
-- [MOB-1466] Starting a migration now holds you on a "Scheduling…" screen while the schedule is confirmed and the first step is prepared, instead of leaving you on the plan under a spinning button for up to half a minute. The summary fills in with your real numbers the moment it is ready.
-- [MOB-1466] The migration split details sheet now scrolls when a split has more than five steps, so long splits stay readable and the sheet's total and "Got it" button stay reachable. Shorter splits are unchanged.
-- [MOB-1466] "Restart Migration" appears in Advanced Settings only while a migration is actually in progress, and no longer lingers once one has finished.
-- [MOB-1466] After restarting a migration, the home screen banner no longer keeps counting the cancelled run — it clears and offers the migration again for your remaining balance.
-- [MOB-1496] The balance-splitting transactions a migration prepares now go out in the same app session that prepares them, instead of waiting for the next 30-second check to pick them up. Preparing one and sending it are a single step by design, so a run's setup phase no longer stalls a step behind itself. Each one is also reported back to the migration engine as sent, so it is never announced to the network a second time from a later check.
-- [MOB-1496] Scheduled migration transfers are no longer delayed by a fixed waiting period after a sync. The app used to refuse to send for ten minutes (three on testnet) after every completed sync, and the SDK refused to sync for ten minutes after every migration broadcast, so a wallet could sit open doing nothing for long stretches while a transfer was ready to go. Both waits are gone: a fixed delay between a sync and a send is itself a recognisable pattern on the network rather than protection from one, so pacing is no longer done by the clock. Migration steps now run when they are actually due, and anything you ask for that needs a sync — pulling to refresh, starting a send — is never held back. The only remaining pause is the few seconds while a migration transaction is actually being submitted.
-- [Ironwood] Migration transactions are now labeled by what they do: the Activity list and the transaction detail screen show "Splitting Balance…"/"Balance Split"/"Split Failed" for note-preparation transactions and "Migrating…"/"Migrated"/"Migration Failed" for pool transfers, with a dedicated coins-swap icon. Their amount now shows the value being moved instead of the transaction fee, without a minus sign — migrations move funds inside your wallet, they don't spend them.
-- [Ironwood] In-progress migration transactions appear in the Activity list as soon as they are prepared, clearly labeled with their live state, instead of being hidden until mined.
-- [Ironwood] Coinholder Polling is available again and reappears in Settings, now that voting runs on the Ironwood network upgrade. Nothing was deleted while it was away — any rounds you had already taken part in are still there.
-- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast, and the prompt reports the firmware version exactly as your Keystone displays it.
-- [MOB-1535] The "Total Balance Across Pools" breakdown now shows each pool's balance to its full precision (up to 8 decimal places) instead of flooring to 0.001 ZEC, so small amounts are no longer hidden, and the pools now appear in the order Ironwood, Orchard, Sapling, Transparent.
-- [MOB-1466] The "ready to run" step badge in the migration plan's Split Balance row now shows its step number instead of a checkmark, to avoid reading as already completed.
-- [Ironwood] Migration plan previews now show sane value breakdowns: exact funding amounts are preserved, and a split that cannot be funded reports as deferred instead of complete.
-- [Ironwood] The migration reminder is now armed from the engine's own next-work answer as well as the schedule, so the "come back" notification lands at the earliest genuinely serviceable moment — and never inside the privacy buffer for send work.
-
-- [MOB-1466] Migration status text now says what is happening right now: while transfers are being prepared, or while one is being sent, the Migration Progress screen says so and asks you to keep ZODL open; the rest of the time it tells you we will notify you when it is your turn. The note above the Got it button follows the same state, so the screen and the home banner can no longer describe different things.
-- [MOB-1466] The Confirm Transfer Plan screens now explain the arrangement the same way in both cases — how long the run takes, that we notify you at each step, and that opening the app promptly keeps it on track. They no longer say the migration continues "in the background", which iOS does not allow.
-- [MOB-1466] The notifications request now explains why it matters: iOS will not let transfers send in the background, so local notifications are the only way ZODL can tell you when to open it and take the next step.
-- [MOB-1466] While ZODL is checking migration status on open, the migration banner no longer offers a button and the Migration Progress screen cannot be opened — until the check finishes, that screen would only show the previous session's numbers.
-- [MOB-1466] Migration banner states now stay on screen for at least half a second each, so a quick run of changes reads as separate states instead of a flicker you cannot follow. Rapid updates to the same state (for example a rising transfer count) update in place without adding delay.
-
-### Removed
-- [MOB-1466] The "Updating…" label and the "Balances as of ~N min ago" line have been removed from the Migration Progress screen. Both described how fresh ZODL's own reads were rather than anything you can act on, and neither was part of the design.
 
 ### Fixed
 - [MOB-1800] Tapping Confirm when submitting a vote now responds immediately: the button disables and shows a spinner the instant it is tapped, extra taps can no longer interrupt and restart a submission already underway, and the screen no longer briefly re-enables mid-submission while the authorization work hands over. Cancelling the Face ID prompt cleanly returns the Confirm button.
@@ -56,7 +26,6 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [Ironwood] Opening a poll no longer deletes and recreates it when its setup was interrupted. The round is reused where it already exists, so nothing a poll has accumulated can be discarded by opening it.
 - [MOB-1810] The polls list opens without waiting for vote-server health checks; checks now run in the background when entering a poll, and recovering share deliveries steer around servers that keep failing.
 - [MOB-1810] Fixed a crash when the voting service configuration lists the same server URL twice; such configurations are now rejected with a clear error.
-- Coinholder Polling now recovers an ambiguously submitted delegation or vote by checking its exact transaction hash, and reopening a poll no longer discards persisted delegation setup needed to retry safely.
 - [MOB-1798] Coinholder Polling now correctly reads delegation positions from older vote-server responses.
 - [MOB-1801] Coinholder Polling no longer becomes unavailable when the primary voting configuration service is unreachable or blocked (for example on networks that filter crypto-related domains). The app now verifies the same pinned configuration from a second, independent mirror and walks the configuration's own mirror list the same way, and configuration requests give up after 15 seconds instead of two minutes, so a dead route fails over quickly instead of locking you out of voting.
 - [MOB-1801] Coinholder Polling no longer becomes unavailable when the primary voting configuration service is unreachable or blocked (for example on networks that filter crypto-related domains). The app now verifies the same pinned configuration from a second, independent mirror and walks the configuration's own mirror list the same way, and configuration requests give up after 15 seconds instead of two minutes, so a dead route fails over quickly instead of locking you out of voting. The Default source in the voting configuration settings now also shows the mirror it may contact.
@@ -67,10 +36,71 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1755] A transparent deposit that arrives while ZODL is still syncing now produces the shielding offer as soon as the sync completes — previously the offer could be silently lost until the next app launch. When a shielding offer stops being valid just as it is about to appear, the banner now moves on to the next suggestion instead of showing nothing, and a completed shield no longer knocks down an unrelated banner that happened to be on screen.
 - [MOB-1755] The shielding suggestion no longer disappears for the whole session when the syncing or error banner takes its place — it returns once the wallet is back up to date. A banner being retracted at the exact moment another one is being shown can no longer knock down the new banner, the sync-error banner included, and a banner that was just retracted can no longer briefly reappear as an empty shell.
 - [MOB-1755] Switching accounts right when ZODL was mid-check for a shielding offer could leave the banner showing a balance left over from the account you switched away from. The check now always applies to whichever account is currently selected.
+- [MOB-1802] Keystone voting signing QR is now drawn on a white plate like the send-flow QR, so Keystone devices can scan it in dark mode.
+
+## [3.10.2] - 2026-08-27
+
+### Added
+- [Ironwood] Before opening the voting database, ZODL now preserves a copy of it under `voting_recovery`. If an earlier version already discarded a poll's delegation, that copy keeps what is needed to restore it later — even if you upgrade long after the poll was affected. It is taken only once, so the earliest and most complete copy is the one kept; it is included in device backups so it survives a migration, and is removed when the wallet is reset.
+
+### Fixed
+- Coinholder Polling now recovers an ambiguously submitted delegation or vote by checking its exact transaction hash, and reopening a poll no longer discards persisted delegation setup needed to retry safely.
+
+## [3.10.0] - 2026-08-24
+
+### Changed
+- [MOB-1678] Coinholder Polling now loads its trusted configuration through the resilient voting config gateway, so a GitHub outage no longer blocks configuration loading while the mirrored copy is available.
+- [Ironwood] Coinholder Polling is available again and reappears in Settings, now that voting runs on the Ironwood network upgrade. Nothing was deleted while it was away — any rounds you had already taken part in are still there.
+
+## [3.9.5] - 2026-08-18
+
+## [3.9.4] - 2026-08-17
+
+## [3.9.3] - 2026-08-13
+
+### Added
+- [Ironwood] Warn before confirming a send that has to spend Orchard funds: the confirmation screen now shows a sheet recommending migration first, with the option to continue or cancel.
+
+## [3.9.2] - 2026-08-11
+
+### Added
+- The hidden database debug screen (Settings → What's New → long-press the logo) now accepts a special "print_notifs" query that lists the migration reminder notifications currently scheduled on the device — their identifiers, fire times and accounts — instead of running SQL.
+
+### Fixed
 - [MOB-1630] The migration banner no longer offers a migration when the account's Orchard balance is below 0.01 ZEC/TAZ — the smallest amount a migration can move. Such an offer could never be fulfilled: tapping it always ended on a failure screen, and the "Migration Required" banner never went away.
 - [MOB-1581] A sent transaction no longer stays stuck showing "Sending…" after it has confirmed. ZODL no longer misses the confirmation signal when it arrives alongside other synchronizer events, keeps refreshing the transaction list after the app returns from the background (previously a single background/foreground cycle silently stopped the automatic refresh until the app was relaunched), and additionally re-checks pending transactions every 30 seconds as a safety net.
 - [MOB-1670] "Split Balance" rows in the migration plan and Migration Progress timelines now always show the coins-swap icon instead of sometimes borrowing a transfer's step number. A split row could previously appear as "1" — while its transaction was confirming, once its window had passed, or for the second and later rows of a balance that splits in several steps — which read as though it were the first transfer rather than the preparation step that comes before them.
 - [MOB-1670] The connecting line below the "Split Balance" row on the Confirm Transfer Plan screen is no longer drawn in black while the split is still waiting to run. The dark line marks the transfer that is currently up, so on a plan you had not started yet it made the split look already underway; every step now reads as the same neutral gray until something actually sends.
+
+## [3.9.1] - 2026-08-11
+
+### Added
+- [MOB-1466] Advanced Settings now offers "Restart Migration" while a migration is running. It shows how much has already migrated and how much is left, warns that restarting cancels the current plan for good, and asks for a separate confirmation before anything happens. Transfers that already went out are untouched — they stay migrated — and once the plan is cancelled you set up a new one for the remaining balance the same way you did the first time.
+- [MOB-1466] With a privacy migration in progress, keeping the app open now advances the migration automatically — transfers send on schedule without reopening the app.
+
+### Changed
+- [MOB-1466] Starting a migration now holds you on a "Scheduling…" screen while the schedule is confirmed and the first step is prepared, instead of leaving you on the plan under a spinning button for up to half a minute. The summary fills in with your real numbers the moment it is ready.
+- [MOB-1466] The migration split details sheet now scrolls when a split has more than five steps, so long splits stay readable and the sheet's total and "Got it" button stay reachable. Shorter splits are unchanged.
+- [MOB-1466] "Restart Migration" appears in Advanced Settings only while a migration is actually in progress, and no longer lingers once one has finished.
+- [MOB-1466] After restarting a migration, the home screen banner no longer keeps counting the cancelled run — it clears and offers the migration again for your remaining balance.
+- [MOB-1496] The balance-splitting transactions a migration prepares now go out in the same app session that prepares them, instead of waiting for the next 30-second check to pick them up. Preparing one and sending it are a single step by design, so a run's setup phase no longer stalls a step behind itself. Each one is also reported back to the migration engine as sent, so it is never announced to the network a second time from a later check.
+- [MOB-1496] Scheduled migration transfers are no longer delayed by a fixed waiting period after a sync. The app used to refuse to send for ten minutes (three on testnet) after every completed sync, and the SDK refused to sync for ten minutes after every migration broadcast, so a wallet could sit open doing nothing for long stretches while a transfer was ready to go. Both waits are gone: a fixed delay between a sync and a send is itself a recognisable pattern on the network rather than protection from one, so pacing is no longer done by the clock. Migration steps now run when they are actually due, and anything you ask for that needs a sync — pulling to refresh, starting a send — is never held back. The only remaining pause is the few seconds while a migration transaction is actually being submitted.
+- [Ironwood] Migration transactions are now labeled by what they do: the Activity list and the transaction detail screen show "Splitting Balance…"/"Balance Split"/"Split Failed" for note-preparation transactions and "Migrating…"/"Migrated"/"Migration Failed" for pool transfers, with a dedicated coins-swap icon. Their amount now shows the value being moved instead of the transaction fee, without a minus sign — migrations move funds inside your wallet, they don't spend them.
+- [Ironwood] In-progress migration transactions appear in the Activity list as soon as they are prepared, clearly labeled with their live state, instead of being hidden until mined.
+- [MOB-1466] The warning shown before a manual send during a scheduled migration is now more precise — it only appears when that specific send would actually spend Orchard funds the migration needs, instead of whenever any unmigrated Orchard balance remains in the account.
+- [MOB-1466] The "ready to run" step badge in the migration plan's Split Balance row now shows its step number instead of a checkmark, to avoid reading as already completed.
+- [Ironwood] Migration plan previews now show sane value breakdowns: exact funding amounts are preserved, and a split that cannot be funded reports as deferred instead of complete.
+- [Ironwood] The migration reminder is now armed from the engine's own next-work answer as well as the schedule, so the "come back" notification lands at the earliest genuinely serviceable moment — and never inside the privacy buffer for send work.
+- [MOB-1466] Migration status text now says what is happening right now: while transfers are being prepared, or while one is being sent, the Migration Progress screen says so and asks you to keep ZODL open; the rest of the time it tells you we will notify you when it is your turn. The note above the Got it button follows the same state, so the screen and the home banner can no longer describe different things.
+- [MOB-1466] The Confirm Transfer Plan screens now explain the arrangement the same way in both cases — how long the run takes, that we notify you at each step, and that opening the app promptly keeps it on track. They no longer say the migration continues "in the background", which iOS does not allow.
+- [MOB-1466] The notifications request now explains why it matters: iOS will not let transfers send in the background, so local notifications are the only way ZODL can tell you when to open it and take the next step.
+- [MOB-1466] While ZODL is checking migration status on open, the migration banner no longer offers a button and the Migration Progress screen cannot be opened — until the check finishes, that screen would only show the previous session's numbers.
+- [MOB-1466] Migration banner states now stay on screen for at least half a second each, so a quick run of changes reads as separate states instead of a flicker you cannot follow. Rapid updates to the same state (for example a rising transfer count) update in place without adding delay.
+
+### Removed
+- [MOB-1466] The "Updating…" label and the "Balances as of ~N min ago" line have been removed from the Migration Progress screen. Both described how fresh ZODL's own reads were rather than anything you can act on, and neither was part of the design.
+
+### Fixed
 - [MOB-1496] While a balance-splitting migration transaction is actually being sent, the app now knows it is busy: the keep-open banner shows for the duration of the send, exactly as it does for a migration transfer, and re-entering the migration flow mid-send is held off the same way. Previously the send ran with no visible state at all, so nothing asked you to keep ZODL open and backgrounding it at the wrong moment could stall the split until a later pass.
 - [MOB-1496] When the network permanently rejects one of the balance-splitting transactions a migration prepares (a validation verdict, not a connection problem), the migration engine is now told the real outcome instead of nothing. Previously the app treated every non-acceptance as a retryable network error, so it kept re-submitting the same doomed transaction every pass and every 30-second check until it expired — hours in the split phase with no failure surface. Now the run can re-evaluate and ask for your attention instead.
 - [MOB-1496] A migration transfer being sent can no longer collide with the automatic server switch: like every other send, the transfer now holds the submission guard for the duration of its broadcast, so a server change waits (or skips) instead of tearing down the connection while the transfer is still on the wire.
@@ -109,6 +139,39 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1466] Confirming a migration while the wallet is already fully synced now starts preparing the first transaction right away. Previously the run could sit at "Preparing…" indefinitely — the first proof only ran at a sync-completion moment that had already passed by the time the migration was confirmed, and nothing re-triggered it until the app was closed and reopened.
 - [MOB-1466] Scheduled migration transfers no longer get stuck behind the privacy buffer while the app stays open: when a transfer is ready to send, the wallet pauses syncing while the privacy quiet-period elapses — up to 10 minutes on mainnet — then sends the transfer automatically.
 - [MOB-1466] The Migration Progress screen now refreshes itself while open — transfer ETAs and statuses update every 30 seconds without closing and reopening the screen.
+- [MOB-1466] The migration plan review screen (before you confirm) now describes transfers in forward-looking terms — "Starts right away" / "Starts in ~N mins" / "Starts in ~N hours" — instead of "Ready now", so the screen doesn't read as if transfers are already under way before you've confirmed anything.
+- [MOB-1466] The migration plan review screen's action button now reads "Start migration" instead of "Confirm", making clear that tapping it is what actually starts your migration.
+- [MOB-1466] Leaving the migration plan review screen via the back button, before you've started the plan, now asks you to confirm first — "Your migration hasn't started yet. Leaving now won't schedule any transfers." — so you can't accidentally back out thinking your migration is already underway.
+- [MOB-1466] A successful migration transfer no longer wedges the wallet: the sync gate's refusal to start (part of the migration privacy protection) is now handled as the broadcast session it actually signals, instead of showing a fatal, unrecoverable initialization error.
+- [MOB-1466] The Migration Progress screen and banner now always show the engine's live state — the stale-cache layer that could show an outdated transfer/split status (or a pre-commit empty screen) while proving ran has been removed.
+- [MOB-1466] Opening the migration from the banner no longer flashes or stacks the mode-picker screen beneath the migration progress screen.
+- [MOB-1466] Swiping back off the very first screen shown when re-opening an in-progress migration now closes the migration flow, instead of leaving a blank, stuck screen with no way forward except quitting the app.
+- The Confirm button on a migration transfer plan now keeps its loading indicator up until your transfers are prepared and presigned (the first delivery kicked off), then opens the Migration Scheduled screen — one tap, no dead first tap, and the Home banner reflects the committed run when you return. The Confirm button still can no longer be tapped again after a successful commit.
+- [Ironwood] Accepting a migration plan on a large wallet no longer stalls for tens of minutes — plan commit completes promptly.
+
+## [3.8.1] - 2026-07-31
+
+### Fixed
+- [MOB-1581] The Activity list now shows a sent transaction immediately after sending, regardless of how the send flow is closed, instead of waiting for the next sync cycle.
+- [MOB-1593] Transaction detail no longer shows an extra, empty message bubble on sent transactions, and "Send again" prefills the actual message text again.
+
+### Changed
+- [MOB-1580] A transaction sent to yourself — a manual send to your own address, or a migration transfer between your own pools — now always shows the network fee rather than an amount that could differ between devices or change once the transaction confirmed.
+
+## [3.8.0] - 2026-07-28
+
+### Added
+- [Ironwood] ZODL now recognizes funds held in the Ironwood shielded pool. Balances on the home screen, in the balances breakdown and in the shielding banner include Ironwood alongside Sapling and Orchard, so those funds are visible and counted as soon as the network upgrade activates.
+- [Ironwood] A transfer that moves funds into the Ironwood pool now shows the amount that actually moved, in both the transaction list and the transaction detail screen. Previously such a transfer displayed only its fee.
+- [Ironwood] Once ZODL sees that the Ironwood network upgrade is live on the network, it shows a short one-time screen introducing the change, with a link to a support article. It appears once per device — after you continue past it, it never comes back.
+- [MOB-1535] Tapping your balance on the home screen now opens a "Total Balance Across Pools" breakdown showing how much ZEC sits in each Zcash pool — Orchard, Sapling, Transparent and Ironwood — so you can see exactly where your funds are. When currency conversion is turned on, each pool also shows its value in your selected currency. Pools you hold nothing in are still listed, and with balances hidden every amount stays masked.
+
+### Changed
+- [Ironwood] Coinholder Polling is temporarily unavailable and no longer appears in Settings, while voting is brought up to date with the Ironwood network upgrade. No voting data is deleted — the feature returns in a later release.
+- [MOB-1510] Signing with a Keystone device now requires firmware 3.0.1 or newer — older or version-less firmware is blocked with an update prompt before anything is broadcast, and the prompt reports the firmware version exactly as your Keystone displays it.
+- [MOB-1535] The "Total Balance Across Pools" breakdown now shows each pool's balance to its full precision (up to 8 decimal places) instead of flooring to 0.001 ZEC, so small amounts are no longer hidden, and the pools now appear in the order Ironwood, Orchard, Sapling, Transparent.
+
+### Fixed
 - [Ironwood] The automatic recovery from another wallet's leftover data (see MOB-1512 below) keeps working with the updated Zcash SDK. The SDK now reports that mismatch as an error rather than a status, so ZODL maps it back onto the same recovery and the wallet still heals itself instead of stopping on an initialization error.
 - [MOB-140] On the Receive screen, the Zcash Sapling address (testnet debug builds only) now shows the same shield badge on its icon as the Zcash Shielded Address, instead of an incomplete badge that made the address look unshielded.
 - [#1948] The Syncing Error details now name the server ZODL is connected to and show both consensus branch IDs in hex (e.g. `0x37a5165b`) — the form used in ZIPs and other documentation — rather than unrecognizable decimal numbers, and the same information is included in the report sent to support. When the failure is a network-rules mismatch (ZCBPEO0011), where retrying can never succeed because either ZODL or the server is out of date, the sheet also offers a Switch server shortcut.
@@ -121,20 +184,8 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1512] The "Wallet data replaced" notice now stays on screen after the healed wallet opens, instead of disappearing during the transition to the home screen.
 - [Keystone] Switching between the ZODL and Keystone accounts now always shows the selected account's transaction history — a slow in-flight refresh for the previous account can no longer overwrite it — and connecting a Keystone hardware wallet refreshes the transaction list and balance immediately.
 - [Keystone] The transaction list no longer gets stuck showing its loading placeholder when switching to an account whose transaction list turns out identical to the previous one — in practice, switching between two accounts that both have no transactions, such as right after connecting a Keystone.
-- [MOB-1581] The Activity list now shows a sent transaction immediately after sending, regardless of how the send flow is closed, instead of waiting for the next sync cycle.
-- [MOB-1593] Transaction detail no longer shows an extra, empty message bubble on sent transactions, and "Send again" prefills the actual message text again.
-- [MOB-1466] The migration plan review screen (before you confirm) now describes transfers in forward-looking terms — "Starts right away" / "Starts in ~N mins" / "Starts in ~N hours" — instead of "Ready now", so the screen doesn't read as if transfers are already under way before you've confirmed anything.
-- [MOB-1466] The migration plan review screen's action button now reads "Start migration" instead of "Confirm", making clear that tapping it is what actually starts your migration.
-- [MOB-1466] Leaving the migration plan review screen via the back button, before you've started the plan, now asks you to confirm first — "Your migration hasn't started yet. Leaving now won't schedule any transfers." — so you can't accidentally back out thinking your migration is already underway.
-- [MOB-1466] A successful migration transfer no longer wedges the wallet: the sync gate's refusal to start (part of the migration privacy protection) is now handled as the broadcast session it actually signals, instead of showing a fatal, unrecoverable initialization error.
-- [MOB-1466] The Migration Progress screen and banner now always show the engine's live state — the stale-cache layer that could show an outdated transfer/split status (or a pre-commit empty screen) while proving ran has been removed.
-- [MOB-1466] Opening the migration from the banner no longer flashes or stacks the mode-picker screen beneath the migration progress screen.
-- [MOB-1466] Swiping back off the very first screen shown when re-opening an in-progress migration now closes the migration flow, instead of leaving a blank, stuck screen with no way forward except quitting the app.
-- The Confirm button on a migration transfer plan now keeps its loading indicator up until your transfers are prepared and presigned (the first delivery kicked off), then opens the Migration Scheduled screen — one tap, no dead first tap, and the Home banner reflects the committed run when you return. The Confirm button still can no longer be tapped again after a successful commit.
-- [Ironwood] Accepting a migration plan on a large wallet no longer stalls for tens of minutes — plan commit completes promptly.
-- [MOB-1802] Keystone voting signing QR is now drawn on a white plate like the send-flow QR, so Keystone devices can scan it in dark mode.
 
-## 3.7.3 build 1 (20026-07-12)
+## 3.7.3 build 1 (2026-07-12)
 
 ### Changed
 - [MOB-1472] The assets you can swap are now a curated set of major coins and stablecoins across the supported chains (plus swapping to ZEC), instead of the full list from the swap provider, and the address-book chain picker is limited to those chains. Existing swaps in your history (including assets no longer offered) still display normally, and existing contacts on other chains are preserved.
@@ -243,14 +294,14 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ### Changed
 - Swap to ZEC's swap type updated to FLEX_INPUT, reducing number of occurences of INCOMPLETE_DEPOSIT states.
-- Tap to enlarge a QR code implemented for: Receive, Request ZEC, Swap to ZEC, Sign with Keystone. 
- 
+- Tap to enlarge a QR code implemented for: Receive, Request ZEC, Swap to ZEC, Sign with Keystone.
+
 ### Fixed
 - Transaction detail row corners.
 - Address font at several places.
 - Splash screen layout in different states.
 - Unresponsivness of the View transaction button.
-- Missing pending transaction in the list. 
+- Missing pending transaction in the list.
 - Missing Done button in a numberic keypad.
 
 ### Removed
@@ -273,7 +324,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ### Fixed
 - Missing back buttons at some flows starting from the Home screen.
 - Load of activities related to the current account.
-- Load of metadata after wallet restore. 
+- Load of metadata after wallet restore.
 
 ## 3.0.0 build 2 (2026-02-26)
 
@@ -380,7 +431,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ### Fixed
 - Zero confirmation transaction.
-- Transaction history cleared after account switches. 
+- Transaction history cleared after account switches.
 
 ## 2.4 build 2 (2025-10-01)
 
@@ -418,8 +469,8 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 * Copy on the Receive screen.
 * The animation on the Sending screen.
 
-### Fixed 
-* The issue with fetching USD conversion rate and made it more reliable. 
+### Fixed
+* The issue with fetching USD conversion rate and made it more reliable.
 
 ## 2.0.3 build 1 (2025-05-19)
 
@@ -429,17 +480,17 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ## 2.0.2 build 1 (2025-05-08)
 
 ### Changed
-- When entering amount in USD in the Send or Request ZEC flow, we floor the Zatoshi amount automatically to the nearest 5000 Zatoshi to prevent creating unspendable dust notes in your wallet. 
+- When entering amount in USD in the Send or Request ZEC flow, we floor the Zatoshi amount automatically to the nearest 5000 Zatoshi to prevent creating unspendable dust notes in your wallet.
 - The privacy policy updated to be displayed in an in-app browser for better user experience.
 - Primary & secondary button position to follow UX best practices.
-- Receive screen design to better align with the app navigation change. 
+- Receive screen design to better align with the app navigation change.
 - Send and Receive screen icons across the app.
 - Copy in a few places.
 
 ### Fixed
 - Home buttons sizing across devices.
 - Padding on the Address Book screen.
-- Issue with word suggestions during Restore flow. 
+- Issue with word suggestions during Restore flow.
 - Issue with the Spendable bottom sheet getting auto-closed in certain edge cases.
 
 ## 2.0.1 build 1 (2025-04-30)
@@ -461,7 +512,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ## 1.5.3 build 1 (2025-04-14)
 
 ### Fixed
-- We fixed an issue with transaction flow getting stuck on the sending screen in case of failed biometric check. 
+- We fixed an issue with transaction flow getting stuck on the sending screen in case of failed biometric check.
 
 ## 1.5.2 build 1 (2025-04-09)
 
@@ -542,8 +593,8 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ### Added
 - Authentication for the app launch and cold starts after 15 minutes.
-- Send experience reworked to display a sending screen, followed by transaction result screens. 
-- You can now select any text you want from a memo directly in Zashi. 
+- Send experience reworked to display a sending screen, followed by transaction result screens.
+- You can now select any text you want from a memo directly in Zashi.
 
 ### Changed
 - Not enough free space screen has been redesigned.
@@ -592,7 +643,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ### Changed
 - The design of the Settings and Advanced Settings screens.
-- The design of the Server Switch screen has been fully updated to the new style. 
+- The design of the Server Switch screen has been fully updated to the new style.
 
 ## 1.1.5 build 1 (2024-08-22)
 
@@ -608,8 +659,8 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ## 1.1.4 build 3 (2024-08-22)
 
 ### Added
-- We added ZEC/USD currency conversion to Zashi which doesn't compromise your IP address. 
-- You can now view your balances, and type in the transaction amount in both USD and ZEC. 
+- We added ZEC/USD currency conversion to Zashi which doesn't compromise your IP address.
+- You can now view your balances, and type in the transaction amount in both USD and ZEC.
 
 ### Changed
 - We adopted the latest Zcash SDK version 2.2.0, which brings ZIP 320 TEX address support and ZEC/USD currency conversion functionality.
@@ -625,7 +676,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ### Fixed
 - The unread transactions with memos are properly marked with a yellow icon again.
-- Sometimes, the memo was missing in the history, and sometimes it disappeared when the transaction state changed. Both cases have been fixed. 
+- Sometimes, the memo was missing in the history, and sometimes it disappeared when the transaction state changed. Both cases have been fixed.
 
 ## 1.1.2 build 1 (2024-06-14)
 
@@ -659,7 +710,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ### Added
 - Dark mode.
 - Scan QR code from an image stored in the library.
-- Hide the balances with an eye icon on the Account or Balances tabs. 
+- Hide the balances with an eye icon on the Account or Balances tabs.
 
 ### Changed
 - The confirmation button at recovery phrase screen changed its name from "I got it" to "I've saved it".
@@ -747,7 +798,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ### Added
 - Pending values (changes) at the Balances tab.
 - Choose a Server feature: available at settings, pre-defined servers + custom server setup.
-- Account tab UI tweaks for no transactions available. 
+- Account tab UI tweaks for no transactions available.
 
 ### Fixed
 - Restore mode in the UI was missing when Zashi was deleted from an iPhone and reinstalled again.
@@ -789,7 +840,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ### Fixed
 - The export buttons are disabled when exporting of the private data is in progress.
-- The alert message and title for the failed transaction send.  
+- The alert message and title for the failed transaction send.
 
 ## 0.2.0 build 11 (2023-12-13)
 
@@ -802,7 +853,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ### Fixed
 - Fixed a bug that caused spends to appear to be stuck.
-- The confirmation screen has been altered such that the message bubble is rendered only when the message is non-empty. 
+- The confirmation screen has been altered such that the message bubble is rendered only when the message is non-empty.
 
 ## 0.2.0 build 10 (2023-11-30)
 
@@ -812,7 +863,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - When the send button is tapped, the sending title + spinner is shown instead of just the spinner. Also, when the send is done, and redirect to the Account page is done, the sending transaction is already populated in the list. The lag between it was presented has been fixed.
 
 ### Removed
-- [testnet only] The sapling address and the QR of it has been removed from the receive screen. The only meaningful options are the UA and the transparent addresses. 
+- [testnet only] The sapling address and the QR of it has been removed from the receive screen. The only meaningful options are the UA and the transparent addresses.
 
 ### Added
 - Confirmation screen when sending funds. The initial screen is about filling in the address, amount and message (optional). The butoon `review` leads to a brand new screen where the summary of the transaction is presented. The send is confirmed by tapping the send button. Going back to update send data is possible via `go back` button.
@@ -820,8 +871,8 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ## 0.2.0 build 9 (2023-11-14)
 
 ### Changed
-- Send (tab) redesigned: All the input fields are at the same screen. The screen is scrollable so it's usable on every possible iPhone.  
-- Complete redesign of transactions on the Account tab. Expandable transactions show details of it, including options to copy transaction IDs as well as addresses. 
+- Send (tab) redesigned: All the input fields are at the same screen. The screen is scrollable so it's usable on every possible iPhone.
+- Complete redesign of transactions on the Account tab. Expandable transactions show details of it, including options to copy transaction IDs as well as addresses.
 
 ### Added
 - The concept of read/unread transactions with the message (memo) implemented. The color of the icon of received transaction that holds message and hasn't been read yet is yellow. Once the transaction is expanded, the icon's color flips to the black and the state is persisted.
@@ -829,17 +880,17 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ## 0.2.0 build 6 (2023-11-01)
 
 ### Added
-- Option to export private data: brand new screen accessible via Settings, where once consent acknowledged, a user can export a database of data. Important note: the data are sensitive because it holds some information about user's transactions and history but spending keys are not exported so lost of funds is not possible. 
+- Option to export private data: brand new screen accessible via Settings, where once consent acknowledged, a user can export a database of data. Important note: the data are sensitive because it holds some information about user's transactions and history but spending keys are not exported so lost of funds is not possible.
 
 ## 0.2.0 build 5 (2023-10-26)
 
 ### Changed
-- Settings screen has been redesigned and options on the screen changed. 
+- Settings screen has been redesigned and options on the screen changed.
 - Truncation of the balances changed from 8 floating points to the 3 only.
 - Restore from the seed flow and UI updated.
 
 ### Added
-- Option to copy the seed to the pasteboard when a new wallet is created and the seed presented.  
+- Option to copy the seed to the pasteboard when a new wallet is created and the seed presented.
 
 ## 0.2.0 build 4 (2023-10-13)
 
@@ -851,7 +902,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - Recovery screen UI updated (the screen with the seed presented).
 
 ### Added
-- The security warning screen with that is presented when the new wallet is created now holds a link in the text that takes a user to the privacy policy.   
+- The security warning screen with that is presented when the new wallet is created now holds a link in the text that takes a user to the privacy policy.
 
 ## 0.2.0 build 3 (2023-10-05)
 
@@ -867,15 +918,15 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - The send button is disabled until the spendable balance is not a zero.
 
 ### Added
-- The wallet now handles lifecycle events: when the app goes to the background and back to the foreground. That fixed lightwalletd errors.  
+- The wallet now handles lifecycle events: when the app goes to the background and back to the foreground. That fixed lightwalletd errors.
 
-# Previous Changelog records before we rethink the idea of the changelog and before Zashi design 
+# Previous Changelog records before we rethink the idea of the changelog and before Zashi design
 
 ## 0.0.1 build 52
 - [#709] Better error handling in tests (#713)
 
 ## 0.0.1 build 51
-- [#711] Transaction History not shown (#715) 
+- [#711] Transaction History not shown (#715)
 
 ## 0.0.1 build 50
 - [#707] Adopt latest SDK (#708)
@@ -923,7 +974,7 @@ Bugs fixed:
 # 0.0.1 build 45
 - [#635] Fix HomeTests
 - [#633] build and release from tag 0.0.1-45
-- [#611] Disable Send ZEC button when sync in progress 
+- [#611] Disable Send ZEC button when sync in progress
 - [#617] Use L10n for all the texts in the app (#627)
 - [#594] Don't Allow user to proceed to send funds if they are not available for spend (#629)
 - [#595] Visbility of fiat conversion on homeage depends on feature flag (#625)
@@ -932,7 +983,7 @@ Bugs fixed:
 - [#618] Use SwiftGen to generate L10n structure (#619)
 - [#609] Split birthday from the import seed phrase (#622)
 # 0.0.1 build 44
-This is the baseline build for iOS Re-Scoping epic. 
+This is the baseline build for iOS Re-Scoping epic.
 - [#819] build and release from tag 0.0.1-44
 - [#566] Change colors app-wide (#603)
 - [#613] Adopt ZcashLightClientKit version 0.19.0-beta (#616)
@@ -966,7 +1017,7 @@ This is the baseline build for iOS Re-Scoping epic.
 [#537] Flaky navigation issue (#567)
 [#545] Fix CI issues with PR builds (#548)
 [#544] Fix swiftlint warnings (#544)
-# 0.0.1 build 40 
+# 0.0.1 build 40
 - [#541] Adopt Latest main commit of SDK (#542)
 # 0.0.1 build 39
 - [#238] Add crash reporter to secant (#531)
@@ -1100,7 +1151,7 @@ issue for more details.
 - [#266]: Placeholder home screen/refactor previous home to debug screen
 - [#256]: [Recovery Phrase Display] Dark mode word chips' color does not match the designs
 - [#268]: [Critical] App get stuck after start #268
-- [#260]: Wrapped Derivation Tool 
+- [#260]: Wrapped Derivation Tool
 - [#254]: Testable and more readable structure for the AppReducer
 - [#231]: Wallet Storage unit tests vs. integration tests
 - [#253]: [Functional] Import wallet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 All notable changes to this application will be documented in this file.
 
-Please be aware that this changelog primarily focuses on user-related modifications, emphasizing changes that can 
-directly impact users rather than highlighting other crucial architectural updates. 
+This changelog is for the people who use ZODL: it records user-visible changes
+— what is different, where you will meet it, and what to do about it. Developer
+tooling, CI, tests, and internal refactors are deliberately not listed.
 
 ## [Unreleased]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,16 +93,19 @@ The app ships a complete design system — reusable SwiftUI components (`secant/
 
 ## CHANGELOG discipline
 
-`CHANGELOG.md` exists for the people who use ZODL, and nothing else. It is also
-where the App Store "What's New" copy comes from, so treat every entry as text a
-user will read.
+`CHANGELOG.md` exists for the people who use ZODL, and nothing else. Treat
+every entry as text a user will read. (The App Store "What's New" copy is a
+separate artifact — `secant/Resources/WhatsNew/whatsNew*.json`, maintained with
+`/update-whatsnew` — not this file.)
 
 - Update it for any **user-visible** change: a feature, a fix, a change in
   behaviour, or something removed. The entry **must** be part of the same commit
   that makes the change, not a follow-up. Treat it as part of "done", and add it
   without waiting to be asked.
 - Add the entry under `## [Unreleased]`, in the matching `### Added` /
-  `### Changed` / `### Fixed` / `### Removed` subsection.
+  `### Changed` / `### Fixed` / `### Removed` subsection — creating the
+  subsection if it isn't there: promotion moves the subsections wholesale, so
+  each cycle starts from a completely empty `## [Unreleased]`.
 - Prefix every line with its issue identifier in brackets, e.g.
   `- [MOB-1321] Short, user-facing description of the change.`
 - Entries carry **only** what a user needs: what is different for them, where
@@ -121,6 +124,9 @@ user will read.
   `## X.Y.Z build N (DATE)` ones, whose tag exists. Those are the historical
   record of what that release shipped, and must not be altered even to clarify
   or correct. New information goes under `## [Unreleased]`.
+- A fix that lands on `candidate/X.Y.Z` after the CHANGELOG was promoted but
+  before the release ships belongs under `## [X.Y.Z]` — that heading is not
+  published history until its tag exists.
 - Do **not** add a separate "Breaking changes" section. `### Changed` already is
   it: a user meets everything under that heading as something that used to work
   differently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,13 +91,53 @@ The app ships a complete design system — reusable SwiftUI components (`secant/
 
 > `Asset.*` symbols are SwiftGen-generated into `Sources/Generated/` — do not edit those files; add the asset/color to the `.xcassets` catalogue and let the build regenerate them.
 
-## Changelog
+## CHANGELOG discipline
 
-Every implemented task — any feature, fix, or other user-facing change — MUST be recorded in `CHANGELOG.md` as part of the same change. Treat the changelog entry as part of "done": do not consider an implementation complete until its entry exists, and add it automatically without waiting to be asked.
+`CHANGELOG.md` exists for the people who use ZODL, and nothing else. It is also
+where the App Store "What's New" copy comes from, so treat every entry as text a
+user will read.
 
-- Add the entry under the `## [Unreleased]` section (create that section if it isn't there), in the matching `### Added` / `### Changed` / `### Fixed` / `### Removed` subsection.
-- Prefix every line with the issue identifier in brackets, e.g. `- [MOB-1321] Short, user-facing description of the change.`
-- Write from the user's perspective — what changed for them and why it matters — not the implementation detail. The changelog focuses on user-impacting modifications.
+- Update it for any **user-visible** change: a feature, a fix, a change in
+  behaviour, or something removed. The entry **must** be part of the same commit
+  that makes the change, not a follow-up. Treat it as part of "done", and add it
+  without waiting to be asked.
+- Add the entry under `## [Unreleased]`, in the matching `### Added` /
+  `### Changed` / `### Fixed` / `### Removed` subsection.
+- Prefix every line with its issue identifier in brackets, e.g.
+  `- [MOB-1321] Short, user-facing description of the change.`
+- Entries carry **only** what a user needs: what is different for them, where
+  they will meet it, and what they should do about it. Write it as they
+  encounter it, not as the code does.
+- **Never** describe implementation detail — a type, a dependency, a refactor —
+  or narrate branch and release topology: which line merged into which, which
+  release on another line carries the same change, which version numbers were
+  skipped, why the file's ordering looks the way it does. None of that is
+  actionable for a user.
+- Record **only completed changes since the last release**, never the
+  interstitial states of something changed several times since then. If a screen
+  was added and then reworked before release, the entry describes what shipped.
+- **Never modify an entry under an already-published version heading** — a
+  `## [X.Y.Z] - DATE` section, or one of the legacy
+  `## X.Y.Z build N (DATE)` ones, whose tag exists. Those are the historical
+  record of what that release shipped, and must not be altered even to clarify
+  or correct. New information goes under `## [Unreleased]`.
+- Do **not** add a separate "Breaking changes" section. `### Changed` already is
+  it: a user meets everything under that heading as something that used to work
+  differently.
+- Privacy, security, and cost properties are user-facing even when they are
+  documented only in a code comment. A change that reveals data on-chain, costs
+  a fee, or can fail at runtime belongs here.
+
+**Not user-visible, so no entry:** developer tooling and scripts, CI workflows,
+tests, build configuration, and refactors with no observable effect. An entry
+for one of these is noise in a file a user reads.
+
+`Scripts/prepare-release.sh start` promotes `## [Unreleased]` to
+`## [X.Y.Z] - YYYY-MM-DD` when the release is cut, and refuses if the section is
+empty. `## [Unreleased]` itself always stays at the top, empty until the next
+change lands. When preparing a release, audit by diffing the release range
+rather than trusting the file to be complete — behaviour-only changes with no
+visible UI change are the ones most often missed.
 
 ## Key Files
 

--- a/Scripts/lib/release-lib.sh
+++ b/Scripts/lib/release-lib.sh
@@ -11,6 +11,7 @@
 # Written for bash 3.2, which is what macOS ships.
 
 # Paths, relative to the repository root.
+# shellcheck disable=SC2034  # PBXPROJ is consumed by the sourcing scripts.
 PBXPROJ="secant.xcodeproj/project.pbxproj"
 # The version bump is delegated rather than reimplemented. This script selects
 # non-test targets from the project's object graph instead of by name, edits
@@ -60,7 +61,12 @@ die_unless_dry_run() {
 # every assertion in its own test suite.
 run_cmd() {
     if [ "$DRY_RUN" = "true" ]; then
-        echo "  would run: $*"
+        # %q per argument, so the description is the command: `git commit -m
+        # Bump version ...` unquoted names a different command than the one a
+        # real run executes.
+        printf '  would run:'
+        printf ' %q' "$@"
+        printf '\n'
     else
         "$@"
     fi
@@ -146,7 +152,10 @@ promote_changelog() {
         rm -f "$tmp"
         return 1
     fi
-    mv "$tmp" "$file"
+    # Overwrite in place rather than mv: mktemp files are 0600, and the
+    # CHANGELOG keeps whatever mode it already has.
+    cat "$tmp" > "$file"
+    rm -f "$tmp"
 }
 
 # True when the file already carries a heading for this version, in either the
@@ -162,13 +171,6 @@ changelog_has_version() {
 }
 
 # ------------------------------------------------------------------ project
-
-# The marketing version the project currently declares. Every non-test target
-# carries the same value, so the first is representative.
-project_marketing_version() {
-    sed -n -E 's/^[[:space:]]*MARKETING_VERSION = ([^;]+);.*/\1/p' "${1:-$PBXPROJ}" \
-        | head -1
-}
 
 # Set MARKETING_VERSION and CURRENT_PROJECT_VERSION for every non-test target.
 set_project_version() {

--- a/Scripts/lib/release-lib.sh
+++ b/Scripts/lib/release-lib.sh
@@ -1,0 +1,225 @@
+# shellcheck shell=bash
+#
+# Shared helpers for the release scripts. Source this; do not execute it.
+#
+#   . "$(dirname "$0")/lib/release-lib.sh"
+#
+# Everything here is either a pure text transform or a preflight predicate, so
+# that Scripts/test/release_lib.bats can exercise it without a network, a git
+# remote, or a GitHub token.
+#
+# Written for bash 3.2, which is what macOS ships.
+
+# Paths, relative to the repository root.
+PBXPROJ="secant.xcodeproj/project.pbxproj"
+# The version bump is delegated rather than reimplemented. This script selects
+# non-test targets from the project's object graph instead of by name, edits
+# atomically, and lints the result before replacing the file -- none of which a
+# sed over the pbxproj would preserve.
+SET_VERSION_TOOL=".claude/skills/update-app-version/scripts/set_version.py"
+
+# Set by each subcommand's argument parsing.
+DRY_RUN="${DRY_RUN:-false}"
+
+# ------------------------------------------------------------------ output
+
+step() { echo; echo "==> $*"; }
+
+die() {
+    echo "error: $1" >&2
+    shift
+    while [ $# -gt 0 ]; do echo "       $1" >&2; shift; done
+    exit 1
+}
+
+warn() {
+    echo "warning: $1" >&2
+    shift
+    while [ $# -gt 0 ]; do echo "         $1" >&2; shift; done
+}
+
+# A precondition that only a real run has to satisfy: fatal normally, advisory
+# under --dry-run. Reserved for checks nothing in the dry run itself depends on,
+# so that a rehearsal still reports the problem rather than refusing to start.
+# A check the dry run does depend on must stay fatal: silencing it there only
+# relocates the failure to a message that blames the wrong thing.
+die_unless_dry_run() {
+    if [ "$DRY_RUN" = "true" ]; then
+        warn "$@"
+    else
+        die "$@"
+    fi
+}
+
+# Run a command, or describe it under --dry-run. Only state-changing commands
+# go through this: preflight reads run unconditionally, so a dry run still
+# reports what it found rather than what it assumed.
+#
+# Named run_cmd rather than the obvious `run` because bats defines its own
+# `run`, and a library that shadows it silently swallows the exit status of
+# every assertion in its own test suite.
+run_cmd() {
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "  would run: $*"
+    else
+        "$@"
+    fi
+}
+
+# ----------------------------------------------------------------- versions
+
+# Semver ordering as a filter. GNU `sort -V` ranks 3.11.0-rc.1 *above* 3.11.0,
+# which is backwards: a pre-release precedes its release. Mapping '-' to '~'
+# fixes it, because sort -V treats '~' as lower than the empty string.
+version_sort() { sed 's/-/~/' | sort -V | sed 's/~/-/'; }
+
+# True when $1 <= $2 under that ordering.
+version_le() {
+    [ "$(printf '%s\n%s\n' "$1" "$2" | version_sort | head -1)" = "$1" ]
+}
+
+# A release tag is exactly X.Y.Z, which is also what linear-release.yml triggers
+# on. Matching that shape rather than a leading digit is what keeps beta4-rc2,
+# release-baseline-2026-08-08 and test-0.0.1-42 out of the running when the
+# previous release is detected.
+RELEASE_TAG_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+# The release tags reachable from a revision, oldest first. Only reachable tags
+# are candidates: a tag on a line this revision does not descend from is not a
+# release it can succeed.
+release_tags_merged_into() {
+    git tag --list --merged "$1" | grep -E "$RELEASE_TAG_RE" | version_sort
+}
+
+# owner/repo from any form of GitHub remote URL: scp-style ssh, ssh://, or
+# https, with or without a .git suffix.
+repo_slug_from_url() {
+    printf '%s\n' "$1" | sed -E \
+        -e 's|\.git$||' \
+        -e 's|^[a-z+]+://||' \
+        -e 's|^[^/@]+@||' \
+        -e 's|^[^/:]+[:/]||'
+}
+
+# ---------------------------------------------------------------- CHANGELOG
+
+# True when the Unreleased section carries at least one entry. The section is
+# subdivided into `### Added` / `### Changed` / ... headings, so a bullet is
+# what counts as an entry -- an empty `### Fixed` left behind by a previous
+# release is not one. Entries are written as part of the commit that makes each
+# change, so an empty section means they were forgotten, which is far more
+# likely than a genuinely invisible release.
+changelog_unreleased_nonempty() {
+    awk '
+        /^## \[Unreleased\]/ { f = 1; next }
+        f && /^## /          { exit }
+        f && /^[-*] /        { found = 1 }
+        END { exit !found }
+    ' "$1"
+}
+
+# Insert a dated release heading below `## [Unreleased]`, leaving the entries
+# where they are. `## [Unreleased]` itself stays, and becomes empty. Never
+# generates text.
+promote_changelog() {
+    local file="$1" version="$2" date="$3" tmp
+    tmp="$(mktemp)"
+    if ! awk -v ver="$version" -v date="$date" '
+        !changed && /^## \[Unreleased\]/ {
+            print
+            print ""
+            print "## [" ver "] - " date
+            changed = 1
+            next
+        }
+        { print }
+        END { if (!changed) exit 1 }
+    ' "$file" > "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+    mv "$tmp" "$file"
+}
+
+# True when the file already carries a heading for this version, in either the
+# current `## [X.Y.Z] - DATE` form or the legacy `## X.Y.Z build N (DATE)` one.
+# Both are published history, so a second heading for the same version must not
+# be introduced.
+changelog_has_version() {
+    local escaped
+    # The version is interpolated into a regex, so its dots must not match
+    # arbitrary characters: 3.10.2 would otherwise find a heading for 3x10y2.
+    escaped="$(printf '%s\n' "$2" | sed 's/\./\\./g')"
+    grep -qE "^## (\[${escaped}\]|${escaped}( |\$))" "$1"
+}
+
+# ------------------------------------------------------------------ project
+
+# The marketing version the project currently declares. Every non-test target
+# carries the same value, so the first is representative.
+project_marketing_version() {
+    sed -n -E 's/^[[:space:]]*MARKETING_VERSION = ([^;]+);.*/\1/p' "${1:-$PBXPROJ}" \
+        | head -1
+}
+
+# Set MARKETING_VERSION and CURRENT_PROJECT_VERSION for every non-test target.
+set_project_version() {
+    python3 "$SET_VERSION_TOOL" set --marketing "$1" --build "$2"
+}
+
+# ----------------------------------------------------------------- preflight
+
+require_clean_tree() {
+    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+        die "the working tree has uncommitted changes." \
+            "Commit or stash them before releasing."
+    fi
+}
+
+require_remote() {
+    if ! git remote get-url "$1" >/dev/null 2>&1; then
+        die "no such remote '$1'." "Available remotes: $(git remote | tr '\n' ' ')"
+    fi
+}
+
+# $1 names how to report a failure, defaulting to `die`. Callers whose
+# --dry-run path makes no authenticated call pass `die_unless_dry_run`, so a
+# rehearsal reports the problem instead of refusing to run.
+require_gh_auth() {
+    local report="${1:-die}"
+    if ! command -v gh >/dev/null 2>&1; then
+        "$report" "the GitHub CLI (gh) is not installed." \
+            "See https://cli.github.com/"
+        return
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        "$report" "gh is not authenticated." "Run: gh auth login"
+    fi
+}
+
+# The version bump reads the Xcode project's object graph through plutil, which
+# ships with macOS only. Reported the same way as gh authentication: advisory
+# under --dry-run, which changes no versions, so the rest of the plan can still
+# be rehearsed from a machine that could never carry it out.
+require_version_tool() {
+    local report="${1:-die}"
+    if [ ! -f "$SET_VERSION_TOOL" ]; then
+        "$report" "${SET_VERSION_TOOL} is missing." \
+            "It sets MARKETING_VERSION and CURRENT_PROJECT_VERSION for every non-test target."
+        return
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        "$report" "python3 is not installed; ${SET_VERSION_TOOL} cannot run."
+        return
+    fi
+    if ! command -v plutil >/dev/null 2>&1; then
+        "$report" "plutil was not found, so the version bump cannot run here." \
+            "It reads the Xcode project's object graph, and ships with macOS only." \
+            "Cut the release from a Mac."
+    fi
+}
+
+# The repository a remote points at. Everything reaching GitHub goes through
+# this rather than a hardcoded slug, so a rehearsal against a fork stays inside
+# the fork instead of reaching the canonical repository.
+repo_for_remote() { repo_slug_from_url "$(git remote get-url "$1")"; }

--- a/Scripts/lib/release-lib.sh
+++ b/Scripts/lib/release-lib.sh
@@ -86,9 +86,17 @@ RELEASE_TAG_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
 
 # The release tags reachable from a revision, oldest first. Only reachable tags
 # are candidates: a tag on a line this revision does not descend from is not a
-# release it can succeed.
+# release it can succeed. grep exits 1 when nothing matches, which pipefail
+# would escalate into killing the caller under set -e -- an empty list is an
+# answer here, not a failure.
 release_tags_merged_into() {
-    git tag --list --merged "$1" | grep -E "$RELEASE_TAG_RE" | version_sort
+    git tag --list --merged "$1" | { grep -E "$RELEASE_TAG_RE" || true; } | version_sort
+}
+
+# The newest release tag in the repository, reachable or not. Empty when no
+# release has ever been tagged.
+newest_release_tag() {
+    git tag --list | { grep -E "$RELEASE_TAG_RE" || true; } | version_sort | tail -1
 }
 
 # owner/repo from any form of GitHub remote URL: scp-style ssh, ssh://, or

--- a/Scripts/lib/release-lib.sh
+++ b/Scripts/lib/release-lib.sh
@@ -236,6 +236,23 @@ require_version_tool() {
     fi
 }
 
+# The maintenance branch for a version's X.Y line, as the remote actually
+# spells it: the repository has carried both maint/X.Y.x and maint/vX.Y.x, so
+# whichever remote-tracking ref exists wins (canonical v spelling first when
+# both do). When neither exists -- a new line -- the canonical maint/vX.Y.x
+# is the name to create. Reads refs/remotes, so fetch the remote first.
+maint_line_for_version() {
+    local remote="$1" version="$2" xy line
+    xy="${version%.*}"
+    for line in "maint/v${xy}.x" "maint/${xy}.x"; do
+        if git rev-parse -q --verify "refs/remotes/${remote}/${line}" >/dev/null; then
+            printf '%s\n' "$line"
+            return 0
+        fi
+    done
+    printf 'maint/v%s.x\n' "$xy"
+}
+
 # The repository a remote points at. Everything reaching GitHub goes through
 # this rather than a hardcoded slug, so a rehearsal against a fork stays inside
 # the fork instead of reaching the canonical repository.

--- a/Scripts/lib/release-lib.sh
+++ b/Scripts/lib/release-lib.sh
@@ -19,8 +19,10 @@ PBXPROJ="secant.xcodeproj/project.pbxproj"
 # sed over the pbxproj would preserve.
 SET_VERSION_TOOL=".claude/skills/update-app-version/scripts/set_version.py"
 
-# Set by each subcommand's argument parsing.
-DRY_RUN="${DRY_RUN:-false}"
+# Set only by each subcommand's --dry-run flag. Deliberately not seeded from
+# the environment: half-honouring an env var is how DRY_RUN=1 once meant a
+# real run. prepare-release.sh refuses to start when the environment sets it.
+DRY_RUN=false
 
 # ------------------------------------------------------------------ output
 

--- a/Scripts/lib/release-lib.sh
+++ b/Scripts/lib/release-lib.sh
@@ -153,8 +153,13 @@ promote_changelog() {
         return 1
     fi
     # Overwrite in place rather than mv: mktemp files are 0600, and the
-    # CHANGELOG keeps whatever mode it already has.
-    cat "$tmp" > "$file"
+    # CHANGELOG keeps whatever mode it already has. The write's status must
+    # decide the function's -- left bare, the rm below would mask a failed
+    # (or truncated) write as a successful promotion.
+    if ! cat "$tmp" > "$file"; then
+        rm -f "$tmp"
+        return 1
+    fi
     rm -f "$tmp"
 }
 

--- a/Scripts/lib/release-lib.sh
+++ b/Scripts/lib/release-lib.sh
@@ -236,21 +236,11 @@ require_version_tool() {
     fi
 }
 
-# The maintenance branch for a version's X.Y line, as the remote actually
-# spells it: the repository has carried both maint/X.Y.x and maint/vX.Y.x, so
-# whichever remote-tracking ref exists wins (canonical v spelling first when
-# both do). When neither exists -- a new line -- the canonical maint/vX.Y.x
-# is the name to create. Reads refs/remotes, so fetch the remote first.
+# The maintenance branch for a version's X.Y line. A line is always named
+# maint/vX.Y.x; when the branch does not exist yet, this is the name to
+# create.
 maint_line_for_version() {
-    local remote="$1" version="$2" xy line
-    xy="${version%.*}"
-    for line in "maint/v${xy}.x" "maint/${xy}.x"; do
-        if git rev-parse -q --verify "refs/remotes/${remote}/${line}" >/dev/null; then
-            printf '%s\n' "$line"
-            return 0
-        fi
-    done
-    printf 'maint/v%s.x\n' "$xy"
+    printf 'maint/v%s.x\n' "${1%.*}"
 }
 
 # The repository a remote points at. Everything reaching GitHub goes through

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -105,6 +105,8 @@ EOF
 cmd_start() {
     local previous="" issue="" build="1" remote version revision rev_sha prev_tag
     local release_branch candidate_branch b today pr_body_file
+    local -a positional
+    positional=()
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -114,17 +116,21 @@ cmd_start() {
             --dry-run)  DRY_RUN=true; shift ;;
             -h|--help)  usage_start; return 0 ;;
             --*)        usage_start >&2; die "unknown option '$1'" ;;
-            *)          break ;;
+            *)          positional+=("$1"); shift ;;
         esac
     done
 
-    if [ $# -lt 2 ]; then
+    if [ "${#positional[@]}" -lt 2 ]; then
         usage_start >&2
         die "start needs a remote and a version."
     fi
-    remote="$1"
-    version="${2#v}"
-    revision="${3:-HEAD}"
+    if [ "${#positional[@]}" -gt 3 ]; then
+        usage_start >&2
+        die "unexpected argument '${positional[3]}'."
+    fi
+    remote="${positional[0]}"
+    version="${positional[1]#v}"
+    revision="${positional[2]:-HEAD}"
 
     if ! printf '%s\n' "$version" | grep -qE "$RELEASE_TAG_RE"; then
         die "version '${version}' is not in X.Y.Z form."

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -206,11 +206,14 @@ cmd_start() {
     for b in "$release_branch" "$candidate_branch"; do
         if git rev-parse -q --verify "refs/heads/${b}" >/dev/null; then
             die "branch ${b} already exists locally." \
-                "This usually means a previous 'start' for ${version} stopped before its" \
-                "single push near the end -- nothing is on ${remote} until then. Delete the" \
-                "local leftovers and re-run:" \
+                "A previous 'start' for ${version} left it behind. Clean up and re-run:" \
                 "" \
-                "  git branch -D ${release_branch} ${candidate_branch}"
+                "  git switch -      # a failed run can leave this checkout on ${candidate_branch}" \
+                "  git branch -D ${release_branch} ${candidate_branch}" \
+                "" \
+                "If that run got as far as its single push, both branches are on ${remote}" \
+                "too -- the re-run's remote check will then say so; either delete them there" \
+                "or finish that attempt by opening the pull request by hand (see start_pr_body)."
         fi
         # Checked separately from the local branches: this checkout no longer
         # having them says nothing about the remote, where a completed (or

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -104,7 +104,7 @@ EOF
 
 cmd_start() {
     local previous="" issue="" build="1" remote version revision rev_sha prev_tag newest_tag
-    local release_branch candidate_branch b today pr_body_file
+    local release_branch candidate_branch b today pr_body_file changelog_at_rev
     local -a positional
     positional=()
 
@@ -222,15 +222,27 @@ cmd_start() {
     done
 
     step "Checking the CHANGELOG"
-    if changelog_has_version CHANGELOG.md "$version"; then
-        die "CHANGELOG.md already carries a heading for ${version}." \
+    # Both guards read CHANGELOG.md as it stands at the revision being
+    # released -- the content the promotion will operate on -- never the
+    # working tree, which is an unrelated checkout when <revision> is explicit
+    # (and under --dry-run is never switched at all).
+    changelog_at_rev="$(mktemp)"
+    if ! git show "${rev_sha}:CHANGELOG.md" > "$changelog_at_rev" 2>/dev/null; then
+        rm -f "$changelog_at_rev"
+        die "CHANGELOG.md does not exist at ${revision}."
+    fi
+    if changelog_has_version "$changelog_at_rev" "$version"; then
+        rm -f "$changelog_at_rev"
+        die "CHANGELOG.md at ${revision} already carries a heading for ${version}." \
             "Published headings are the historical record of what shipped;" \
             "a second one for the same version must not be added."
     fi
-    if ! changelog_unreleased_nonempty CHANGELOG.md; then
-        die "the Unreleased section of CHANGELOG.md has no entries." \
+    if ! changelog_unreleased_nonempty "$changelog_at_rev"; then
+        rm -f "$changelog_at_rev"
+        die "the Unreleased section of CHANGELOG.md at ${revision} has no entries." \
             "Every user-visible change needs one before release."
     fi
+    rm -f "$changelog_at_rev"
     echo "  the Unreleased section has entries to promote"
 
     echo

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+#
+# prepare-release.sh: cut a release for review.
+#
+#   start  Cut release/X.Y.Z from the previous release tag and candidate/X.Y.Z
+#          from the revision being released, promote the CHANGELOG, record the
+#          new version, and open a pull request from candidate into release.
+#          That PR's diff is exactly what users receive relative to the previous
+#          release, with none of the intervening history.
+#
+# Building and uploading is a separate concern, handled by Scripts/release.sh
+# against candidate/X.Y.Z. Tagging and the back-merge stay manual for now.
+#
+# Run `./Scripts/prepare-release.sh <subcommand> --help` for the options of
+# each phase.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=Scripts/lib/release-lib.sh
+. "Scripts/lib/release-lib.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: ./Scripts/prepare-release.sh <subcommand> [options]
+
+Subcommands:
+  start  Cut the release branches, record the version, and open the pull request.
+
+Run `./Scripts/prepare-release.sh start --help` for details.
+EOF
+}
+
+usage_start() {
+    cat <<'EOF'
+Usage: ./Scripts/prepare-release.sh start [options] <remote> <version> [<revision>]
+
+Creates release/X.Y.Z from the previous release tag and pushes it; creates
+candidate/X.Y.Z from the revision being released; promotes the CHANGELOG's
+Unreleased section; records the version in the Xcode project; and opens a pull
+request from the candidate branch into the release branch.
+
+Basing the release branch on the previous release tag is what makes the pull
+request worth reviewing: its diff is exactly what users receive relative to the
+last release, rather than the intervening development history.
+
+Arguments:
+  <remote>    git remote for the repository being released, e.g. upstream
+  <version>   version being released, e.g. 3.11.0
+  <revision>  commit or branch holding the changes to release
+              (default: current HEAD)
+
+Options:
+  --issue <N>       release tracking issue; the PR body gets a closing keyword
+                    for it.
+  --build <N>       build number to record alongside the version (default: 1).
+                    Build numbers are a per-variant App Store Connect sequence,
+                    and Scripts/release.sh passes its own --build at archive
+                    time, so this is only the project's recorded starting point.
+  --previous <tag>  base the release branch on this tag rather than the detected
+                    one. Use when the newest tag reachable from <revision> is not
+                    the release you are following.
+  --dry-run         print what would happen and change nothing.
+EOF
+}
+
+# --------------------------------------------------------------------- start
+
+# The body of the pull request. It has to carry enough context that a reviewer
+# arriving cold knows what they are looking at and why the base branch looks
+# the way it does.
+start_pr_body() {
+    local version="$1" prev_tag="$2" issue="$3"
+    if [ -n "$issue" ]; then
+        printf 'Closes #%s\n\n' "$issue"
+    fi
+    cat <<EOF
+Release \`${version}\`, following \`${prev_tag}\`.
+
+The base of this pull request is \`release/${version}\`, which starts out
+identical to \`${prev_tag}\`. Its diff is therefore exactly what users receive
+relative to the last release, rather than the intervening development history.
+
+On top of the released content this branch carries:
+
+- the CHANGELOG's Unreleased section, promoted to \`## [${version}]\`;
+- \`MARKETING_VERSION\` and \`CURRENT_PROJECT_VERSION\`, set across every
+  non-test target.
+
+## Do not merge before the build has shipped
+
+TestFlight and App Store builds for this release are made from
+\`candidate/${version}\`, the head of this pull request:
+
+    ./Scripts/release.sh --variant internal-testnet --ref candidate/${version} \\
+        --version ${version} --build <n>
+
+Fixes found in testing land on \`candidate/${version}\` and appear here. Merging
+this pull request is what declares the release final; tag \`release/${version}\`
+afterwards, then merge it back into \`maint/v${version%.*}.x\` and forward to
+\`main\` so the tag stays reachable.
+EOF
+}
+
+cmd_start() {
+    local previous="" issue="" build="1" remote version revision rev_sha prev_tag
+    local release_branch candidate_branch b today pr_body_file
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --issue)    issue="${2:?--issue needs an issue number}"; shift 2 ;;
+            --build)    build="${2:?--build needs a build number}"; shift 2 ;;
+            --previous) previous="${2:?--previous needs a tag}"; shift 2 ;;
+            --dry-run)  DRY_RUN=true; shift ;;
+            -h|--help)  usage_start; return 0 ;;
+            --*)        usage_start >&2; die "unknown option '$1'" ;;
+            *)          break ;;
+        esac
+    done
+
+    if [ $# -lt 2 ]; then
+        usage_start >&2
+        die "start needs a remote and a version."
+    fi
+    remote="$1"
+    version="${2#v}"
+    revision="${3:-HEAD}"
+
+    if ! printf '%s\n' "$version" | grep -qE "$RELEASE_TAG_RE"; then
+        die "version '${version}' is not in X.Y.Z form."
+    fi
+    if ! printf '%s\n' "$build" | grep -qE '^[0-9]+$'; then
+        die "build '${build}' is not an integer."
+    fi
+
+    step "Checking preconditions"
+    require_clean_tree
+    require_remote "$remote"
+    # Advisory under --dry-run: a dry run reaches GitHub nowhere and changes no
+    # versions, so an unauthenticated rehearsal on a machine without plutil can
+    # still show the whole plan.
+    require_gh_auth die_unless_dry_run
+    require_version_tool die_unless_dry_run
+
+    GH_REPO="$(repo_for_remote "$remote")"
+    export GH_REPO
+    echo "  repository: ${GH_REPO}"
+
+    echo "  fetching ${remote} ..."
+    if ! git fetch --tags "$remote" >/dev/null 2>&1; then
+        die "git fetch ${remote} failed." \
+            "Every check below compares against ${remote}; running them on" \
+            "stale refs would report agreement that does not exist."
+    fi
+
+    rev_sha="$(git rev-parse --verify "${revision}^{commit}")"
+    echo "  releasing the content of ${revision} ($(git rev-parse --short "$rev_sha"))"
+
+    if git rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
+        die "${version} is already tagged; pick a new version."
+    fi
+
+    step "Determining the release base"
+    if [ -n "$previous" ]; then
+        prev_tag="$previous"
+        if ! git rev-parse -q --verify "refs/tags/${prev_tag}" >/dev/null; then
+            die "no such tag '${prev_tag}'."
+        fi
+        echo "  using --previous ${prev_tag}"
+    else
+        prev_tag="$(release_tags_merged_into "$rev_sha" | tail -1)"
+        if [ -z "$prev_tag" ]; then
+            die "no release tags are reachable from ${revision}." \
+                "Pass --previous <tag> to say which release this follows."
+        fi
+        echo "  newest release reachable from ${revision}: ${prev_tag}"
+    fi
+
+    if version_le "$version" "$prev_tag"; then
+        die "${version} does not come after ${prev_tag}."
+    fi
+
+    release_branch="release/${version}"
+    candidate_branch="candidate/${version}"
+    for b in "$release_branch" "$candidate_branch"; do
+        if git rev-parse -q --verify "refs/heads/${b}" >/dev/null; then
+            die "branch ${b} already exists locally." \
+                "This usually means a previous 'start' for ${version} got partway through." \
+                "Delete ${release_branch} and ${candidate_branch} locally and re-run, or, if" \
+                "both are already pushed to ${remote} and only the pull request is missing," \
+                "open it by hand (see start_pr_body for the body text)."
+        fi
+        # Checked separately from the local branches: a run that pushed and then
+        # failed leaves the branch on the remote whether or not this checkout
+        # still has it, and re-running would then die at the push instead of here.
+        if git ls-remote --exit-code --heads "$remote" "refs/heads/${b}" >/dev/null 2>&1; then
+            die "branch ${b} already exists on ${remote}." \
+                "A previous 'start' for ${version} pushed it. Delete it there, or finish" \
+                "that attempt by hand rather than starting a second one."
+        fi
+    done
+
+    step "Checking the CHANGELOG"
+    if changelog_has_version CHANGELOG.md "$version"; then
+        die "CHANGELOG.md already carries a heading for ${version}." \
+            "Published headings are the historical record of what shipped;" \
+            "a second one for the same version must not be added."
+    fi
+    if ! changelog_unreleased_nonempty CHANGELOG.md; then
+        die "the Unreleased section of CHANGELOG.md has no entries." \
+            "Every user-visible change needs one before release."
+    fi
+    echo "  the Unreleased section has entries to promote"
+
+    echo
+    echo "  ${release_branch}    <- ${prev_tag}  (PR base, pushed to ${remote})"
+    echo "  ${candidate_branch}  <- ${revision}  (release prep goes here)"
+
+    step "Creating ${release_branch} from ${prev_tag}"
+    run_cmd git branch "$release_branch" "refs/tags/${prev_tag}"
+    run_cmd git push "$remote" "${release_branch}:${release_branch}"
+
+    step "Creating ${candidate_branch} from ${revision}"
+    run_cmd git switch -c "$candidate_branch" "$rev_sha"
+
+    step "Promoting the CHANGELOG"
+    today="$(date +%Y-%m-%d)"
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "  would insert '## [${version}] - ${today}' below '## [Unreleased]'"
+    else
+        if ! promote_changelog CHANGELOG.md "$version" "$today"; then
+            die "CHANGELOG.md has no '## [Unreleased]' heading to promote."
+        fi
+        echo "  ## [${version}] - ${today}"
+    fi
+    run_cmd git add CHANGELOG.md
+    run_cmd git commit -m "Promote CHANGELOG for ${version}"
+
+    step "Recording version ${version} (${build})"
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "  would set MARKETING_VERSION and CURRENT_PROJECT_VERSION for every non-test target"
+    elif ! set_project_version "$version" "$build"; then
+        # Leave the tree as the CHANGELOG commit left it, so a re-run after
+        # fixing the project starts from a clean tree rather than dying at
+        # require_clean_tree.
+        git checkout -- "$PBXPROJ"
+        die "${SET_VERSION_TOOL} failed; ${PBXPROJ} is unchanged." \
+            "Its own message above says which target or key is at fault."
+    fi
+    run_cmd git add "$PBXPROJ"
+    run_cmd git commit -m "Bump version to ${version} (${build})"
+
+    step "Pushing ${candidate_branch}"
+    run_cmd git push -u "$remote" "$candidate_branch"
+
+    step "Opening the pull request"
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "  would open a PR ${candidate_branch} -> ${release_branch} on ${GH_REPO}"
+        [ -n "$issue" ] && echo "  body would close issue #${issue}"
+    elif ! start_pr_body "$version" "$prev_tag" "$issue" |
+        gh pr create --repo "$GH_REPO" \
+            --base "$release_branch" --head "$candidate_branch" \
+            --title "Release ${version}" \
+            --body-file -; then
+        # Opening the pull request is the last step; both branches are already
+        # on the remote by this point. Detect the failure explicitly, rather
+        # than letting set -e abort with only gh's own output, so the operator
+        # knows not to re-push and can open it by hand.
+        pr_body_file="$(mktemp)"
+        start_pr_body "$version" "$prev_tag" "$issue" > "$pr_body_file"
+        die "opening the pull request failed." \
+            "${release_branch} and ${candidate_branch} are already pushed to ${remote} --" \
+            "they do not need re-pushing. Open the pull request by hand:" \
+            "" \
+            "  gh pr create --repo ${GH_REPO} \\" \
+            "      --base ${release_branch} --head ${candidate_branch} \\" \
+            "      --title \"Release ${version}\" \\" \
+            "      --body-file ${pr_body_file}" \
+            "" \
+            "(the PR body is already written out at ${pr_body_file})"
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        cat <<EOF
+
+Dry run: nothing was changed. ${release_branch} and ${candidate_branch} were
+not created, nothing was pushed to ${remote}, and no pull request was opened.
+The working tree is untouched -- ${candidate_branch} is not checked out.
+
+A real run would leave a pull request open whose diff is exactly what users get
+over ${prev_tag}.
+EOF
+    else
+        cat <<EOF
+
+Done. ${release_branch} and ${candidate_branch} are on ${remote}, the pull
+request is open, and ${candidate_branch} is checked out here.
+
+Review the PR diff: it is exactly what users get over ${prev_tag}. Build from
+${candidate_branch}, not from ${release_branch}, which is still ${prev_tag}:
+
+  ./Scripts/release.sh --variant internal-testnet --ref ${candidate_branch} \\
+      --version ${version} --build ${build}
+
+Merge the pull request once the release is final, then tag ${release_branch} and
+merge it back into maint/v${version%.*}.x and forward to main, so the tag stays
+reachable from a live branch.
+EOF
+    fi
+}
+
+# ------------------------------------------------------------------ dispatch
+
+main() {
+    if [ $# -lt 1 ]; then
+        usage >&2
+        exit 1
+    fi
+    case "$1" in
+        start)     shift; cmd_start "$@" ;;
+        -h|--help) usage ;;
+        *)         usage >&2; die "unknown subcommand '$1'" ;;
+    esac
+}
+
+main "$@"

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -112,7 +112,10 @@ Fixes found in testing land on \`candidate/${version}\` and appear here. This
 pull request stays a **draft** while builds are in progress; marking it ready
 for review is part of declaring the release final, and merging it is what makes
 it final. Tag \`release/${version}\` afterwards, then merge it back into
-\`${maint_line}\` and forward to \`main\` so the tag stays reachable.
+\`${maint_line}\` and forward to \`main\` so the tag stays reachable. Make each
+merge with \`--no-commit\` and check that \`## [${version}]\` in the CHANGELOG
+still matches the tag before committing — entries added on the target branch
+during the release cycle merge into the published section without a conflict.
 EOF
 }
 
@@ -394,7 +397,9 @@ ${candidate_branch}, not from ${release_branch}, which is still ${prev_tag}:
 
 Mark the pull request ready for review and merge it once the release is final,
 then tag ${release_branch} and merge it back into ${maint_line} and
-forward to main, so the tag stays reachable from a live branch.
+forward to main, so the tag stays reachable from a live branch. Merge with
+--no-commit and check that ## [${version}] in the CHANGELOG still matches the
+tag before committing (docs/release-automation.md, step 6, says why).
 EOF
     fi
 }

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -278,7 +278,12 @@ cmd_start() {
         echo "  would insert '## [${version}] - ${today}' below '## [Unreleased]'"
     else
         if ! promote_changelog CHANGELOG.md "$version" "$today"; then
-            die "CHANGELOG.md has no '## [Unreleased]' heading to promote." \
+            # A failed write can truncate the file, so restore the revision's
+            # own CHANGELOG before reporting -- the retry instructions below
+            # promise a clean starting point.
+            git checkout -- CHANGELOG.md
+            die "promoting CHANGELOG.md failed: no '## [Unreleased]' heading, or the file could not be written." \
+                "CHANGELOG.md has been restored." \
                 "Nothing has been pushed. To retry: git switch -, then" \
                 "git branch -D ${release_branch} ${candidate_branch}, fix, and re-run."
         fi

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -224,10 +224,7 @@ cmd_start() {
         die "${version} does not come after ${prev_tag}."
     fi
 
-    # Resolved from the remote's refs (just fetched), so the merge-back
-    # instructions name a branch that exists -- the repo has carried both
-    # maint/X.Y.x and maint/vX.Y.x spellings.
-    maint_line="$(maint_line_for_version "$remote" "$version")"
+    maint_line="$(maint_line_for_version "$version")"
 
     release_branch="release/${version}"
     candidate_branch="candidate/${version}"

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -51,8 +51,7 @@ Arguments:
               (default: current HEAD)
 
 Options:
-  --issue <N>       release tracking issue; the PR body gets a closing keyword
-                    for it.
+  --issue <N>       release tracking issue, referenced from the PR body.
   --build <N>       build number to record alongside the version (default: 1).
                     Build numbers are a per-variant App Store Connect sequence,
                     and Scripts/release.sh passes its own --build at archive
@@ -72,7 +71,7 @@ EOF
 start_pr_body() {
     local version="$1" prev_tag="$2" issue="$3"
     if [ -n "$issue" ]; then
-        printf 'Closes #%s\n\n' "$issue"
+        printf 'Release tracking issue: #%s.\n\n' "$issue"
     fi
     cat <<EOF
 Release \`${version}\`, following \`${prev_tag}\`.
@@ -95,10 +94,11 @@ TestFlight and App Store builds for this release are made from
     ./Scripts/release.sh --variant internal-testnet --ref candidate/${version} \\
         --version ${version} --build <n>
 
-Fixes found in testing land on \`candidate/${version}\` and appear here. Merging
-this pull request is what declares the release final; tag \`release/${version}\`
-afterwards, then merge it back into \`maint/v${version%.*}.x\` and forward to
-\`main\` so the tag stays reachable.
+Fixes found in testing land on \`candidate/${version}\` and appear here. This
+pull request stays a **draft** while builds are in progress; marking it ready
+for review is part of declaring the release final, and merging it is what makes
+it final. Tag \`release/${version}\` afterwards, then merge it back into
+\`maint/v${version%.*}.x\` and forward to \`main\` so the tag stays reachable.
 EOF
 }
 
@@ -206,18 +206,21 @@ cmd_start() {
     for b in "$release_branch" "$candidate_branch"; do
         if git rev-parse -q --verify "refs/heads/${b}" >/dev/null; then
             die "branch ${b} already exists locally." \
-                "This usually means a previous 'start' for ${version} got partway through." \
-                "Delete ${release_branch} and ${candidate_branch} locally and re-run, or, if" \
-                "both are already pushed to ${remote} and only the pull request is missing," \
-                "open it by hand (see start_pr_body for the body text)."
+                "This usually means a previous 'start' for ${version} stopped before its" \
+                "single push near the end -- nothing is on ${remote} until then. Delete the" \
+                "local leftovers and re-run:" \
+                "" \
+                "  git branch -D ${release_branch} ${candidate_branch}"
         fi
-        # Checked separately from the local branches: a run that pushed and then
-        # failed leaves the branch on the remote whether or not this checkout
-        # still has it, and re-running would then die at the push instead of here.
+        # Checked separately from the local branches: this checkout no longer
+        # having them says nothing about the remote, where a completed (or
+        # merely PR-less) run leaves both.
         if git ls-remote --exit-code --heads "$remote" "refs/heads/${b}" >/dev/null 2>&1; then
             die "branch ${b} already exists on ${remote}." \
-                "A previous 'start' for ${version} pushed it. Delete it there, or finish" \
-                "that attempt by hand rather than starting a second one."
+                "A previous 'start' for ${version} pushed it -- the branches are pushed" \
+                "together, so its twin is there too. If only the pull request is missing," \
+                "open it by hand (see start_pr_body for the body text); otherwise delete" \
+                "both branches on ${remote} and re-run."
         fi
     done
 
@@ -246,12 +249,11 @@ cmd_start() {
     echo "  the Unreleased section has entries to promote"
 
     echo
-    echo "  ${release_branch}    <- ${prev_tag}  (PR base, pushed to ${remote})"
+    echo "  ${release_branch}    <- ${prev_tag}  (PR base)"
     echo "  ${candidate_branch}  <- ${revision}  (release prep goes here)"
 
     step "Creating ${release_branch} from ${prev_tag}"
     run_cmd git branch "$release_branch" "refs/tags/${prev_tag}"
-    run_cmd git push "$remote" "${release_branch}:${release_branch}"
 
     step "Creating ${candidate_branch} from ${revision}"
     run_cmd git switch -c "$candidate_branch" "$rev_sha"
@@ -262,7 +264,9 @@ cmd_start() {
         echo "  would insert '## [${version}] - ${today}' below '## [Unreleased]'"
     else
         if ! promote_changelog CHANGELOG.md "$version" "$today"; then
-            die "CHANGELOG.md has no '## [Unreleased]' heading to promote."
+            die "CHANGELOG.md has no '## [Unreleased]' heading to promote." \
+                "Nothing has been pushed. To retry: git switch -, then" \
+                "git branch -D ${release_branch} ${candidate_branch}, fix, and re-run."
         fi
         echo "  ## [${version}] - ${today}"
     fi
@@ -272,42 +276,61 @@ cmd_start() {
     step "Recording version ${version} (${build})"
     if [ "$DRY_RUN" = "true" ]; then
         echo "  would set MARKETING_VERSION and CURRENT_PROJECT_VERSION for every non-test target"
-    elif ! set_project_version "$version" "$build"; then
-        # Leave the tree as the CHANGELOG commit left it, so a re-run after
-        # fixing the project starts from a clean tree rather than dying at
-        # require_clean_tree.
-        git checkout -- "$PBXPROJ"
-        die "${SET_VERSION_TOOL} failed; ${PBXPROJ} is unchanged." \
-            "Its own message above says which target or key is at fault."
+    else
+        if ! set_project_version "$version" "$build"; then
+            # Leave the tree as the CHANGELOG commit left it, so the re-run
+            # described below starts clean.
+            git checkout -- "$PBXPROJ"
+            die "${SET_VERSION_TOOL} failed; ${PBXPROJ} is unchanged." \
+                "Its own message above says which target or key is at fault." \
+                "Nothing has been pushed. To retry: git switch -, then" \
+                "git branch -D ${release_branch} ${candidate_branch}, fix, and re-run."
+        fi
+        if git diff --quiet -- "$PBXPROJ"; then
+            # set_version.py rewrites unconditionally and reports success even
+            # when every value already matched; committing nothing would kill
+            # the script with only git's own "nothing to commit" as a clue.
+            die "the project is already at ${version} (${build}); there is no bump to commit." \
+                "The revision already carries this release's version -- re-releasing a prior" \
+                "candidate's content needs a fresh version or build number." \
+                "Nothing has been pushed. To retry: git switch -, then" \
+                "git branch -D ${release_branch} ${candidate_branch}."
+        fi
     fi
     run_cmd git add "$PBXPROJ"
     run_cmd git commit -m "Bump version to ${version} (${build})"
 
-    step "Pushing ${candidate_branch}"
-    run_cmd git push -u "$remote" "$candidate_branch"
+    step "Pushing ${release_branch} and ${candidate_branch}"
+    # One atomic push, only after every piece of local work has succeeded:
+    # either both branches land on ${remote} or neither does, so no failure
+    # above or below leaves the remote half-prepared.
+    run_cmd git push --atomic -u "$remote" "$release_branch" "$candidate_branch"
 
     step "Opening the pull request"
+    pr_body_file="$(mktemp)"
+    start_pr_body "$version" "$prev_tag" "$issue" > "$pr_body_file"
     if [ "$DRY_RUN" = "true" ]; then
-        echo "  would open a PR ${candidate_branch} -> ${release_branch} on ${GH_REPO}"
-        [ -n "$issue" ] && echo "  body would close issue #${issue}"
-    elif ! start_pr_body "$version" "$prev_tag" "$issue" |
-        gh pr create --repo "$GH_REPO" \
+        echo "  would open a draft PR ${candidate_branch} -> ${release_branch} on ${GH_REPO}"
+        [ -n "$issue" ] && echo "  body would reference issue #${issue}"
+        rm -f "$pr_body_file"
+    elif gh pr create --repo "$GH_REPO" \
             --base "$release_branch" --head "$candidate_branch" \
             --title "Release ${version}" \
-            --body-file -; then
+            --draft \
+            --body-file "$pr_body_file"; then
+        rm -f "$pr_body_file"
+    else
         # Opening the pull request is the last step; both branches are already
         # on the remote by this point. Detect the failure explicitly, rather
         # than letting set -e abort with only gh's own output, so the operator
         # knows not to re-push and can open it by hand.
-        pr_body_file="$(mktemp)"
-        start_pr_body "$version" "$prev_tag" "$issue" > "$pr_body_file"
         die "opening the pull request failed." \
             "${release_branch} and ${candidate_branch} are already pushed to ${remote} --" \
             "they do not need re-pushing. Open the pull request by hand:" \
             "" \
             "  gh pr create --repo ${GH_REPO} \\" \
             "      --base ${release_branch} --head ${candidate_branch} \\" \
-            "      --title \"Release ${version}\" \\" \
+            "      --title \"Release ${version}\" --draft \\" \
             "      --body-file ${pr_body_file}" \
             "" \
             "(the PR body is already written out at ${pr_body_file})"
@@ -320,13 +343,13 @@ Dry run: nothing was changed. ${release_branch} and ${candidate_branch} were
 not created, nothing was pushed to ${remote}, and no pull request was opened.
 The working tree is untouched -- ${candidate_branch} is not checked out.
 
-A real run would leave a pull request open whose diff is exactly what users get
-over ${prev_tag}.
+A real run would leave a draft pull request open whose diff is exactly what
+users get over ${prev_tag}.
 EOF
     else
         cat <<EOF
 
-Done. ${release_branch} and ${candidate_branch} are on ${remote}, the pull
+Done. ${release_branch} and ${candidate_branch} are on ${remote}, a draft pull
 request is open, and ${candidate_branch} is checked out here.
 
 Review the PR diff: it is exactly what users get over ${prev_tag}. Build from
@@ -335,9 +358,9 @@ ${candidate_branch}, not from ${release_branch}, which is still ${prev_tag}:
   ./Scripts/release.sh --variant internal-testnet --ref ${candidate_branch} \\
       --version ${version} --build ${build}
 
-Merge the pull request once the release is final, then tag ${release_branch} and
-merge it back into maint/v${version%.*}.x and forward to main, so the tag stays
-reachable from a live branch.
+Mark the pull request ready for review and merge it once the release is final,
+then tag ${release_branch} and merge it back into maint/v${version%.*}.x and
+forward to main, so the tag stays reachable from a live branch.
 EOF
     fi
 }

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -83,7 +83,7 @@ EOF
 # arriving cold knows what they are looking at and why the base branch looks
 # the way it does.
 start_pr_body() {
-    local version="$1" prev_tag="$2" issue="$3"
+    local version="$1" prev_tag="$2" issue="$3" maint_line="$4"
     if [ -n "$issue" ]; then
         printf 'Release tracking issue: #%s.\n\n' "$issue"
     fi
@@ -112,13 +112,13 @@ Fixes found in testing land on \`candidate/${version}\` and appear here. This
 pull request stays a **draft** while builds are in progress; marking it ready
 for review is part of declaring the release final, and merging it is what makes
 it final. Tag \`release/${version}\` afterwards, then merge it back into
-\`maint/v${version%.*}.x\` and forward to \`main\` so the tag stays reachable.
+\`${maint_line}\` and forward to \`main\` so the tag stays reachable.
 EOF
 }
 
 cmd_start() {
     local previous="" issue="" build="1" remote version revision rev_sha prev_tag newest_tag
-    local release_branch candidate_branch b today pr_body_file changelog_at_rev
+    local release_branch candidate_branch b today pr_body_file changelog_at_rev maint_line
     local -a positional
     positional=()
 
@@ -221,6 +221,11 @@ cmd_start() {
         die "${version} does not come after ${prev_tag}."
     fi
 
+    # Resolved from the remote's refs (just fetched), so the merge-back
+    # instructions name a branch that exists -- the repo has carried both
+    # maint/X.Y.x and maint/vX.Y.x spellings.
+    maint_line="$(maint_line_for_version "$remote" "$version")"
+
     release_branch="release/${version}"
     candidate_branch="candidate/${version}"
     for b in "$release_branch" "$candidate_branch"; do
@@ -274,6 +279,7 @@ cmd_start() {
     echo
     echo "  ${release_branch}    <- ${prev_tag}  (PR base)"
     echo "  ${candidate_branch}  <- ${revision}  (release prep goes here)"
+    echo "  merge back into ${maint_line}, then forward to main, once the release is final"
 
     step "Creating ${release_branch} from ${prev_tag}"
     run_cmd git branch "$release_branch" "refs/tags/${prev_tag}"
@@ -336,7 +342,7 @@ cmd_start() {
 
     step "Opening the pull request"
     pr_body_file="$(mktemp)"
-    start_pr_body "$version" "$prev_tag" "$issue" > "$pr_body_file"
+    start_pr_body "$version" "$prev_tag" "$issue" "$maint_line" > "$pr_body_file"
     if [ "$DRY_RUN" = "true" ]; then
         echo "  would open a draft PR ${candidate_branch} -> ${release_branch} on ${GH_REPO}"
         [ -n "$issue" ] && echo "  body would reference issue #${issue}"
@@ -387,7 +393,7 @@ ${candidate_branch}, not from ${release_branch}, which is still ${prev_tag}:
       --version ${version} --build ${build}
 
 Mark the pull request ready for review and merge it once the release is final,
-then tag ${release_branch} and merge it back into maint/v${version%.*}.x and
+then tag ${release_branch} and merge it back into ${maint_line} and
 forward to main, so the tag stays reachable from a live branch.
 EOF
     fi

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -103,7 +103,7 @@ EOF
 }
 
 cmd_start() {
-    local previous="" issue="" build="1" remote version revision rev_sha prev_tag
+    local previous="" issue="" build="1" remote version revision rev_sha prev_tag newest_tag
     local release_branch candidate_branch b today pr_body_file
     local -a positional
     positional=()
@@ -172,12 +172,27 @@ cmd_start() {
         if ! git rev-parse -q --verify "refs/tags/${prev_tag}" >/dev/null; then
             die "no such tag '${prev_tag}'."
         fi
+        # The release branch starts at this tag and the PR diff is everything
+        # between it and the revision -- meaningless, and silently destructive
+        # in the merge, unless the tag is part of the revision's history.
+        if ! git merge-base --is-ancestor "refs/tags/${prev_tag}" "$rev_sha"; then
+            die "--previous ${prev_tag} is not an ancestor of ${revision}." \
+                "The release branch must start from a commit the revision builds on." \
+                "Merge the ${prev_tag} release back into the line you are cutting from first."
+        fi
         echo "  using --previous ${prev_tag}"
     else
         prev_tag="$(release_tags_merged_into "$rev_sha" | tail -1)"
         if [ -z "$prev_tag" ]; then
             die "no release tags are reachable from ${revision}." \
                 "Pass --previous <tag> to say which release this follows."
+        fi
+        newest_tag="$(newest_release_tag)"
+        if [ "$newest_tag" != "$prev_tag" ]; then
+            die "the newest release tag is ${newest_tag}, but it is not reachable from ${revision}." \
+                "Cutting over ${prev_tag} would silently drop what ${newest_tag} shipped." \
+                "Merge release/${newest_tag} back into its line first (the Release Merged" \
+                "Back check reports this), or pass --previous to choose the base deliberately."
         fi
         echo "  newest release reachable from ${revision}: ${prev_tag}"
     fi

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -16,6 +16,15 @@
 
 set -euo pipefail
 
+# DRY_RUN is not an interface: only --dry-run selects a rehearsal. An
+# environment value used to be half-honoured (only the literal "true"
+# rehearsed; DRY_RUN=1 cut a release for real), so any value is refused
+# outright rather than guessed at.
+if [ -n "${DRY_RUN:-}" ]; then
+    echo "error: DRY_RUN in the environment has no effect; use --dry-run." >&2
+    exit 1
+fi
+
 # Resolve everything relative to this script, not the caller's directory: the
 # script edits and pushes the repository it lives in whichever checkout is
 # invoked, and a failed rev-parse would otherwise become `cd ""`, which

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -122,6 +122,7 @@ EOF
 cmd_start() {
     local previous="" issue="" build="1" remote version revision rev_sha prev_tag newest_tag
     local release_branch candidate_branch b today pr_body_file changelog_at_rev maint_line
+    local rc start_branch return_cmd
     local -a positional
     positional=()
 
@@ -233,8 +234,9 @@ cmd_start() {
             die "branch ${b} already exists locally." \
                 "A previous 'start' for ${version} left it behind. Clean up and re-run:" \
                 "" \
-                "  git switch -      # a failed run can leave this checkout on ${candidate_branch}" \
-                "  git branch -D ${release_branch} ${candidate_branch}" \
+                "  git switch main   # or wherever you work; a failed run can leave this checkout on ${candidate_branch}" \
+                "  git branch -D ${release_branch}   # delete whichever of the two exists --" \
+                "  git branch -D ${candidate_branch} # a run that died early created only the first" \
                 "" \
                 "If that run got as far as its single push, both branches are on ${remote}" \
                 "too -- the re-run's remote check will then say so; either delete them there" \
@@ -242,14 +244,26 @@ cmd_start() {
         fi
         # Checked separately from the local branches: this checkout no longer
         # having them says nothing about the remote, where a completed (or
-        # merely PR-less) run leaves both.
-        if git ls-remote --exit-code --heads "$remote" "refs/heads/${b}" >/dev/null 2>&1; then
-            die "branch ${b} already exists on ${remote}." \
-                "A previous 'start' for ${version} pushed it -- the branches are pushed" \
-                "together, so its twin is there too. If only the pull request is missing," \
-                "open it by hand (see start_pr_body for the body text); otherwise delete" \
-                "both branches on ${remote} and re-run."
-        fi
+        # merely PR-less) run leaves both. ls-remote tells a branch that is
+        # absent (exit 2) apart from a remote that could not be queried (any
+        # other failure); only the former means the preflight is clean.
+        rc=0
+        git ls-remote --exit-code --heads "$remote" "refs/heads/${b}" >/dev/null 2>&1 || rc=$?
+        case "$rc" in
+            0)
+                die "branch ${b} already exists on ${remote}." \
+                    "A previous 'start' for ${version} pushed it -- the branches are pushed" \
+                    "together, so its twin is there too. If only the pull request is missing," \
+                    "open it by hand (see start_pr_body for the body text); otherwise delete" \
+                    "both branches on ${remote} and re-run."
+                ;;
+            2) ;;
+            *)
+                die "checking ${remote} for ${b} failed (git ls-remote exit ${rc})." \
+                    "The remote could not be queried, so whether the branch exists there" \
+                    "is unknown. Nothing has been created. Fix the connection and re-run."
+                ;;
+        esac
     done
 
     step "Checking the CHANGELOG"
@@ -281,6 +295,15 @@ cmd_start() {
     echo "  ${candidate_branch}  <- ${revision}  (release prep goes here)"
     echo "  merge back into ${maint_line}, then forward to main, once the release is final"
 
+    # The recovery instructions in the dies below must return this checkout
+    # to where the run began. 'git switch -' cannot: it needs a branch name,
+    # which a run started from a detached HEAD does not have.
+    if start_branch="$(git symbolic-ref -q --short HEAD)"; then
+        return_cmd="git switch ${start_branch}"
+    else
+        return_cmd="git switch --detach $(git rev-parse --short HEAD)"
+    fi
+
     step "Creating ${release_branch} from ${prev_tag}"
     run_cmd git branch "$release_branch" "refs/tags/${prev_tag}"
 
@@ -299,7 +322,7 @@ cmd_start() {
             git checkout -- CHANGELOG.md
             die "promoting CHANGELOG.md failed: no '## [Unreleased]' heading, or the file could not be written." \
                 "CHANGELOG.md has been restored." \
-                "Nothing has been pushed. To retry: git switch -, then" \
+                "Nothing has been pushed. To retry: ${return_cmd}, then" \
                 "git branch -D ${release_branch} ${candidate_branch}, fix, and re-run."
         fi
         echo "  ## [${version}] - ${today}"
@@ -317,7 +340,7 @@ cmd_start() {
             git checkout -- "$PBXPROJ"
             die "${SET_VERSION_TOOL} failed; ${PBXPROJ} is unchanged." \
                 "Its own message above says which target or key is at fault." \
-                "Nothing has been pushed. To retry: git switch -, then" \
+                "Nothing has been pushed. To retry: ${return_cmd}, then" \
                 "git branch -D ${release_branch} ${candidate_branch}, fix, and re-run."
         fi
         if git diff --quiet -- "$PBXPROJ"; then
@@ -327,7 +350,7 @@ cmd_start() {
             die "the project is already at ${version} (${build}); there is no bump to commit." \
                 "The revision already carries this release's version -- re-releasing a prior" \
                 "candidate's content needs a fresh version or build number." \
-                "Nothing has been pushed. To retry: git switch -, then" \
+                "Nothing has been pushed. To retry: ${return_cmd}, then" \
                 "git branch -D ${release_branch} ${candidate_branch}."
         fi
     fi

--- a/Scripts/prepare-release.sh
+++ b/Scripts/prepare-release.sh
@@ -16,9 +16,14 @@
 
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Resolve everything relative to this script, not the caller's directory: the
+# script edits and pushes the repository it lives in whichever checkout is
+# invoked, and a failed rev-parse would otherwise become `cd ""`, which
+# succeeds and leaves the script running somewhere it does not understand.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
 # shellcheck source=Scripts/lib/release-lib.sh
-. "Scripts/lib/release-lib.sh"
+. "${SCRIPT_DIR}/lib/release-lib.sh"
 
 usage() {
     cat <<'EOF'
@@ -149,6 +154,12 @@ cmd_start() {
     require_version_tool die_unless_dry_run
 
     GH_REPO="$(repo_for_remote "$remote")"
+    # Validated here, in preflight, rather than discovered by `gh pr create`
+    # after both branches are already pushed.
+    if ! printf '%s\n' "$GH_REPO" | grep -qE '^[^/:@]+/[^/:@]+$'; then
+        die "remote '${remote}' does not look like a GitHub repository (got '${GH_REPO}')." \
+            "Releases are cut against a GitHub remote; gh needs an owner/repo slug."
+    fi
     export GH_REPO
     echo "  repository: ${GH_REPO}"
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -11,6 +11,7 @@ Usage: Scripts/release.sh --variant <v> --ref <ref> --version <X.Y.Z> --build <n
   --submit-review  appstore only: submit the build to App Review after upload;
                    without --ref, submits a build already on App Store Connect
   --ref         branch, tag, or commit SHA to build (optional with --submit-review)
+  --remote      git remote the release lives on (default: origin)
   --version     marketing version you intend to ship (X.Y.Z)
   --build       build number (integer)
   --dry-run     run all preflight checks, then stop before building
@@ -20,13 +21,14 @@ Usage: Scripts/release.sh --variant <v> --ref <ref> --version <X.Y.Z> --build <n
 EOF
 }
 
-VARIANT="" ; REF="" ; VERSION="" ; BUILD=""
+VARIANT="" ; REF="" ; REMOTE="origin" ; VERSION="" ; BUILD=""
 DRY_RUN=false ; YES=false ; SKIP_TESTS=false ; SUBMIT_REVIEW=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --variant) VARIANT="$2" ; shift 2 ;;
     --ref) REF="$2" ; shift 2 ;;
+    --remote) REMOTE="$2" ; shift 2 ;;
     --version) VERSION="$2" ; shift 2 ;;
     --build) BUILD="$2" ; shift 2 ;;
     --submit-review) SUBMIT_REVIEW=true ; shift ;;
@@ -52,5 +54,5 @@ fi
 
 FASTLANE="${FASTLANE_CMD:-bundle exec fastlane}"
 exec $FASTLANE release \
-  variant:"$VARIANT" ref:"$REF" version:"$VERSION" build:"$BUILD" \
+  variant:"$VARIANT" ref:"$REF" remote:"$REMOTE" version:"$VERSION" build:"$BUILD" \
   dry_run:"$DRY_RUN" yes:"$YES" skip_tests:"$SKIP_TESTS" submit_review:"$SUBMIT_REVIEW"

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -30,7 +30,7 @@ mkcommit() {
   run "$CHECK"
   [ "$status" -eq 0 ]
   [[ "$output" == *'is in `maint/3.10.x` and downstream'* ]] || false
-  [[ "$output" != *"no longer exists"* ]] || false
+  [[ "$output" != *"does not exist"* ]] || false
 }
 
 @test "a released branch missing from its own line fails" {
@@ -135,4 +135,27 @@ mkcommit() {
   run "$CHECK" maint/3.10.x no-such-ref
   [ "$status" -eq 2 ]
   [[ "$output" == *"cannot resolve pr-ref"* ]] || false
+}
+
+@test "a release whose line does not exist warns on main, never fails" {
+  mkcommit "release 3.11.0"; REL="$SHA"
+  git tag 3.11.0 "$REL"
+  git update-ref refs/remotes/origin/release/3.11.0 "$REL"
+  git update-ref refs/remotes/origin/main "$BASE"
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'belongs to `maint/v3.11.x`, which does not exist'* ]] || false
+  [[ "$output" == *'has not reached `main` yet'* ]] || false
+  [[ "$output" != *':x:'* ]] || false
+}
+
+@test "a release whose line does not exist and is in main is green" {
+  mkcommit "release 3.11.0"; REL="$SHA"
+  git tag 3.11.0 "$REL"
+  git update-ref refs/remotes/origin/release/3.11.0 "$REL"
+  mkcommit "merge forward"
+  git update-ref refs/remotes/origin/main "$SHA"
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'is in `main`'* ]] || false
 }

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -58,6 +58,19 @@ mkcommit() {
   [[ "$output" == *"All 1 tagged release branches are merged back"* ]] || false
 }
 
+@test "a commit after the tag does not unmark a released branch" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  mkcommit "post-tag fix"; TIP="$SHA"
+  git update-ref refs/remotes/origin/release/3.10.2 "$TIP"
+  git update-ref refs/remotes/origin/maint/3.10.x "$BASE"
+  git update-ref refs/remotes/origin/main "$BASE"
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"no release tag"* ]] || false
+  [[ "$output" == *'`release/3.10.2` (`3.10.2`) is **not** merged back into `maint/3.10.x`'* ]] || false
+}
+
 @test "non-release tags neither elect a maintenance line nor mark a release" {
   mkcommit "release 3.10.2"; REL="$SHA"
   git tag 3.10.2 "$REL"

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -20,7 +20,7 @@ mkcommit() {
   SHA="$(git rev-parse HEAD)"
 }
 
-@test "a maintenance line without the v prefix is the release's own line" {
+@test "a wrongly-spelled maint branch is reported and is not the release's line" {
   mkcommit "release 3.10.2"; REL="$SHA"
   git tag 3.10.2 "$REL"
   git update-ref refs/remotes/origin/release/3.10.2 "$REL"
@@ -29,19 +29,36 @@ mkcommit() {
   git update-ref refs/remotes/origin/main "$SHA"
   run "$CHECK"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'is in `maint/3.10.x` and downstream'* ]] || false
-  [[ "$output" != *"does not exist"* ]] || false
+  [[ "$output" == *'`maint/3.10.x` does not match maint/vX.Y.x; not a maintenance line, ignored.'* ]] || false
+  [[ "$output" == *'belongs to `maint/v3.10.x`, which does not exist; checking main only'* ]] || false
+  [[ "$output" == *'is in `main`'* ]] || false
+}
+
+@test "a wrongly-spelled twin of the line neither fails nor lags the release" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  mkcommit "merge back"
+  # Merged into maint/v3.10.x exactly as prepare-release.sh instructs; the
+  # stale wrongly-spelled twin must neither be the own-line obligation nor lag.
+  git update-ref refs/remotes/origin/maint/v3.10.x "$SHA"
+  git update-ref refs/remotes/origin/maint/3.10.x "$BASE"
+  git update-ref refs/remotes/origin/main "$SHA"
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'is in `maint/v3.10.x` and downstream'* ]] || false
+  [[ "$output" != *':warning:'* ]] || false
 }
 
 @test "a released branch missing from its own line fails" {
   mkcommit "release 3.10.2"; REL="$SHA"
   git tag 3.10.2 "$REL"
   git update-ref refs/remotes/origin/release/3.10.2 "$REL"
-  git update-ref refs/remotes/origin/maint/3.10.x "$BASE"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$BASE"
   git update-ref refs/remotes/origin/main "$BASE"
   run "$CHECK"
   [ "$status" -eq 1 ]
-  [[ "$output" == *'is **not** merged back into `maint/3.10.x`'* ]] || false
+  [[ "$output" == *'is **not** merged back into `maint/v3.10.x`'* ]] || false
 }
 
 @test "a freshly cut release branch still pointing at the previous tag is skipped" {
@@ -63,12 +80,12 @@ mkcommit() {
   git tag 3.10.2 "$REL"
   mkcommit "post-tag fix"; TIP="$SHA"
   git update-ref refs/remotes/origin/release/3.10.2 "$TIP"
-  git update-ref refs/remotes/origin/maint/3.10.x "$BASE"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$BASE"
   git update-ref refs/remotes/origin/main "$BASE"
   run "$CHECK"
   [ "$status" -eq 1 ]
   [[ "$output" != *"no release tag"* ]] || false
-  [[ "$output" == *'`release/3.10.2` (`3.10.2`) is **not** merged back into `maint/3.10.x`'* ]] || false
+  [[ "$output" == *'`release/3.10.2` (`3.10.2`) is **not** merged back into `maint/v3.10.x`'* ]] || false
 }
 
 @test "non-release tags neither elect a maintenance line nor mark a release" {
@@ -93,27 +110,27 @@ mkcommit() {
   mkcommit "release 3.10.2"; REL="$SHA"
   git tag 3.10.2 "$REL"
   git update-ref refs/remotes/origin/release/3.10.2 "$REL"
-  git update-ref refs/remotes/origin/maint/3.10.x "$BASE"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$BASE"
   git update-ref refs/remotes/origin/main "$BASE"
   git checkout -q -b prmerge "$REL"
   mkcommit "pr merge"
-  run "$CHECK" maint/3.10.x prmerge
+  run "$CHECK" maint/v3.10.x prmerge
   [ "$status" -eq 0 ]
-  [[ "$output" == *'is in `maint/3.10.x` but has not reached main'* ]] || false
+  [[ "$output" == *'is in `maint/v3.10.x` but has not reached main'* ]] || false
 }
 
-@test "maintenance lines are ordered by version across both spellings" {
+@test "maintenance lines are ordered by version, not lexically" {
   mkcommit "release 3.9.5"; REL="$SHA"
   git tag 3.9.5 "$REL"
   git update-ref refs/remotes/origin/release/3.9.5 "$REL"
   mkcommit "on the 3.9 line only"
-  git update-ref refs/remotes/origin/maint/3.9.x "$SHA"
+  git update-ref refs/remotes/origin/maint/v3.9.x "$SHA"
   git update-ref refs/remotes/origin/maint/v3.10.x "$BASE"
-  git update-ref refs/remotes/origin/maint/3.11.x "$BASE"
+  git update-ref refs/remotes/origin/maint/v3.11.x "$BASE"
   git update-ref refs/remotes/origin/main "$BASE"
   run "$CHECK"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'is in `maint/3.9.x` but has not reached maint/v3.10.x, maint/3.11.x, main yet'* ]] || false
+  [[ "$output" == *'is in `maint/v3.9.x` but has not reached maint/v3.10.x, maint/v3.11.x, main yet'* ]] || false
 }
 
 @test "a git failure is an infrastructure error, not a clean run" {
@@ -129,7 +146,7 @@ mkcommit() {
   mkcommit "release 3.10.2"; REL="$SHA"
   git tag 3.10.2 "$REL"
   git update-ref refs/remotes/origin/release/3.10.2 "$REL"
-  git update-ref refs/remotes/origin/maint/3.10.x "$REL"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$REL"
   # origin/main deliberately absent: the chain still ends in main, and the
   # old code reported this as a confident (false) verdict about main.
   run "$CHECK"
@@ -143,9 +160,9 @@ mkcommit() {
   mkcommit "release 3.10.2"; REL="$SHA"
   git tag 3.10.2 "$REL"
   git update-ref refs/remotes/origin/release/3.10.2 "$REL"
-  git update-ref refs/remotes/origin/maint/3.10.x "$REL"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$REL"
   git update-ref refs/remotes/origin/main "$REL"
-  run "$CHECK" maint/3.10.x no-such-ref
+  run "$CHECK" maint/v3.10.x no-such-ref
   [ "$status" -eq 2 ]
   [[ "$output" == *"cannot resolve pr-ref"* ]] || false
 }

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -167,16 +167,16 @@ mkcommit() {
   [[ "$output" == *"cannot resolve pr-ref"* ]] || false
 }
 
-@test "a release whose line does not exist warns on main, never fails" {
+@test "a release with no maintenance line must reach main" {
   mkcommit "release 3.11.0"; REL="$SHA"
   git tag 3.11.0 "$REL"
   git update-ref refs/remotes/origin/release/3.11.0 "$REL"
   git update-ref refs/remotes/origin/main "$BASE"
   run "$CHECK"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" == *'belongs to `maint/v3.11.x`, which does not exist'* ]] || false
-  [[ "$output" == *'has not reached `main` yet'* ]] || false
-  [[ "$output" != *':x:'* ]] || false
+  [[ "$output" == *':x:'*'has no maintenance line and has not reached `main`'* ]] || false
+  [[ "$output" != *'tagged release branches are merged back'* ]] || false
 }
 
 @test "a release whose line does not exist and is in main is green" {

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -10,6 +10,7 @@ setup() {
   git init -q -b main "$REPO"
   cd "$REPO"
   git config tag.gpgsign false
+  git config commit.gpgsign false
   git -c user.name=t -c user.email=t@t commit -q --allow-empty -m base
   BASE="$(git rev-parse HEAD)"
 }

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+#
+# Tests for .github/scripts/check-release-merged-back.sh against fixture
+# repositories. Remote-tracking refs are planted with git update-ref, so
+# nothing here needs a network or a real remote.
+
+setup() {
+  CHECK="$BATS_TEST_DIRNAME/../../.github/scripts/check-release-merged-back.sh"
+  REPO="$BATS_TEST_TMPDIR/repo"
+  git init -q -b main "$REPO"
+  cd "$REPO"
+  git config tag.gpgsign false
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m base
+  BASE="$(git rev-parse HEAD)"
+}
+
+# One empty commit on the current branch; its sha lands in $SHA.
+mkcommit() {
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m "$1"
+  SHA="$(git rev-parse HEAD)"
+}
+
+@test "a maintenance line without the v prefix is the release's own line" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  mkcommit "merge back"
+  git update-ref refs/remotes/origin/maint/3.10.x "$SHA"
+  git update-ref refs/remotes/origin/main "$SHA"
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'is in `maint/3.10.x` and downstream'* ]] || false
+  [[ "$output" != *"no longer exists"* ]] || false
+}
+
+@test "a released branch missing from its own line fails" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  git update-ref refs/remotes/origin/maint/3.10.x "$BASE"
+  git update-ref refs/remotes/origin/main "$BASE"
+  run "$CHECK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *'is **not** merged back into `maint/3.10.x`'* ]] || false
+}
+
+@test "a freshly cut release branch still pointing at the previous tag is skipped" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.11.0 "$REL"
+  mkcommit "merge back"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$SHA"
+  git update-ref refs/remotes/origin/main "$SHA"
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'`release/3.11.0` is freshly cut from `3.10.2`'* ]] || false
+  [[ "$output" == *"All 1 tagged release branches are merged back"* ]] || false
+}
+
+@test "non-release tags neither elect a maintenance line nor mark a release" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git tag 0.0.1-42-mainnet "$REL"
+  git tag beta4-rc2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  mkcommit "wip"; W="$SHA"
+  git tag beta5-rc1 "$W"
+  git update-ref refs/remotes/origin/release/experimental "$W"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$W"
+  git update-ref refs/remotes/origin/main "$W"
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'(`3.10.2`)'* ]] || false
+  [[ "$output" != *"vbeta"* ]] || false
+  [[ "$output" != *"v0.0.x"* ]] || false
+  [[ "$output" == *'`release/experimental` has no release tag at its tip'* ]] || false
+}
+
+@test "a pending merge-back PR into its line is evaluated as merged" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  git update-ref refs/remotes/origin/maint/3.10.x "$BASE"
+  git update-ref refs/remotes/origin/main "$BASE"
+  git checkout -q -b prmerge "$REL"
+  mkcommit "pr merge"
+  run "$CHECK" maint/3.10.x prmerge
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'is in `maint/3.10.x` but has not reached main'* ]] || false
+}

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -72,7 +72,6 @@ mkcommit() {
   run "$CHECK"
   [ "$status" -eq 0 ]
   [[ "$output" == *'(`3.10.2`)'* ]] || false
-  [[ "$output" != *"vbeta"* ]] || false
   [[ "$output" != *"v0.0.x"* ]] || false
   [[ "$output" == *'`release/experimental` has no release tag at its tip'* ]] || false
 }
@@ -88,4 +87,18 @@ mkcommit() {
   run "$CHECK" maint/3.10.x prmerge
   [ "$status" -eq 0 ]
   [[ "$output" == *'is in `maint/3.10.x` but has not reached main'* ]] || false
+}
+
+@test "maintenance lines are ordered by version across both spellings" {
+  mkcommit "release 3.9.5"; REL="$SHA"
+  git tag 3.9.5 "$REL"
+  git update-ref refs/remotes/origin/release/3.9.5 "$REL"
+  mkcommit "on the 3.9 line only"
+  git update-ref refs/remotes/origin/maint/3.9.x "$SHA"
+  git update-ref refs/remotes/origin/maint/v3.10.x "$BASE"
+  git update-ref refs/remotes/origin/maint/3.11.x "$BASE"
+  git update-ref refs/remotes/origin/main "$BASE"
+  run "$CHECK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'is in `maint/3.9.x` but has not reached maint/v3.10.x, maint/3.11.x, main yet'* ]] || false
 }

--- a/Scripts/test/merged_back.bats
+++ b/Scripts/test/merged_back.bats
@@ -102,3 +102,37 @@ mkcommit() {
   [ "$status" -eq 0 ]
   [[ "$output" == *'is in `maint/3.9.x` but has not reached maint/v3.10.x, maint/3.11.x, main yet'* ]] || false
 }
+
+@test "a git failure is an infrastructure error, not a clean run" {
+  mkdir -p "$BATS_TEST_TMPDIR/notarepo"
+  cd "$BATS_TEST_TMPDIR/notarepo"
+  run "$CHECK"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"could not run"* ]] || false
+  [[ "$output" != *"No tagged release branches to check"* ]] || false
+}
+
+@test "an unresolvable chain ref is an infrastructure error, not a finding" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  git update-ref refs/remotes/origin/maint/3.10.x "$REL"
+  # origin/main deliberately absent: the chain still ends in main, and the
+  # old code reported this as a confident (false) verdict about main.
+  run "$CHECK"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"could not run"* ]] || false
+  [[ "$output" != *"has not reached"* ]] || false
+  [[ "$output" != *"is **not** merged back"* ]] || false
+}
+
+@test "an unresolvable pr-ref is an infrastructure error" {
+  mkcommit "release 3.10.2"; REL="$SHA"
+  git tag 3.10.2 "$REL"
+  git update-ref refs/remotes/origin/release/3.10.2 "$REL"
+  git update-ref refs/remotes/origin/maint/3.10.x "$REL"
+  git update-ref refs/remotes/origin/main "$REL"
+  run "$CHECK" maint/3.10.x no-such-ref
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"cannot resolve pr-ref"* ]] || false
+}

--- a/Scripts/test/prepare_release_args.bats
+++ b/Scripts/test/prepare_release_args.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+#
+# Tests for prepare-release.sh's argument handling. Every case here is rejected
+# before the script reaches git or the network, so the suite needs neither.
+
+setup() {
+  PREPARE="$BATS_TEST_DIRNAME/../prepare-release.sh"
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+@test "--help exits 0 and lists the subcommands" {
+  run "$PREPARE" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh <subcommand>"* ]]
+  [[ "$output" == *"start"* ]]
+}
+
+@test "no subcommand exits non-zero with usage" {
+  run "$PREPARE"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh <subcommand>"* ]]
+}
+
+@test "an unknown subcommand is named in the error" {
+  run "$PREPARE" finish upstream 3.11.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown subcommand 'finish'"* ]]
+}
+
+# --- start ------------------------------------------------------------------
+
+@test "start --help exits 0 and documents the arguments" {
+  run "$PREPARE" start --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh start"* ]]
+  [[ "$output" == *"<remote>"* ]]
+  [[ "$output" == *"--previous"* ]]
+}
+
+@test "start with no arguments asks for a remote and a version" {
+  run "$PREPARE" start
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"start needs a remote and a version"* ]]
+}
+
+@test "start with only a remote asks for a version" {
+  run "$PREPARE" start upstream
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"start needs a remote and a version"* ]]
+}
+
+@test "an unknown option is named in the error" {
+  run "$PREPARE" start --bogus x upstream 3.11.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option '--bogus'"* ]]
+}
+
+@test "a version that is not X.Y.Z is rejected" {
+  for bad in 3.11 3.11.0-rc.1 three 3.11.0.1; do
+    run "$PREPARE" start upstream "$bad"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is not in X.Y.Z form"* ]]
+  done
+}
+
+# A leading v is stripped before validation, so `v3.11.0` means 3.11.0 and is
+# accepted -- it reaches the preconditions rather than the version check.
+@test "a leading v is stripped rather than rejected" {
+  run "$PREPARE" start upstream v3.11.0
+  [[ "$output" != *"is not in X.Y.Z form"* ]]
+}
+
+# Confirm the rejection message names the value actually checked, not the
+# argument as typed.
+@test "a rejected version is reported without its stripped v" {
+  run "$PREPARE" start upstream v3.11
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"version '3.11' is not in X.Y.Z form"* ]]
+}
+
+@test "a non-integer build number is rejected" {
+  run "$PREPARE" start --build one upstream 3.11.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"build 'one' is not an integer"* ]]
+}
+
+@test "an option missing its value is rejected rather than swallowing the next argument" {
+  run "$PREPARE" start --issue
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--issue needs an issue number"* ]]
+
+  run "$PREPARE" start --previous
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--previous needs a tag"* ]]
+
+  run "$PREPARE" start --build
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--build needs a build number"* ]]
+}

--- a/Scripts/test/prepare_release_args.bats
+++ b/Scripts/test/prepare_release_args.bats
@@ -105,3 +105,27 @@ setup() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"--build needs a build number"* ]]
 }
+
+@test "a fourth positional argument is rejected" {
+  run "$PREPARE" start bats-no-such-remote 3.11.0 HEAD stray
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unexpected argument 'stray'"* ]]
+}
+
+@test "options after the positional arguments are parsed, not dropped" {
+  # --help after positionals must short-circuit to usage (exit 0); the old
+  # loop silently discarded everything past the third positional.
+  run "$PREPARE" start bats-no-such-remote 3.11.0 --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh start"* ]]
+
+  run "$PREPARE" start bats-no-such-remote 3.11.0 HEAD --bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown option '--bogus'"* ]]
+}
+
+@test "a value option after the positionals still requires its value" {
+  run "$PREPARE" start bats-no-such-remote 3.11.0 --previous
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--previous needs a tag"* ]]
+}

--- a/Scripts/test/prepare_release_args.bats
+++ b/Scripts/test/prepare_release_args.bats
@@ -1,7 +1,9 @@
 #!/usr/bin/env bats
 #
-# Tests for prepare-release.sh's argument handling. Every case here is rejected
-# before the script reaches git or the network, so the suite needs neither.
+# Tests for prepare-release.sh's argument handling. Every case here either is
+# rejected at parsing or dies in read-only preflight (against a remote that
+# cannot exist, under --dry-run), so the suite touches neither the network nor
+# any repository state.
 
 setup() {
   PREPARE="$BATS_TEST_DIRNAME/../prepare-release.sh"
@@ -65,10 +67,15 @@ setup() {
 }
 
 # A leading v is stripped before validation, so `v3.11.0` means 3.11.0 and is
-# accepted -- it reaches the preconditions rather than the version check.
+# accepted -- it reaches the preconditions rather than the version check. The
+# remote deliberately cannot exist and --dry-run is set, so the run dies in
+# preflight (dirty tree or unknown remote, depending on the checkout) without
+# touching anything; the non-zero status is asserted, not assumed.
 @test "a leading v is stripped rather than rejected" {
-  run "$PREPARE" start upstream v3.11.0
+  run "$PREPARE" start --dry-run bats-no-such-remote v3.11.0
+  [ "$status" -ne 0 ]
   [[ "$output" != *"is not in X.Y.Z form"* ]]
+  [[ "$output" == *"Checking preconditions"* ]]
 }
 
 # Confirm the rejection message names the value actually checked, not the

--- a/Scripts/test/prepare_release_args.bats
+++ b/Scripts/test/prepare_release_args.bats
@@ -14,20 +14,20 @@ setup() {
 @test "--help exits 0 and lists the subcommands" {
   run "$PREPARE" --help
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh <subcommand>"* ]]
-  [[ "$output" == *"start"* ]]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh <subcommand>"* ]] || false
+  [[ "$output" == *"start"* ]] || false
 }
 
 @test "no subcommand exits non-zero with usage" {
   run "$PREPARE"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh <subcommand>"* ]]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh <subcommand>"* ]] || false
 }
 
 @test "an unknown subcommand is named in the error" {
   run "$PREPARE" finish upstream 3.11.0
   [ "$status" -ne 0 ]
-  [[ "$output" == *"unknown subcommand 'finish'"* ]]
+  [[ "$output" == *"unknown subcommand 'finish'"* ]] || false
 }
 
 # --- start ------------------------------------------------------------------
@@ -35,34 +35,34 @@ setup() {
 @test "start --help exits 0 and documents the arguments" {
   run "$PREPARE" start --help
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh start"* ]]
-  [[ "$output" == *"<remote>"* ]]
-  [[ "$output" == *"--previous"* ]]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh start"* ]] || false
+  [[ "$output" == *"<remote>"* ]] || false
+  [[ "$output" == *"--previous"* ]] || false
 }
 
 @test "start with no arguments asks for a remote and a version" {
   run "$PREPARE" start
   [ "$status" -ne 0 ]
-  [[ "$output" == *"start needs a remote and a version"* ]]
+  [[ "$output" == *"start needs a remote and a version"* ]] || false
 }
 
 @test "start with only a remote asks for a version" {
   run "$PREPARE" start upstream
   [ "$status" -ne 0 ]
-  [[ "$output" == *"start needs a remote and a version"* ]]
+  [[ "$output" == *"start needs a remote and a version"* ]] || false
 }
 
 @test "an unknown option is named in the error" {
   run "$PREPARE" start --bogus x upstream 3.11.0
   [ "$status" -ne 0 ]
-  [[ "$output" == *"unknown option '--bogus'"* ]]
+  [[ "$output" == *"unknown option '--bogus'"* ]] || false
 }
 
 @test "a version that is not X.Y.Z is rejected" {
   for bad in 3.11 3.11.0-rc.1 three 3.11.0.1; do
     run "$PREPARE" start upstream "$bad"
     [ "$status" -ne 0 ]
-    [[ "$output" == *"is not in X.Y.Z form"* ]]
+    [[ "$output" == *"is not in X.Y.Z form"* ]] || false
   done
 }
 
@@ -74,8 +74,8 @@ setup() {
 @test "a leading v is stripped rather than rejected" {
   run "$PREPARE" start --dry-run bats-no-such-remote v3.11.0
   [ "$status" -ne 0 ]
-  [[ "$output" != *"is not in X.Y.Z form"* ]]
-  [[ "$output" == *"Checking preconditions"* ]]
+  [[ "$output" != *"is not in X.Y.Z form"* ]] || false
+  [[ "$output" == *"Checking preconditions"* ]] || false
 }
 
 # Confirm the rejection message names the value actually checked, not the
@@ -83,33 +83,33 @@ setup() {
 @test "a rejected version is reported without its stripped v" {
   run "$PREPARE" start upstream v3.11
   [ "$status" -ne 0 ]
-  [[ "$output" == *"version '3.11' is not in X.Y.Z form"* ]]
+  [[ "$output" == *"version '3.11' is not in X.Y.Z form"* ]] || false
 }
 
 @test "a non-integer build number is rejected" {
   run "$PREPARE" start --build one upstream 3.11.0
   [ "$status" -ne 0 ]
-  [[ "$output" == *"build 'one' is not an integer"* ]]
+  [[ "$output" == *"build 'one' is not an integer"* ]] || false
 }
 
 @test "an option missing its value is rejected rather than swallowing the next argument" {
   run "$PREPARE" start --issue
   [ "$status" -ne 0 ]
-  [[ "$output" == *"--issue needs an issue number"* ]]
+  [[ "$output" == *"--issue needs an issue number"* ]] || false
 
   run "$PREPARE" start --previous
   [ "$status" -ne 0 ]
-  [[ "$output" == *"--previous needs a tag"* ]]
+  [[ "$output" == *"--previous needs a tag"* ]] || false
 
   run "$PREPARE" start --build
   [ "$status" -ne 0 ]
-  [[ "$output" == *"--build needs a build number"* ]]
+  [[ "$output" == *"--build needs a build number"* ]] || false
 }
 
 @test "a fourth positional argument is rejected" {
   run "$PREPARE" start bats-no-such-remote 3.11.0 HEAD stray
   [ "$status" -ne 0 ]
-  [[ "$output" == *"unexpected argument 'stray'"* ]]
+  [[ "$output" == *"unexpected argument 'stray'"* ]] || false
 }
 
 @test "options after the positional arguments are parsed, not dropped" {
@@ -117,15 +117,15 @@ setup() {
   # loop silently discarded everything past the third positional.
   run "$PREPARE" start bats-no-such-remote 3.11.0 --help
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh start"* ]]
+  [[ "$output" == *"Usage: ./Scripts/prepare-release.sh start"* ]] || false
 
   run "$PREPARE" start bats-no-such-remote 3.11.0 HEAD --bogus
   [ "$status" -ne 0 ]
-  [[ "$output" == *"unknown option '--bogus'"* ]]
+  [[ "$output" == *"unknown option '--bogus'"* ]] || false
 }
 
 @test "a value option after the positionals still requires its value" {
   run "$PREPARE" start bats-no-such-remote 3.11.0 --previous
   [ "$status" -ne 0 ]
-  [[ "$output" == *"--previous needs a tag"* ]]
+  [[ "$output" == *"--previous needs a tag"* ]] || false
 }

--- a/Scripts/test/prepare_release_args.bats
+++ b/Scripts/test/prepare_release_args.bats
@@ -92,6 +92,18 @@ setup() {
   [[ "$output" == *"build 'one' is not an integer"* ]] || false
 }
 
+# DRY_RUN is not an interface: only --dry-run selects a rehearsal. An
+# environment value used to be half-honoured -- only the literal "true"
+# rehearsed, and DRY_RUN=1 cut a release for real -- so any value at all is
+# now refused outright rather than guessed at.
+@test "DRY_RUN in the environment is refused, whatever its value" {
+  for v in 1 true yes false; do
+    run env DRY_RUN="$v" "$PREPARE" start --dry-run bats-no-such-remote 3.11.0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"DRY_RUN in the environment has no effect; use --dry-run."* ]] || false
+  done
+}
+
 @test "an option missing its value is rejected rather than swallowing the next argument" {
   run "$PREPARE" start --issue
   [ "$status" -ne 0 ]

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -36,8 +36,8 @@ sandbox_commit() {
   git -c user.name=t -c user.email=t@t commit -q --allow-empty -m ahead
   run "$START" start --dry-run upstream 0.2.0
   [ "$status" -ne 0 ]
-  [[ "$output" == *"newest release tag is 0.1.1"* ]]
-  [[ "$output" == *"not reachable"* ]]
+  [[ "$output" == *"newest release tag is 0.1.1"* ]] || false
+  [[ "$output" == *"not reachable"* ]] || false
 }
 
 @test "--previous must be an ancestor of the revision" {
@@ -48,14 +48,14 @@ sandbox_commit() {
   git -c user.name=t -c user.email=t@t commit -q --allow-empty -m ahead
   run "$START" start --dry-run --previous 0.1.1 upstream 0.2.0
   [ "$status" -ne 0 ]
-  [[ "$output" == *"--previous 0.1.1 is not an ancestor of HEAD"* ]]
+  [[ "$output" == *"--previous 0.1.1 is not an ancestor of HEAD"* ]] || false
 }
 
 @test "a clean dry run rehearses the whole cut and changes nothing" {
   run "$START" start --dry-run upstream 0.2.0
   [ "$status" -eq 0 ]
-  [[ "$output" == *"newest release reachable from HEAD: 0.1.0"* ]]
-  [[ "$output" == *"Dry run: nothing was changed"* ]]
+  [[ "$output" == *"newest release reachable from HEAD: 0.1.0"* ]] || false
+  [[ "$output" == *"Dry run: nothing was changed"* ]] || false
   # Nothing mutated: no branches, tree clean, HEAD still on main.
   [ -z "$(git status --porcelain)" ]
   [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]
@@ -73,7 +73,7 @@ sandbox_commit() {
   sandbox_commit "entries again"
   run "$START" start --dry-run upstream 0.2.0 "$EMPTY_SHA"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Unreleased section of CHANGELOG.md at ${EMPTY_SHA} has no entries"* ]]
+  [[ "$output" == *"Unreleased section of CHANGELOG.md at ${EMPTY_SHA} has no entries"* ]] || false
 }
 
 @test "the existing-heading guard reads the revision, not the working tree" {
@@ -86,5 +86,5 @@ sandbox_commit() {
   sandbox_commit "heading gone"
   run "$START" start --dry-run upstream 0.2.0 "$HAS_SHA"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"already carries a heading for 0.2.0"* ]]
+  [[ "$output" == *"already carries a heading for 0.2.0"* ]] || false
 }

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -16,6 +16,7 @@ setup() {
   git init -q -b main "$SB"
   cd "$SB"
   git config tag.gpgsign false
+  git config commit.gpgsign false
   # `upstream` is this repository itself, reached through a relative path whose
   # derived slug parses as owner/repo, so the GitHub-shape preflight passes
   # offline: repo_slug_from_url strips through the first separator, leaving

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -76,14 +76,14 @@ sandbox_commit() {
   [ "$status" -ne 0 ]
 }
 
-@test "the merge-back line matches the remote's existing spelling" {
+@test "the merge-back line is canonical even when a wrongly-spelled branch exists" {
   # The sandbox's remote is itself, so a local maint branch is what the
   # script's own fetch turns into refs/remotes/upstream/maint/0.1.x.
   git branch maint/0.1.x
   run "$START" start --dry-run upstream 0.1.5
   [ "$status" -eq 0 ]
-  [[ "$output" == *"merge back into"*"maint/0.1.x"* ]] || false
-  [[ "$output" != *"maint/v0.1.x"* ]] || false
+  [[ "$output" == *"merge back into"*"maint/v0.1.x"* ]] || false
+  [[ "$output" != *"maint/0.1.x"* ]] || false
 }
 
 @test "the empty-Unreleased guard reads the revision, not the working tree" {

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+#
+# Tests for prepare-release.sh's start flow beyond argument parsing, run
+# against a COPY of the script inside a throwaway repository whose `upstream`
+# remote is the repository itself. Everything runs under --dry-run, so the
+# suite needs no network, no GitHub auth, and mutates nothing -- and because
+# the copy anchors to the sandbox checkout, the real repository is never
+# touched even if an assertion is wrong.
+
+setup() {
+  SB="$BATS_TEST_TMPDIR/sandbox"
+  mkdir -p "$SB/Scripts/lib"
+  cp "$BATS_TEST_DIRNAME/../prepare-release.sh" "$SB/Scripts/prepare-release.sh"
+  cp "$BATS_TEST_DIRNAME/../lib/release-lib.sh" "$SB/Scripts/lib/release-lib.sh"
+  START="$SB/Scripts/prepare-release.sh"
+  git init -q -b main "$SB"
+  cd "$SB"
+  git config tag.gpgsign false
+  git remote add upstream .
+  printf '# Changelog\n\n## [Unreleased]\n\n### Added\n- [MOB-1] entry\n' > CHANGELOG.md
+  git add .
+  git -c user.name=t -c user.email=t@t commit -q -m base
+  git tag 0.1.0
+}
+
+sandbox_commit() {
+  git add .
+  git -c user.name=t -c user.email=t@t commit -q -m "$1"
+}
+
+@test "an unreachable newer release tag stops an auto-detected cut" {
+  git checkout -q -b side
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m divergent
+  git tag 0.1.1
+  git checkout -q main
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m ahead
+  run "$START" start --dry-run upstream 0.2.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"newest release tag is 0.1.1"* ]]
+  [[ "$output" == *"not reachable"* ]]
+}
+
+@test "--previous must be an ancestor of the revision" {
+  git checkout -q -b side
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m divergent
+  git tag 0.1.1
+  git checkout -q main
+  git -c user.name=t -c user.email=t@t commit -q --allow-empty -m ahead
+  run "$START" start --dry-run --previous 0.1.1 upstream 0.2.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--previous 0.1.1 is not an ancestor of HEAD"* ]]
+}
+
+@test "a clean dry run rehearses the whole cut and changes nothing" {
+  run "$START" start --dry-run upstream 0.2.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"newest release reachable from HEAD: 0.1.0"* ]]
+  [[ "$output" == *"Dry run: nothing was changed"* ]]
+  # Nothing mutated: no branches, tree clean, HEAD still on main.
+  [ -z "$(git status --porcelain)" ]
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]
+  run git rev-parse -q --verify refs/heads/release/0.2.0
+  [ "$status" -ne 0 ]
+}

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -62,3 +62,29 @@ sandbox_commit() {
   run git rev-parse -q --verify refs/heads/release/0.2.0
   [ "$status" -ne 0 ]
 }
+
+@test "the empty-Unreleased guard reads the revision, not the working tree" {
+  # First commit: CHANGELOG whose Unreleased section is empty.
+  printf '# Changelog\n\n## [Unreleased]\n\n### Added\n' > CHANGELOG.md
+  sandbox_commit "empty unreleased"
+  EMPTY_SHA="$(git rev-parse HEAD)"
+  # HEAD moves on; the checkout has entries again.
+  printf '# Changelog\n\n## [Unreleased]\n\n### Added\n- [MOB-2] newer entry\n' > CHANGELOG.md
+  sandbox_commit "entries again"
+  run "$START" start --dry-run upstream 0.2.0 "$EMPTY_SHA"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unreleased section of CHANGELOG.md at ${EMPTY_SHA} has no entries"* ]]
+}
+
+@test "the existing-heading guard reads the revision, not the working tree" {
+  # First commit: CHANGELOG that already carries the version being cut.
+  printf '# Changelog\n\n## [Unreleased]\n\n- [MOB-1] entry\n\n## [0.2.0] - 2026-01-01\n- old\n' > CHANGELOG.md
+  sandbox_commit "already has 0.2.0"
+  HAS_SHA="$(git rev-parse HEAD)"
+  # HEAD moves on; the checkout no longer mentions 0.2.0.
+  printf '# Changelog\n\n## [Unreleased]\n\n- [MOB-1] entry\n' > CHANGELOG.md
+  sandbox_commit "heading gone"
+  run "$START" start --dry-run upstream 0.2.0 "$HAS_SHA"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already carries a heading for 0.2.0"* ]]
+}

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -56,6 +56,10 @@ sandbox_commit() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"newest release reachable from HEAD: 0.1.0"* ]] || false
   [[ "$output" == *"Dry run: nothing was changed"* ]] || false
+  # The rehearsal must describe the atomic shape of a real run: one push
+  # carrying both branches, after all local work, then a draft PR.
+  [[ "$output" == *"would run: git push --atomic -u upstream release/0.2.0 candidate/0.2.0"* ]] || false
+  [[ "$output" == *"would open a draft PR candidate/0.2.0 -> release/0.2.0"* ]] || false
   # Nothing mutated: no branches, tree clean, HEAD still on main.
   [ -z "$(git status --porcelain)" ]
   [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -16,7 +16,14 @@ setup() {
   git init -q -b main "$SB"
   cd "$SB"
   git config tag.gpgsign false
-  git remote add upstream .
+  # `upstream` is this repository itself, reached through a relative path whose
+  # derived slug parses as owner/repo, so the GitHub-shape preflight passes
+  # offline: repo_slug_from_url strips through the first separator, leaving
+  # `sandbox/sandbox`.
+  mkdir -p x/sandbox
+  ln -s "$SB/.git" x/sandbox/sandbox
+  git remote add upstream x/sandbox/sandbox
+  printf 'x/\n' > .gitignore
   printf '# Changelog\n\n## [Unreleased]\n\n### Added\n- [MOB-1] entry\n' > CHANGELOG.md
   git add .
   git -c user.name=t -c user.email=t@t commit -q -m base

--- a/Scripts/test/prepare_release_start.bats
+++ b/Scripts/test/prepare_release_start.bats
@@ -67,11 +67,23 @@ sandbox_commit() {
   # carrying both branches, after all local work, then a draft PR.
   [[ "$output" == *"would run: git push --atomic -u upstream release/0.2.0 candidate/0.2.0"* ]] || false
   [[ "$output" == *"would open a draft PR candidate/0.2.0 -> release/0.2.0"* ]] || false
+  # The plan names the merge-back line; no 0.2 line exists, so canonical v.
+  [[ "$output" == *"merge back into"*"maint/v0.2.x"* ]] || false
   # Nothing mutated: no branches, tree clean, HEAD still on main.
   [ -z "$(git status --porcelain)" ]
   [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]
   run git rev-parse -q --verify refs/heads/release/0.2.0
   [ "$status" -ne 0 ]
+}
+
+@test "the merge-back line matches the remote's existing spelling" {
+  # The sandbox's remote is itself, so a local maint branch is what the
+  # script's own fetch turns into refs/remotes/upstream/maint/0.1.x.
+  git branch maint/0.1.x
+  run "$START" start --dry-run upstream 0.1.5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"merge back into"*"maint/0.1.x"* ]] || false
+  [[ "$output" != *"maint/v0.1.x"* ]] || false
 }
 
 @test "the empty-Unreleased guard reads the revision, not the working tree" {

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -103,26 +103,16 @@ make_tag_repo() {
 
 # --- maintenance line naming ---------------------------------------------
 
-@test "maint_line_for_version matches the remote's spelling of the line" {
+@test "maint_line_for_version always names the canonical maint/vX.Y.x line" {
   make_tag_repo
+  # A wrongly-spelled branch on the remote does not change the answer.
   git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/3.10.x HEAD
-  git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/v3.11.x HEAD
-  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.10.4"
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version 3.10.4"
   [ "$status" -eq 0 ]
-  [ "$output" = "maint/3.10.x" ]
-  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.11.2"
-  [ "$output" = "maint/v3.11.x" ]
-  # A line that exists nowhere yet is named canonically, to be created.
-  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.12.0"
-  [ "$output" = "maint/v3.12.x" ]
-}
-
-@test "maint_line_for_version prefers the canonical v spelling when both exist" {
-  make_tag_repo
-  git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/3.10.x HEAD
-  git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/v3.10.x HEAD
-  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.10.4"
   [ "$output" = "maint/v3.10.x" ]
+  # A line that does not exist yet is named the same way, to be created.
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version 3.12.0"
+  [ "$output" = "maint/v3.12.x" ]
 }
 
 # --- CHANGELOG --------------------------------------------------------------

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -59,6 +59,7 @@ make_tag_repo() {
   TAG_REPO="$BATS_TEST_TMPDIR/tagrepo"
   git init -q -b main "$TAG_REPO"
   git -C "$TAG_REPO" config tag.gpgsign false
+  git -C "$TAG_REPO" config commit.gpgsign false
   git -C "$TAG_REPO" -c user.name=t -c user.email=t@t commit -q --allow-empty -m one
 }
 

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -256,16 +256,17 @@ EOF
   [ "$status" -ne 0 ]
 }
 
-# --- project versions -------------------------------------------------------
+@test "promote_changelog preserves the file's permissions" {
+  write_changelog <<'EOF'
+## [Unreleased]
 
-@test "project_marketing_version reads the value from a pbxproj" {
-  cat > "$BATS_TEST_TMPDIR/project.pbxproj" <<'EOF'
-		buildSettings = {
-			CURRENT_PROJECT_VERSION = 1;
-			MARKETING_VERSION = 3.10.2;
-		};
+- [MOB-1] entry
 EOF
-  [ "$(project_marketing_version "$BATS_TEST_TMPDIR/project.pbxproj")" = "3.10.2" ]
+  chmod 664 "$FIXTURE"
+  before="$(ls -l "$FIXTURE" | cut -c1-10)"
+  promote_changelog "$FIXTURE" 3.11.0 2026-08-27
+  [ "$(ls -l "$FIXTURE" | cut -c1-10)" = "$before" ]
+  [ "$before" = "-rw-rw-r--" ]
 }
 
 # --- dry-run plumbing -------------------------------------------------------
@@ -278,7 +279,23 @@ EOF
   DRY_RUN=true
   run run_cmd echo hello
   [[ "$output" == *"would run: echo hello"* ]] || false
-  [[ "$output" != "hello" ]] || false
+  [ "${#lines[@]}" -eq 1 ]
+}
+
+# The one regression the description cannot reveal: describing AND executing.
+# Asserted through a side effect rather than the output, which the describe
+# line's own text would always satisfy.
+@test "run_cmd under DRY_RUN does not execute the command" {
+  DRY_RUN=true
+  run run_cmd touch "$BATS_TEST_TMPDIR/executed"
+  [ "$status" -eq 0 ]
+  [ ! -e "$BATS_TEST_TMPDIR/executed" ]
+}
+
+@test "run_cmd describes arguments re-runnably, with quoting intact" {
+  DRY_RUN=true
+  run run_cmd git commit -m "Bump version to 3.11.0 (1)"
+  [[ "$output" == *'git commit -m Bump\ version\ to\ 3.11.0\ \(1\)'* ]] || false
 }
 
 # The library must not define a function named `run`: bats provides its own,

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -101,6 +101,30 @@ make_tag_repo() {
   [ "$(repo_slug_from_url 'ssh://git@github.com/zodl-inc/zodl-ios.git')" = "zodl-inc/zodl-ios" ]
 }
 
+# --- maintenance line naming ---------------------------------------------
+
+@test "maint_line_for_version matches the remote's spelling of the line" {
+  make_tag_repo
+  git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/3.10.x HEAD
+  git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/v3.11.x HEAD
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.10.4"
+  [ "$status" -eq 0 ]
+  [ "$output" = "maint/3.10.x" ]
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.11.2"
+  [ "$output" = "maint/v3.11.x" ]
+  # A line that exists nowhere yet is named canonically, to be created.
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.12.0"
+  [ "$output" = "maint/v3.12.x" ]
+}
+
+@test "maint_line_for_version prefers the canonical v spelling when both exist" {
+  make_tag_repo
+  git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/3.10.x HEAD
+  git -C "$TAG_REPO" update-ref refs/remotes/origin/maint/v3.10.x HEAD
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; maint_line_for_version origin 3.10.4"
+  [ "$output" = "maint/v3.10.x" ]
+}
+
 # --- CHANGELOG --------------------------------------------------------------
 
 write_changelog() {

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -50,6 +50,48 @@ setup() {
   done
 }
 
+# --- tag discovery ----------------------------------------------------------
+
+# A fixture repository for the tag helpers. Its default branch is `main`; a
+# `side` branch diverges by one commit so a tag can exist without being
+# reachable from main.
+make_tag_repo() {
+  TAG_REPO="$BATS_TEST_TMPDIR/tagrepo"
+  git init -q -b main "$TAG_REPO"
+  git -C "$TAG_REPO" config tag.gpgsign false
+  git -C "$TAG_REPO" -c user.name=t -c user.email=t@t commit -q --allow-empty -m one
+}
+
+@test "release_tags_merged_into is empty, not fatal, when no release tag is reachable" {
+  make_tag_repo
+  git -C "$TAG_REPO" tag beta4-rc2
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; release_tags_merged_into HEAD"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "newest_release_tag reports the newest release tag regardless of reachability" {
+  make_tag_repo
+  git -C "$TAG_REPO" tag 3.10.2
+  git -C "$TAG_REPO" checkout -q -b side
+  git -C "$TAG_REPO" -c user.name=t -c user.email=t@t commit -q --allow-empty -m two
+  git -C "$TAG_REPO" tag 3.10.3
+  git -C "$TAG_REPO" tag not-a-release
+  git -C "$TAG_REPO" checkout -q main
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; newest_release_tag"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3.10.3" ]
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; release_tags_merged_into main | tail -1"
+  [ "$output" = "3.10.2" ]
+}
+
+@test "newest_release_tag is empty in a repo with no release tags" {
+  make_tag_repo
+  run bash -c "set -euo pipefail; . '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; cd '$TAG_REPO'; newest_release_tag"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 # --- remote URL parsing -----------------------------------------------------
 
 @test "repo_slug_from_url handles every GitHub remote form" {

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -1,0 +1,262 @@
+#!/usr/bin/env bats
+#
+# Tests for the pure text transforms and predicates in Scripts/lib/release-lib.sh.
+# Nothing here needs a network, a git remote, or a GitHub token.
+
+setup() {
+  # shellcheck source=Scripts/lib/release-lib.sh
+  . "$BATS_TEST_DIRNAME/../lib/release-lib.sh"
+  FIXTURE="$BATS_TEST_TMPDIR/CHANGELOG.md"
+}
+
+# --- version ordering -------------------------------------------------------
+
+@test "version_sort orders by version, not lexically" {
+  run bash -c ". '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; printf '3.9.5\n3.10.2\n3.10.0\n' | version_sort"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "3.9.5" ]
+  [ "${lines[1]}" = "3.10.0" ]
+  [ "${lines[2]}" = "3.10.2" ]
+}
+
+@test "version_sort ranks a pre-release below its release" {
+  run bash -c ". '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; printf '3.11.0\n3.11.0-rc.1\n' | version_sort"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "3.11.0-rc.1" ]
+  [ "${lines[1]}" = "3.11.0" ]
+}
+
+@test "version_le compares across a two-digit minor" {
+  run version_le 3.9.5 3.10.0
+  [ "$status" -eq 0 ]
+  run version_le 3.10.0 3.9.5
+  [ "$status" -ne 0 ]
+}
+
+@test "version_le is true for equal versions" {
+  run version_le 3.10.2 3.10.2
+  [ "$status" -eq 0 ]
+}
+
+# --- release tag shape ------------------------------------------------------
+
+@test "RELEASE_TAG_RE accepts X.Y.Z and rejects the repo's non-release tags" {
+  for good in 3.10.2 2.4.4 3.9.5; do
+    echo "$good" | grep -qE "$RELEASE_TAG_RE"
+  done
+  for bad in beta4-rc2 release-baseline-2026-08-08 test-0.0.1-42 3.10 v3.10.2 3.10.2-rc.1; do
+    run bash -c "echo '$bad' | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\$'"
+    [ "$status" -ne 0 ]
+  done
+}
+
+# --- remote URL parsing -----------------------------------------------------
+
+@test "repo_slug_from_url handles every GitHub remote form" {
+  [ "$(repo_slug_from_url 'git@github.com:zodl-inc/zodl-ios.git')" = "zodl-inc/zodl-ios" ]
+  [ "$(repo_slug_from_url 'https://github.com/zodl-inc/zodl-ios.git')" = "zodl-inc/zodl-ios" ]
+  [ "$(repo_slug_from_url 'https://github.com/zodl-inc/zodl-ios')" = "zodl-inc/zodl-ios" ]
+  [ "$(repo_slug_from_url 'ssh://git@github.com/zodl-inc/zodl-ios.git')" = "zodl-inc/zodl-ios" ]
+}
+
+# --- CHANGELOG --------------------------------------------------------------
+
+write_changelog() {
+  cat > "$FIXTURE"
+}
+
+@test "changelog_unreleased_nonempty is true when the section has entries" {
+  write_changelog <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- [MOB-1] Something users can see.
+
+## 3.7.3 build 1 (2026-07-12)
+- older
+EOF
+  run changelog_unreleased_nonempty "$FIXTURE"
+  [ "$status" -eq 0 ]
+}
+
+@test "changelog_unreleased_nonempty is false for an empty section" {
+  write_changelog <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## 3.7.3 build 1 (2026-07-12)
+- older
+EOF
+  run changelog_unreleased_nonempty "$FIXTURE"
+  [ "$status" -ne 0 ]
+}
+
+@test "changelog_unreleased_nonempty is false for bare subsection headings" {
+  write_changelog <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+## 3.7.3 build 1 (2026-07-12)
+- older
+EOF
+  run changelog_unreleased_nonempty "$FIXTURE"
+  [ "$status" -ne 0 ]
+}
+
+@test "changelog_unreleased_nonempty does not see the previous release's entries" {
+  write_changelog <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [3.10.2] - 2026-08-27
+- [MOB-1] Shipped already.
+EOF
+  run changelog_unreleased_nonempty "$FIXTURE"
+  [ "$status" -ne 0 ]
+}
+
+@test "promote_changelog inserts a dated heading and keeps Unreleased" {
+  write_changelog <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+- [MOB-1] Something users can see.
+
+## 3.7.3 build 1 (2026-07-12)
+- older
+EOF
+  run promote_changelog "$FIXTURE" 3.11.0 2026-08-27
+  [ "$status" -eq 0 ]
+  run cat "$FIXTURE"
+  [[ "$output" == *"## [Unreleased]"* ]]
+  [[ "$output" == *"## [3.11.0] - 2026-08-27"* ]]
+  # The entries stay where they are; only a heading is inserted above them.
+  [ "$(grep -n '## \[3.11.0\]' "$FIXTURE" | cut -d: -f1)" -lt \
+    "$(grep -n 'MOB-1' "$FIXTURE" | cut -d: -f1)" ]
+  [ "$(grep -n '## \[Unreleased\]' "$FIXTURE" | cut -d: -f1)" -lt \
+    "$(grep -n '## \[3.11.0\]' "$FIXTURE" | cut -d: -f1)" ]
+}
+
+@test "promote_changelog generates no text of its own" {
+  write_changelog <<'EOF'
+## [Unreleased]
+
+### Added
+- [MOB-1] Exactly this line.
+EOF
+  promote_changelog "$FIXTURE" 3.11.0 2026-08-27
+  [ "$(grep -c 'MOB-1' "$FIXTURE")" -eq 1 ]
+  [ "$(grep -c '^- ' "$FIXTURE")" -eq 1 ]
+}
+
+@test "promote_changelog fails and leaves the file alone without an Unreleased heading" {
+  write_changelog <<'EOF'
+# Changelog
+
+## 3.7.3 build 1 (2026-07-12)
+- older
+EOF
+  before="$(cat "$FIXTURE")"
+  run promote_changelog "$FIXTURE" 3.11.0 2026-08-27
+  [ "$status" -ne 0 ]
+  [ "$(cat "$FIXTURE")" = "$before" ]
+}
+
+@test "promote_changelog only promotes once" {
+  write_changelog <<'EOF'
+## [Unreleased]
+
+- [MOB-1] entry
+
+## [Unreleased]
+EOF
+  promote_changelog "$FIXTURE" 3.11.0 2026-08-27
+  [ "$(grep -c '## \[3.11.0\]' "$FIXTURE")" -eq 1 ]
+}
+
+@test "changelog_has_version recognises both heading formats" {
+  write_changelog <<'EOF'
+## [Unreleased]
+
+## [3.10.2] - 2026-08-27
+- newer
+
+## 3.7.3 build 1 (2026-07-12)
+- older
+EOF
+  run changelog_has_version "$FIXTURE" 3.10.2
+  [ "$status" -eq 0 ]
+  run changelog_has_version "$FIXTURE" 3.7.3
+  [ "$status" -eq 0 ]
+  run changelog_has_version "$FIXTURE" 3.11.0
+  [ "$status" -ne 0 ]
+}
+
+@test "changelog_has_version does not match a version that is a prefix of another" {
+  write_changelog <<'EOF'
+## [Unreleased]
+
+## [3.10.20] - 2026-08-27
+- newer
+EOF
+  run changelog_has_version "$FIXTURE" 3.10.2
+  [ "$status" -ne 0 ]
+}
+
+# --- project versions -------------------------------------------------------
+
+@test "project_marketing_version reads the value from a pbxproj" {
+  cat > "$BATS_TEST_TMPDIR/project.pbxproj" <<'EOF'
+		buildSettings = {
+			CURRENT_PROJECT_VERSION = 1;
+			MARKETING_VERSION = 3.10.2;
+		};
+EOF
+  [ "$(project_marketing_version "$BATS_TEST_TMPDIR/project.pbxproj")" = "3.10.2" ]
+}
+
+# --- dry-run plumbing -------------------------------------------------------
+
+@test "run_cmd executes normally and only describes under DRY_RUN" {
+  DRY_RUN=false
+  run run_cmd echo hello
+  [ "$output" = "hello" ]
+
+  DRY_RUN=true
+  run run_cmd echo hello
+  [[ "$output" == *"would run: echo hello"* ]]
+  [[ "$output" != "hello" ]]
+}
+
+# The library must not define a function named `run`: bats provides its own,
+# and shadowing it makes every `run <helper>` assertion in this file silently
+# stop capturing a status.
+@test "the library does not shadow bats' run helper" {
+  [ "$(type -t run)" = "function" ]
+  run true
+  [ "$status" -eq 0 ]
+  run false
+  [ "$status" -eq 1 ]
+}
+
+@test "die_unless_dry_run warns under DRY_RUN and exits otherwise" {
+  DRY_RUN=true
+  run die_unless_dry_run "not fatal here"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"warning: not fatal here"* ]]
+
+  run bash -c ". '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; DRY_RUN=false; die_unless_dry_run 'fatal here'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"error: fatal here"* ]]
+}

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -336,3 +336,9 @@ EOF
   [ "$status" -eq 1 ]
   [[ "$output" == *"error: fatal here"* ]] || false
 }
+
+@test "sourcing the library ignores DRY_RUN from the environment" {
+  run env DRY_RUN=1 bash -c ". '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; printf '%s' \"\$DRY_RUN\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -181,8 +181,8 @@ EOF
   run promote_changelog "$FIXTURE" 3.11.0 2026-08-27
   [ "$status" -eq 0 ]
   run cat "$FIXTURE"
-  [[ "$output" == *"## [Unreleased]"* ]]
-  [[ "$output" == *"## [3.11.0] - 2026-08-27"* ]]
+  [[ "$output" == *"## [Unreleased]"* ]] || false
+  [[ "$output" == *"## [3.11.0] - 2026-08-27"* ]] || false
   # The entries stay where they are; only a heading is inserted above them.
   [ "$(grep -n '## \[3.11.0\]' "$FIXTURE" | cut -d: -f1)" -lt \
     "$(grep -n 'MOB-1' "$FIXTURE" | cut -d: -f1)" ]
@@ -277,8 +277,8 @@ EOF
 
   DRY_RUN=true
   run run_cmd echo hello
-  [[ "$output" == *"would run: echo hello"* ]]
-  [[ "$output" != "hello" ]]
+  [[ "$output" == *"would run: echo hello"* ]] || false
+  [[ "$output" != "hello" ]] || false
 }
 
 # The library must not define a function named `run`: bats provides its own,
@@ -296,9 +296,9 @@ EOF
   DRY_RUN=true
   run die_unless_dry_run "not fatal here"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"warning: not fatal here"* ]]
+  [[ "$output" == *"warning: not fatal here"* ]] || false
 
   run bash -c ". '$BATS_TEST_DIRNAME/../lib/release-lib.sh'; DRY_RUN=false; die_unless_dry_run 'fatal here'"
   [ "$status" -eq 1 ]
-  [[ "$output" == *"error: fatal here"* ]]
+  [[ "$output" == *"error: fatal here"* ]] || false
 }

--- a/Scripts/test/release_lib.bats
+++ b/Scripts/test/release_lib.bats
@@ -269,6 +269,23 @@ EOF
   [ "$before" = "-rw-rw-r--" ]
 }
 
+# The write's status must decide the function's: before this test existed the
+# function returned the trailing rm's status, so a failed write to the
+# CHANGELOG was reported as a successful promotion.
+@test "promote_changelog fails, and changes nothing, when the file cannot be written" {
+  write_changelog <<'EOF'
+## [Unreleased]
+
+- [MOB-1] entry
+EOF
+  chmod 444 "$FIXTURE"
+  before="$(cat "$FIXTURE")"
+  run promote_changelog "$FIXTURE" 3.11.0 2026-08-27
+  chmod 644 "$FIXTURE"
+  [ "$status" -ne 0 ]
+  [ "$(cat "$FIXTURE")" = "$before" ]
+}
+
 # --- dry-run plumbing -------------------------------------------------------
 
 @test "run_cmd executes normally and only describes under DRY_RUN" {

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -12,10 +12,13 @@ refuses to build on any mismatch.
 
 | Piece | Role |
 |---|---|
+| `Scripts/prepare-release.sh` | cuts the release branches and opens the release PR (git + `gh` only) |
+| `Scripts/lib/release-lib.sh` | its text transforms and preflight predicates (unit-tested) |
 | `Scripts/release.sh`, `Scripts/bump.sh` | GNU-style CLI wrappers you run |
 | `fastlane/Fastfile` | the `release` and `bump` lanes |
 | `fastlane/lib/zodl/` | pure preflight logic (unit-tested) |
 | `fastlane/spec/*_test.rb` | tests for that logic (see [Tests](#tests-and-project-files)) |
+| `Scripts/test/*.bats` | tests for the wrapper scripts and the release library |
 | `git worktree` (temporary) | each build runs against a clean checkout of the exact ref |
 | `.claude/skills/make-builds/` | the `/make-builds` skill — runs a whole release's builds through the wrapper and announces them in Slack (see [Driving a whole run](#driving-a-whole-run-with-make-builds)) |
 
@@ -117,38 +120,54 @@ independent — a build number only has to beat that variant's own history.
 tries `<ref>` and then `origin/<ref>`), and builds it in an isolated `git
 worktree`. Your current checkout and working changes are left untouched.
 
-**1. Start a new version (in `main`).** Set and commit the marketing version, push,
-then cut the release branch:
+**1. Cut the release** with `Scripts/prepare-release.sh` (see
+[Cutting a release](#cutting-a-release) below for what it does and why):
 
 ```bash
-./Scripts/bump.sh --version 3.8.0 --build 1     # edits the project + commits
-git push                                         # push the bump commit on main
-git checkout -b release/3.8.0
-git push -u origin release/3.8.0
+./Scripts/prepare-release.sh start --dry-run upstream 3.8.0   # rehearse
+./Scripts/prepare-release.sh start upstream 3.8.0
 ```
 
-**2. Build the TestFlight pair** from the release branch — note you can run this
-from any checkout, e.g. while still on `main`:
+That leaves `release/3.8.0` and `candidate/3.8.0` on the remote, the marketing
+version and build number recorded, and a pull request open between them.
+
+**2. Build the TestFlight pair** from the **candidate** branch — note you can run
+this from any checkout, e.g. while still on `main`:
 
 ```bash
-./Scripts/release.sh --variant internal-testnet --ref release/3.8.0 --version 3.8.0 --build 1
+./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --version 3.8.0 --build 1
 ```
 
-**3. Need a fix?** Commit and push it on `release/3.8.0`, then rebuild with the next
-build number:
+`release/3.8.0` is still the *previous* release until the pull request merges,
+so building from it would ship the wrong code.
+
+**3. Need a fix?** Commit and push it on `candidate/3.8.0` — it appears in the
+pull request — then rebuild with the next build number:
 
 ```bash
-./Scripts/release.sh --variant internal-testnet --ref release/3.8.0 --version 3.8.0 --build 2
+./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --version 3.8.0 --build 2
 ```
 
 **4. Ship to the App Store** when you're happy:
 
 ```bash
-./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 1
+./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 1
 ```
 
 `appstore` is its own App Store Connect app, so its build numbers are a separate
 sequence — start from wherever that app left off.
+
+**5. Finish the release.** Merge the pull request, then tag and merge back:
+
+```bash
+git switch release/3.8.0 && git pull --ff-only upstream release/3.8.0
+git tag -s 3.8.0 -m "Release 3.8.0"
+git push upstream refs/tags/3.8.0        # this fires linear-release.yml
+```
+
+Then merge `release/3.8.0` into `maint/v3.8.x` and forward to `main`. Do not
+cherry-pick: a tag that is not reachable from a live branch stops being part of
+the history it shipped from, and the `Release Merged Back` check reports it.
 
 #### Submitting to App Review with `--submit-review`
 
@@ -173,6 +192,59 @@ Submitting to App Review:
 - Reads back promotional text and What's New per locale from App Store Connect and warns loudly if promotional text is empty where a copy was planned (this is **non-fatal and fixable in App Store Connect without a new review** — edit the missing text directly in ASC and save)
 
 The submission fails if: a version is already submitted/in review (cancel in App Store Connect first), a version is approved-awaiting-release (release it first), the requested version is already live, or any enabled App Store localization lacks a What's New entry for the version.
+
+## Cutting a release
+
+`Scripts/prepare-release.sh start <remote> <version> [<revision>]` creates the
+two branches a release runs on and opens the pull request between them:
+
+- **`release/X.Y.Z`** starts out identical to the **previous release tag**.
+- **`candidate/X.Y.Z`** starts at the revision being released (`HEAD` by
+  default), and gets the CHANGELOG promotion and the version bump on top.
+
+The pull request is `candidate/X.Y.Z → release/X.Y.Z`. Basing it on the previous
+tag is the whole point: **its diff is exactly what users receive relative to the
+last release**, rather than the intervening development history. A release
+branch cut from `main` would produce a diff against nothing anyone shipped.
+
+Everything the release needs lands on the candidate branch, so that is what you
+build and what reviewers read. `release/X.Y.Z` is not touched again until the
+pull request merges — which is what declares the release final.
+
+The script does, in order: check the tree, remote, `gh` login and version tool;
+fetch tags; find the previous release tag reachable from the revision; refuse if
+either branch already exists locally or on the remote; refuse if the CHANGELOG's
+`## [Unreleased]` section is empty or already carries a heading for this version;
+create and push `release/X.Y.Z`; create `candidate/X.Y.Z`; promote the CHANGELOG;
+set `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` across every non-test
+target; push; open the pull request.
+
+```
+Scripts/prepare-release.sh start [options] <remote> <version> [<revision>]
+  --issue <N>       release tracking issue; the PR body closes it
+  --build <N>       build number to record (default: 1)
+  --previous <tag>  base the release branch on this tag instead of the detected one
+  --dry-run         print what would happen and change nothing
+```
+
+**The version bump needs macOS.** It runs
+`.claude/skills/update-app-version/scripts/set_version.py`, which reads the Xcode
+project's object graph through `plutil`. `--dry-run` reports the requirement
+rather than refusing, so the plan can be rehearsed anywhere.
+
+`--previous` is for the case where the newest tag reachable from the revision is
+not the release you are following — a patch cut from a maintenance line while a
+newer version has already shipped from `main`.
+
+Tagging and the back-merge are steps 5 above, done by hand. The
+`Release Merged Back` check (`.github/workflows/release-merged-back.yml`) runs on
+every pull request into a maintenance branch or `main` and reports any tagged
+release branch that has not been merged back into its line. It is advisory and
+never blocks; run it locally with:
+
+```bash
+REMOTE=upstream ./.github/scripts/check-release-merged-back.sh
+```
 
 ## Always check first with `--dry-run`
 
@@ -329,7 +401,18 @@ Scripts/release.sh --variant <v> --ref <ref> --version <X.Y.Z> --build <n> [opti
   -h, --help
 
 Scripts/bump.sh --version <X.Y.Z> --build <n>
+
+Scripts/prepare-release.sh start [options] <remote> <version> [<revision>]
+  --issue <N>       release tracking issue; the PR body closes it
+  --build <N>       build number to record (default: 1)
+  --previous <tag>  base the release branch on this tag instead of the detected one
+  --dry-run         print what would happen and change nothing
+  -h, --help
 ```
+
+`Scripts/bump.sh` sets the version on whatever branch you are on;
+`Scripts/prepare-release.sh` does the same as one step of cutting a release.
+Use `bump.sh` only outside a release cut.
 
 ## Troubleshooting (preflight messages)
 
@@ -359,10 +442,16 @@ logic in `fastlane/lib/zodl/` (version parsing, the variant table, build-number
 validation, and the full reconciliation). The app's own tests are the Swift
 `zodlTests` suite and are unrelated.
 
+The `Scripts/test/*.bats` files are the same thing for the shell side:
+`release_args.bats` and `prepare_release_args.bats` cover argument parsing, and
+`release_lib.bats` covers the text transforms and predicates in
+`Scripts/lib/release-lib.sh` — version ordering, the CHANGELOG promotion, remote
+URL parsing. None of them need a network, a git remote, or a GitHub token.
+
 These tests are **not run automatically** today — there is no CI hook for them yet
 (a possible future addition). Run them by hand:
 
 ```bash
-bundle exec rake test                 # Ruby preflight logic (minitest)
-bats Scripts/test/release_args.bats   # wrapper arg parsing (needs bats-core)
+bundle exec rake test    # Ruby preflight logic (minitest)
+bats Scripts/test/       # shell scripts and the release library (needs bats-core)
 ```

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -182,8 +182,8 @@ git switch release/3.8.0 &&
 ```
 
 Then merge `release/3.8.0` into its maintenance line and forward to `main` —
-the script's closing message and the pull request body name the exact branch
-(`maint/v3.8.x`, or the line's existing spelling). Do not
+a maintenance line is always named `maint/vX.Y.x` (`maint/v3.8.x` here), and
+the script's closing message and the pull request body name it. Do not
 cherry-pick: a tag that is not reachable from a live branch stops being part of
 the history it shipped from, and the `Release Merged Back` check reports it.
 
@@ -196,11 +196,12 @@ move anything newer back under `## [Unreleased]`:
 
 ```bash
 VERSION=3.8.0
-git switch maint/v3.8.x &&
-  git pull --ff-only upstream maint/v3.8.x &&
+MAINT=maint/v${VERSION%.*}.x
+git switch "$MAINT" &&
+  git pull --ff-only upstream "$MAINT" &&
   git merge --no-ff --no-commit release/$VERSION   # --no-ff: a fast-forward would skip the pause
 git diff $VERSION -- CHANGELOG.md                  # ## [$VERSION] must match the tag exactly
-git commit && git push upstream maint/v3.8.x
+git commit && git push upstream "$MAINT"
 ```
 
 and the same again to forward the maintenance line to `main`.

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -260,8 +260,9 @@ been merged back into it first.
 Tagging and the back-merge are step 6 above, done by hand. The
 `Release Merged Back` check (`.github/workflows/release-merged-back.yml`) runs on
 every pull request into a maintenance branch or `main` and reports any tagged
-release branch that has not been merged back into its line. It is advisory and
-never blocks; run it locally with:
+release branch that has not been merged back into its line. Findings are advisory
+and never block; only the check itself failing to run (unreadable refs, a broken
+checkout) fails the job. Run it locally with:
 
 ```bash
 REMOTE=upstream ./.github/scripts/check-release-merged-back.sh

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -116,9 +116,12 @@ independent — a build number only has to beat that variant's own history.
 ## Everyday use — the release flow
 
 **You do not need to check out the branch you want to build.** Pass it to `--ref`
-(a branch, tag, or commit); the script fetches from `origin`, resolves it (it
-tries `<ref>` and then `origin/<ref>`), and builds it in an isolated `git
-worktree`. Your current checkout and working changes are left untouched.
+(a branch, tag, or commit); the script fetches from the release remote — named
+with `--remote`, default `origin` — resolves the ref, and builds it in an
+isolated `git worktree`. Your current checkout and working changes are left
+untouched. A branch resolves as `<remote>/<ref>` and must be on the remote — a
+stale local branch of the same name is never built silently; tags and commit
+SHAs may resolve locally.
 
 **1. Cut the release** with `Scripts/prepare-release.sh` (see
 [Cutting a release](#cutting-a-release) below for what it does and why):
@@ -135,8 +138,11 @@ version and build number recorded, and a pull request open between them.
 this from any checkout, e.g. while still on `main`:
 
 ```bash
-./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --version 3.8.0 --build 1
+./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --remote upstream --version 3.8.0 --build 1
 ```
+
+`--remote` names the remote the release was cut on — the one step 1 was given —
+wherever it differs from the default `origin`.
 
 `release/3.8.0` is still the *previous* release until the pull request merges,
 so building from it would ship the wrong code.
@@ -145,7 +151,7 @@ so building from it would ship the wrong code.
 pull request — then rebuild with the next build number:
 
 ```bash
-./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --version 3.8.0 --build 2
+./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --remote upstream --version 3.8.0 --build 2
 ```
 
 **4. Update What's New** before the App Store build. The App Store "What's
@@ -158,7 +164,7 @@ blocks the submission — with `--ref`, before the build even starts.
 **5. Ship to the App Store** when you're happy:
 
 ```bash
-./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 1
+./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --remote upstream --version 3.8.0 --build 1
 ```
 
 `appstore` is its own App Store Connect app, so its build numbers are a separate
@@ -205,7 +211,7 @@ After the build is uploaded and App Store Connect has processed it, you can subm
 
 With `--ref` (build in one go, then submit):
 ```bash
-./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 1 --submit-review
+./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --remote upstream --version 3.8.0 --build 1 --submit-review
 ```
 
 Without `--ref` (submit an already-uploaded build):
@@ -299,7 +305,7 @@ The preflight blocks the build if: the version doesn't match the project's
 `MARKETING_VERSION` or the version in the `release/X.Y.Z` / `candidate/X.Y.Z`
 branch name; the build number duplicates or
 is lower than the variant's latest on App Store Connect; the ref isn't on
-`origin`; `PartnerKeys.plist` is missing/invalid; Xcode doesn't match
+the release remote; `PartnerKeys.plist` is missing/invalid; Xcode doesn't match
 `.xcode-version`; or no distribution signing identity is present. It *warns* (but
 proceeds) on a build-number gap or an uncommitted working tree.
 
@@ -461,8 +467,9 @@ Use `bump.sh` only outside a release cut.
 |---|---|
 | `version … does not match project MARKETING_VERSION …` | During a release cycle you are probably building from `release/X.Y.Z`, which is still the *previous* release — pass `--ref candidate/X.Y.Z`. Outside a cut, run `bump` or pass the version the project is actually at. |
 | `build N already exists` / `is lower than the latest build` | Pick a higher number — check that variant's app in App Store Connect / TestFlight. With `--submit-review`, you can instead drop `--ref` to submit that already-uploaded build. |
-| `ref is not on origin` | `git push` the branch or commit first. |
-| `Could not resolve ref …` | The branch/tag/commit isn't on `origin` or locally — push or fetch it. |
+| `ref is not on <remote>` | `git push` the branch or commit to the release remote — the one named by `--remote` (default `origin`). |
+| `Branch … is not on <remote>` | A local branch of that name exists, but the release remote doesn't have it — push it, or pass `--remote` for the remote that does. |
+| `Could not resolve ref …` | The branch/tag/commit isn't on the release remote or locally — push or fetch it, or point `--remote` at the remote that has it. |
 | `PartnerKeys.plist is missing or invalid` | Place a valid plist at `secant/Resources/PartnerKeys.plist` (see `Scripts/validate-partner-keys.sh`). |
 | `Xcode version does not match .xcode-version` | Switch Xcode (e.g. `xcodes select`) to the pinned version, or update `.xcode-version`. |
 | `no distribution signing identity` | Ensure your Apple Distribution certificate is in the keychain — the same setup that lets you Archive manually. |

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -181,6 +181,24 @@ the script's closing message and the pull request body name the exact branch
 cherry-pick: a tag that is not reachable from a live branch stops being part of
 the history it shipped from, and the `Release Merged Back` check reports it.
 
+Make each of these merges with `--no-commit` and check the CHANGELOG before
+committing. Entries added to `## [Unreleased]` on the target branch during the
+release cycle merge **cleanly** into the published `## [3.8.0]` section — the
+promotion inserted its heading above them, so git files them below it without
+raising a conflict. The published section must be exactly what the tag shipped;
+move anything newer back under `## [Unreleased]`:
+
+```bash
+VERSION=3.8.0
+git switch maint/v3.8.x &&
+  git pull --ff-only upstream maint/v3.8.x &&
+  git merge --no-ff --no-commit release/$VERSION   # --no-ff: a fast-forward would skip the pause
+git diff $VERSION -- CHANGELOG.md                  # ## [$VERSION] must match the tag exactly
+git commit && git push upstream maint/v3.8.x
+```
+
+and the same again to forward the maintenance line to `main`.
+
 #### Submitting to App Review with `--submit-review`
 
 After the build is uploaded and App Store Connect has processed it, you can submit it for review:

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -175,7 +175,9 @@ git switch release/3.8.0 &&
   git push upstream refs/tags/3.8.0      # firing linear-release.yml is the last step
 ```
 
-Then merge `release/3.8.0` into `maint/v3.8.x` and forward to `main`. Do not
+Then merge `release/3.8.0` into its maintenance line and forward to `main` —
+the script's closing message and the pull request body name the exact branch
+(`maint/v3.8.x`, or the line's existing spelling). Do not
 cherry-pick: a tag that is not reachable from a live branch stops being part of
 the history it shipped from, and the `Release Merged Back` check reports it.
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -65,7 +65,7 @@ brew install bats-core
 ```
 
 `bats-core` is "Bash Automated Testing System" — it provides the `bats` command
-used to run `Scripts/test/release_args.bats`. It is **only** needed to run those
+used to run the suites under `Scripts/test/`. It is **only** needed to run those
 tests; you do not need it to build or ship.
 
 ### B. Secrets and inputs (per machine, but not committed)
@@ -148,7 +148,14 @@ pull request — then rebuild with the next build number:
 ./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --version 3.8.0 --build 2
 ```
 
-**4. Ship to the App Store** when you're happy:
+**4. Update What's New** before the App Store build. The App Store "What's
+New" copy does **not** come from `CHANGELOG.md` — it lives in
+`secant/Resources/WhatsNew/whatsNew*.json`: run `/update-whatsnew` for 3.8.0
+and commit the result on `candidate/3.8.0`. `--submit-review` refuses in
+preflight when a localization has no entry for the version, so a missing entry
+blocks the submission — with `--ref`, before the build even starts.
+
+**5. Ship to the App Store** when you're happy:
 
 ```bash
 ./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 1
@@ -157,12 +164,15 @@ pull request — then rebuild with the next build number:
 `appstore` is its own App Store Connect app, so its build numbers are a separate
 sequence — start from wherever that app left off.
 
-**5. Finish the release.** Merge the pull request, then tag and merge back:
+**6. Finish the release.** Mark the pull request ready for review and merge it,
+then tag and merge back — as a single chain, so a failed switch or pull cannot
+put the tag on the wrong branch:
 
 ```bash
-git switch release/3.8.0 && git pull --ff-only upstream release/3.8.0
-git tag -s 3.8.0 -m "Release 3.8.0"
-git push upstream refs/tags/3.8.0        # this fires linear-release.yml
+git switch release/3.8.0 &&
+  git pull --ff-only upstream release/3.8.0 &&
+  git tag -s 3.8.0 -m "Release 3.8.0" &&
+  git push upstream refs/tags/3.8.0      # firing linear-release.yml is the last step
 ```
 
 Then merge `release/3.8.0` into `maint/v3.8.x` and forward to `main`. Do not
@@ -175,7 +185,7 @@ After the build is uploaded and App Store Connect has processed it, you can subm
 
 With `--ref` (build in one go, then submit):
 ```bash
-./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 1 --submit-review
+./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 1 --submit-review
 ```
 
 Without `--ref` (submit an already-uploaded build):
@@ -202,7 +212,9 @@ two branches a release runs on and opens the pull request between them:
 - **`candidate/X.Y.Z`** starts at the revision being released (`HEAD` by
   default), and gets the CHANGELOG promotion and the version bump on top.
 
-The pull request is `candidate/X.Y.Z → release/X.Y.Z`. Basing it on the previous
+The pull request is `candidate/X.Y.Z → release/X.Y.Z`, opened as a **draft**;
+marking it ready for review is part of declaring the release final (and is when
+the E2E smoke suite runs, once). Basing it on the previous
 tag is the whole point: **its diff is exactly what users receive relative to the
 last release**, rather than the intervening development history. A release
 branch cut from `main` would produce a diff against nothing anyone shipped.
@@ -212,19 +224,24 @@ build and what reviewers read. `release/X.Y.Z` is not touched again until the
 pull request merges — which is what declares the release final.
 
 The script does, in order: check the tree, remote, `gh` login and version tool;
-fetch tags; find the previous release tag reachable from the revision; refuse if
+fetch tags; find the previous release tag reachable from the revision — refusing
+when a newer release tag exists that the revision does not contain; refuse if
 either branch already exists locally or on the remote; refuse if the CHANGELOG's
-`## [Unreleased]` section is empty or already carries a heading for this version;
-create and push `release/X.Y.Z`; create `candidate/X.Y.Z`; promote the CHANGELOG;
-set `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` across every non-test
-target; push; open the pull request.
+`## [Unreleased]` section *at the revision* is empty or already carries a
+heading for this version. Only then does it do the local work — create
+`release/X.Y.Z` and `candidate/X.Y.Z`, promote the CHANGELOG, set
+`MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` across every non-test
+target — and finish by pushing both branches in a single atomic push and opening
+the draft pull request. A failure anywhere before that push leaves the remote
+untouched.
 
 ```
 Scripts/prepare-release.sh start [options] <remote> <version> [<revision>]
-  --issue <N>       release tracking issue; the PR body closes it
+  --issue <N>       release tracking issue, referenced from the PR body
   --build <N>       build number to record (default: 1)
   --previous <tag>  base the release branch on this tag instead of the detected one
   --dry-run         print what would happen and change nothing
+  -h, --help
 ```
 
 **The version bump needs macOS.** It runs
@@ -234,9 +251,11 @@ rather than refusing, so the plan can be rehearsed anywhere.
 
 `--previous` is for the case where the newest tag reachable from the revision is
 not the release you are following — a patch cut from a maintenance line while a
-newer version has already shipped from `main`.
+newer version has already shipped from `main`. The tag must be an **ancestor**
+of the revision: cutting a patch requires that line's previous release to have
+been merged back into it first.
 
-Tagging and the back-merge are steps 5 above, done by hand. The
+Tagging and the back-merge are step 6 above, done by hand. The
 `Release Merged Back` check (`.github/workflows/release-merged-back.yml`) runs on
 every pull request into a maintenance branch or `main` and reports any tagged
 release branch that has not been merged back into its line. It is advisory and
@@ -252,11 +271,12 @@ Add `--dry-run` to run every preflight check and print the reconciliation summar
 **without building** — the cheap way to confirm your intent is correct:
 
 ```bash
-./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 1 --dry-run
+./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 1 --dry-run
 ```
 
 The preflight blocks the build if: the version doesn't match the project's
-`MARKETING_VERSION` or the `release/X.Y.Z` branch; the build number duplicates or
+`MARKETING_VERSION` or the version in the `release/X.Y.Z` / `candidate/X.Y.Z`
+branch name; the build number duplicates or
 is lower than the variant's latest on App Store Connect; the ref isn't on
 `origin`; `PartnerKeys.plist` is missing/invalid; Xcode doesn't match
 `.xcode-version`; or no distribution signing identity is present. It *warns* (but
@@ -403,7 +423,7 @@ Scripts/release.sh --variant <v> --ref <ref> --version <X.Y.Z> --build <n> [opti
 Scripts/bump.sh --version <X.Y.Z> --build <n>
 
 Scripts/prepare-release.sh start [options] <remote> <version> [<revision>]
-  --issue <N>       release tracking issue; the PR body closes it
+  --issue <N>       release tracking issue, referenced from the PR body
   --build <N>       build number to record (default: 1)
   --previous <tag>  base the release branch on this tag instead of the detected one
   --dry-run         print what would happen and change nothing
@@ -418,7 +438,7 @@ Use `bump.sh` only outside a release cut.
 
 | Message | Fix |
 |---|---|
-| `version … does not match project MARKETING_VERSION …` | Run `bump` first, or pass the version the project is actually at. |
+| `version … does not match project MARKETING_VERSION …` | During a release cycle you are probably building from `release/X.Y.Z`, which is still the *previous* release — pass `--ref candidate/X.Y.Z`. Outside a cut, run `bump` or pass the version the project is actually at. |
 | `build N already exists` / `is lower than the latest build` | Pick a higher number — check that variant's app in App Store Connect / TestFlight. With `--submit-review`, you can instead drop `--ref` to submit that already-uploaded build. |
 | `ref is not on origin` | `git push` the branch or commit first. |
 | `Could not resolve ref …` | The branch/tag/commit isn't on `origin` or locally — push or fetch it. |
@@ -443,10 +463,13 @@ validation, and the full reconciliation). The app's own tests are the Swift
 `zodlTests` suite and are unrelated.
 
 The `Scripts/test/*.bats` files are the same thing for the shell side:
-`release_args.bats` and `prepare_release_args.bats` cover argument parsing, and
+`release_args.bats` and `prepare_release_args.bats` cover argument parsing,
+`prepare_release_start.bats` covers the start flow against sandbox repositories,
 `release_lib.bats` covers the text transforms and predicates in
 `Scripts/lib/release-lib.sh` — version ordering, the CHANGELOG promotion, remote
-URL parsing. None of them need a network, a git remote, or a GitHub token.
+URL parsing — and `merged_back.bats` covers the Release Merged Back check
+against fixture repositories. None of them need a network, a git remote, or a
+GitHub token.
 
 These tests are **not run automatically** today — there is no CI hook for them yet
 (a possible future addition). Run them by hand:

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -204,7 +204,13 @@ git diff $VERSION -- CHANGELOG.md                  # ## [$VERSION] must match th
 git commit && git push upstream "$MAINT"
 ```
 
-and the same again to forward the maintenance line to `main`.
+and the same again to forward the maintenance line to `main`. For the first
+release of a line, `$MAINT` does not exist yet — create it from the release
+instead, which leaves only the forward-to-`main` merge:
+
+```bash
+git switch -c "$MAINT" release/$VERSION && git push -u upstream "$MAINT"
+```
 
 #### Submitting to App Review with `--submit-review`
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -309,7 +309,7 @@ One header line, then one line per build, then optional changelog lines:
 
 ```
 /make-builds
-release/3.8.0 3.8.0 2
+candidate/3.8.0 3.8.0 2
 internal-testnet
 appstore submit-review
 - Sending now works while a migration is running
@@ -368,7 +368,7 @@ Builds: internal-testnet, appstore (→ App Review)
 ```
 _iOS TestFlight Build (internal-testnet)_ — 3.8.0 (2)
 
-App: `release/3.8.0@54812f81`
+App: `candidate/3.8.0@54812f81`
 SDK: `candidate/4.1.0@cafca07a (tag: 4.1.0-rc.1)`
 ```
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -157,10 +157,14 @@ the pull request is a draft — then rebuild with the next build number:
 
 **4. Update What's New** before the App Store build. The App Store "What's
 New" copy does **not** come from `CHANGELOG.md` — it lives in
-`secant/Resources/WhatsNew/whatsNew*.json`: run `/update-whatsnew` for 3.8.0
-and commit the result on `candidate/3.8.0`. `--submit-review` refuses in
-preflight when a localization has no entry for the version, so a missing entry
-blocks the submission — with `--ref`, before the build even starts.
+`secant/Resources/WhatsNew/whatsNew*.json`: from a `candidate/3.8.0` checkout,
+run `/update-whatsnew 3.8.0` with the changelog text and commit the result on
+that branch. Name the version: invoked without one, the skill reads the
+version from the checkout, and anywhere but the candidate branch that is
+still the *previous* release — whose existing What's New entry the run would
+replace. `--submit-review` refuses in preflight when a localization has no
+entry for the version, so a missing entry blocks the submission — with
+`--ref`, before the build even starts.
 
 **5. Ship to the App Store** when you're happy:
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -148,7 +148,8 @@ wherever it differs from the default `origin`.
 so building from it would ship the wrong code.
 
 **3. Need a fix?** Commit and push it on `candidate/3.8.0` — it appears in the
-pull request — then rebuild with the next build number:
+pull request, and every push runs the full unit-test and E2E suites even while
+the pull request is a draft — then rebuild with the next build number:
 
 ```bash
 ./Scripts/release.sh --variant internal-testnet --ref candidate/3.8.0 --remote upstream --version 3.8.0 --build 2

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,6 +54,8 @@ desc "Build, sign, and upload one or more variants; optionally submit to App Rev
 lane :release do |options|
   repo_root = run("git rev-parse --show-toplevel", must_succeed: true).strip
   ref           = options[:ref].to_s
+  remote        = options[:remote].to_s
+  remote        = "origin" if remote.empty?
   version       = options.fetch(:version)
   build         = Integer(options.fetch(:build))
   dry_run       = truthy(options[:dry_run])
@@ -71,11 +73,11 @@ lane :release do |options|
 
   sha = nil
   if building
-    UI.message("Fetching latest refs from origin…")
-    # Fail closed: the preflight reconciles against origin, so a failed fetch must abort
-    # rather than silently leave the checks running on stale local refs.
-    run("git -C #{repo_root.shellescape} fetch --quiet --tags origin", must_succeed: true)
-    sha = resolve_sha(repo_root, ref)
+    UI.message("Fetching latest refs from #{remote}…")
+    # Fail closed: the preflight reconciles against the release remote, so a failed
+    # fetch must abort rather than silently leave the checks running on stale local refs.
+    run("git -C #{repo_root.shellescape} fetch --quiet --tags #{remote.shellescape}", must_succeed: true)
+    sha = resolve_sha(repo_root, ref, remote)
     branch_version = Zodl::Version.from_branch(ref)
     project_version = marketing_version_at(repo_root, sha)
     local_packages = local_packages_at(repo_root, sha)
@@ -93,7 +95,8 @@ lane :release do |options|
         project_version: project_version,
         branch_version: branch_version,
         latest_build: latest_build_number(api_key, cfg[:app_identifier], version),
-        ref_on_origin: ref_on_origin?(repo_root, sha),
+        remote: remote,
+        ref_on_remote: ref_on_remote?(repo_root, sha, remote),
         dirty_tree: dirty_tree?(repo_root),
         partner_keys_error: partner_keys_error(repo_root),
         xcode_ok: xcode_ok?(repo_root),
@@ -325,27 +328,39 @@ def set_marketing_version(version)
   File.write(path, content)
 end
 
-# Resolves a branch/tag/commit to a commit SHA. Prefers origin/<ref> so a release
-# built from a branch name uses the freshly-fetched origin tip, not a possibly-stale
-# local branch of the same name; falls back to the bare ref, which is what resolves
-# tags and commit SHAs (origin/<tag> and origin/<sha> don't exist).
-def resolve_sha(repo_root, ref)
-  ["origin/#{ref}", "#{ref}"].each do |candidate|
-    out = run("git -C #{repo_root.shellescape} rev-parse --verify --quiet #{candidate.shellescape}^{commit}").strip
-    return out unless out.empty?
+# Resolves a branch/tag/commit to a commit SHA. A branch name must resolve as
+# <remote>/<ref>: the remote was fetched a moment ago, so its tip is fresh, while
+# a same-named local branch may be stale — and silently building the stale tip is
+# how a fix someone else pushed gets left out of a release. The bare form is what
+# resolves tags and commit SHAs (<remote>/<tag> and <remote>/<sha> don't exist).
+def resolve_sha(repo_root, ref, remote)
+  remote_ref = "#{remote}/#{ref}"
+  sha = run("git -C #{repo_root.shellescape} rev-parse --verify --quiet #{remote_ref.shellescape}^{commit}").strip
+  return sha unless sha.empty?
+
+  local_branch = !run("git -C #{repo_root.shellescape} rev-parse --verify --quiet #{"refs/heads/#{ref}".shellescape}").strip.empty?
+  if local_branch
+    UI.user_error!("Branch '#{ref}' is not on '#{remote}'; a local branch of that name exists, but it may be stale. Push it, or name the remote that has it with --remote.")
   end
-  UI.user_error!("Could not resolve ref '#{ref}' (tried 'origin/#{ref}' and '#{ref}'). Fetch or push it first.")
+
+  sha = run("git -C #{repo_root.shellescape} rev-parse --verify --quiet #{ref.shellescape}^{commit}").strip
+  return sha unless sha.empty?
+
+  UI.user_error!("Could not resolve ref '#{ref}' (tried '#{remote_ref}' and '#{ref}'). Fetch or push it first.")
 end
 
-def ref_on_origin?(repo_root, sha)
-  # branch -r --contains lists only remote-tracking branches, never tags. A
-  # release built from a tag whose commit isn't on a remote branch is still on
-  # origin if the tag is pushed, so also match the sha against origin's tags
-  # (ls-remote prints the tagged commit on the ^{} line for annotated tags).
-  on_branch = !run("git -C #{repo_root.shellescape} branch -r --contains #{sha} 2>/dev/null").strip.empty?
+def ref_on_remote?(repo_root, sha, remote)
+  # branch -r --contains lists only remote-tracking branches, never tags -- and
+  # is scoped to this remote's, since a commit that only some other remote
+  # carries is not released content. A release built from a tag whose commit
+  # isn't on a remote branch is still on the remote if the tag is pushed, so
+  # also match the sha against the remote's tags (ls-remote prints the tagged
+  # commit on the ^{} line for annotated tags).
+  pattern = "#{remote}/*"
+  on_branch = !run("git -C #{repo_root.shellescape} branch -r --contains #{sha} --list #{pattern.shellescape} 2>/dev/null").strip.empty?
   return true if on_branch
 
-  run("git -C #{repo_root.shellescape} ls-remote --tags origin 2>/dev/null").lines.any? do |line|
+  run("git -C #{repo_root.shellescape} ls-remote --tags #{remote.shellescape} 2>/dev/null").lines.any? do |line|
     line.split(/\s+/).first == sha
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -17,9 +17,13 @@ Xcode identity — no keys are stored in the repo or anywhere new.
 
 ## Commands
 
+Cut a release (branches, CHANGELOG promotion, version, draft PR) — see `docs/release-automation.md`:
+
+    ./Scripts/prepare-release.sh start <remote> <X.Y.Z>
+
 Build a variant:
 
-    ./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 3
+    ./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 3
 
 `--variant` is one of `internal`, `testnet`, `appstore`, or `internal-testnet`
 (builds internal then testnet, running tests once). `--ref` is any branch, tag,
@@ -27,11 +31,11 @@ or commit.
 
 Dry run (all checks, no build):
 
-    ./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 3 --dry-run
+    ./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 3 --dry-run
 
 Build, upload, and submit to App Review in one go (`appstore` only):
 
-    ./Scripts/release.sh --variant appstore --ref release/3.8.0 --version 3.8.0 --build 3 --submit-review
+    ./Scripts/release.sh --variant appstore --ref candidate/3.8.0 --version 3.8.0 --build 3 --submit-review
 
 Submit a build that is already on App Store Connect (omit `--ref`):
 
@@ -45,7 +49,7 @@ attaches the build (replacing a wrong one), and submits with manual release —
 you still press Release in App Store Connect after approval. It refuses to run
 when a version is already in review or approved-but-unreleased.
 
-Bump the marketing version + build (the deliberate version-change step, run in `main`):
+Bump the marketing version + build (outside a release cut — `Scripts/prepare-release.sh` records the version for you when cutting one):
 
     ./Scripts/bump.sh --version 3.8.0 --build 1
 
@@ -83,4 +87,4 @@ The first notification may prompt you to allow notifications for your terminal a
 ## Tests
 
     bundle exec rake test                 # Ruby preflight logic (minitest)
-    bats Scripts/test/release_args.bats   # wrapper arg parsing
+    bats Scripts/test/                    # wrapper scripts and the release library

--- a/fastlane/lib/zodl/preflight.rb
+++ b/fastlane/lib/zodl/preflight.rb
@@ -13,7 +13,7 @@ module Zodl
     # phasing out of the standard library).
     Context = Struct.new(
       :variant, :requested_version, :requested_build, :project_version,
-      :branch_version, :latest_build, :ref_on_origin, :dirty_tree,
+      :branch_version, :latest_build, :remote, :ref_on_remote, :dirty_tree,
       :partner_keys_error, :xcode_ok, :signing_identity_ok, :local_packages,
       keyword_init: true
     )
@@ -44,7 +44,7 @@ module Zodl
       errors << bn.error if bn.error
       warnings << bn.warning if bn.warning
 
-      errors << "ref is not on origin — push it before releasing" unless ctx.ref_on_origin
+      errors << "ref is not on #{ctx.remote} — push it before releasing" unless ctx.ref_on_remote
       errors << ctx.partner_keys_error if ctx.partner_keys_error
       errors << "Xcode version does not match .xcode-version" unless ctx.xcode_ok
       errors << "no distribution signing identity found in the keychain" unless ctx.signing_identity_ok

--- a/fastlane/lib/zodl/version.rb
+++ b/fastlane/lib/zodl/version.rb
@@ -4,7 +4,12 @@ module Zodl
   # Marketing-version parsing/validation (X.Y.Z) and release-branch derivation.
   module Version
     SEMVER = /\A\d+\.\d+\.\d+\z/
-    RELEASE_BRANCH = %r{\Arelease/(\d+\.\d+\.\d+)\z}
+    # Both branches a release is built from. Scripts/prepare-release.sh cuts
+    # release/X.Y.Z from the previous tag and candidate/X.Y.Z from the revision
+    # being released, and every build during a release cycle comes from the
+    # candidate branch -- so recognising only release/ would drop the
+    # branch-against-version check exactly where it is used.
+    RELEASE_BRANCH = %r{\A(?:release|candidate)/(\d+\.\d+\.\d+)\z}
 
     module_function
 
@@ -12,7 +17,7 @@ module Zodl
       value.is_a?(String) && SEMVER.match?(value)
     end
 
-    # "release/3.8.0" -> "3.8.0"; anything else -> nil
+    # "release/3.8.0" or "candidate/3.8.0" -> "3.8.0"; anything else -> nil
     def from_branch(ref)
       match = RELEASE_BRANCH.match(ref.to_s)
       match && match[1]

--- a/fastlane/spec/preflight_test.rb
+++ b/fastlane/spec/preflight_test.rb
@@ -6,7 +6,7 @@ class ZodlPreflightTest < Minitest::Test
     base = {
       variant: "appstore", requested_version: "3.8.0", requested_build: 3,
       project_version: "3.8.0", branch_version: "3.8.0", latest_build: 2,
-      ref_on_origin: true, dirty_tree: false, partner_keys_error: nil,
+      remote: "origin", ref_on_remote: true, dirty_tree: false, partner_keys_error: nil,
       xcode_ok: true, signing_identity_ok: true
     }
     Zodl::Preflight::Context.new(**base.merge(overrides))
@@ -37,7 +37,7 @@ class ZodlPreflightTest < Minitest::Test
   end
 
   def test_unpushed_ref_blocks
-    report = Zodl::Preflight.check(facts(ref_on_origin: false))
+    report = Zodl::Preflight.check(facts(ref_on_remote: false))
     refute report.ok?
     assert(report.errors.any? { |e| e.include?("origin") })
   end

--- a/fastlane/spec/version_test.rb
+++ b/fastlane/spec/version_test.rb
@@ -19,9 +19,15 @@ class ZodlVersionTest < Minitest::Test
     assert_equal "3.8.0", Zodl::Version.from_branch("release/3.8.0")
   end
 
+  def test_from_branch_extracts_candidate_version
+    assert_equal "3.8.0", Zodl::Version.from_branch("candidate/3.8.0")
+  end
+
   def test_from_branch_returns_nil_for_non_release
     assert_nil Zodl::Version.from_branch("main")
     assert_nil Zodl::Version.from_branch("feature/release/3.8.0")
+    assert_nil Zodl::Version.from_branch("feature/candidate/3.8.0")
     assert_nil Zodl::Version.from_branch("release/3.8")
+    assert_nil Zodl::Version.from_branch("candidate/3.8")
   end
 end


### PR DESCRIPTION
Closes #2039

Adds `Scripts/prepare-release.sh`, modelled on the equivalent in
`zodl-swift-wallet-sdk`, and ports that repo family's "release merged back"
check.

## `prepare-release.sh start <remote> <version> [<revision>]`

Cuts two branches and opens the pull request between them:

- **`release/X.Y.Z`** starts out identical to the **previous release tag**.
- **`candidate/X.Y.Z`** starts at the revision being released, and gets the
  CHANGELOG promotion and the version bump on top.

Basing the release branch on the previous tag is the whole point: **the release
PR's diff is then exactly what users receive relative to the last release**,
rather than the intervening development history.

It checks the tree, remote, `gh` login and version tool; fetches tags; finds the
newest `X.Y.Z` tag reachable from the revision; refuses if either branch already
exists locally or on the remote, or if `## [Unreleased]` is empty or already
carries a heading for this version; then creates and pushes `release/X.Y.Z`,
creates `candidate/X.Y.Z`, promotes the CHANGELOG to `## [X.Y.Z] - YYYY-MM-DD`,
sets `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`, pushes, and opens the PR.

`--issue N`, `--build N` (default 1), `--previous TAG`, `--dry-run`.

The version bump delegates to `.claude/skills/update-app-version/scripts/set_version.py`
rather than reimplementing it, so target selection stays driven by the project's
object graph. That tool needs macOS; `--dry-run` reports the requirement instead
of refusing, and rehearses the whole plan anywhere.

**This changes which branch you build from.** During a release cycle
`release/X.Y.Z` is still the *previous* release, so TestFlight and App Store
builds come from `candidate/X.Y.Z`. `docs/release-automation.md` is updated
accordingly, and `fastlane/lib/zodl/version.rb` now recognises `candidate/X.Y.Z`
so the preflight's branch-against-version check applies to the branch actually
being built — previously only `MARKETING_VERSION` was checked there.

## Release Merged Back

`.github/workflows/release-merged-back.yml` runs on pull requests into a
maintenance branch or `main` and reports any tagged `release/` branch missing
from the line it belongs to. Advisory: missing from its own maintenance line
fails the job, not having reached `main` yet only warns. The maintenance line is
derived from the tag, not the branch name.

Run against this repository's refs today it reports:

```
:grey_question: `release/3.10.2` (`3.10.2`) belongs to `maint/v3.10.x`, which no longer exists; checking main only.
:white_check_mark: `release/3.10.2` (`3.10.2`) is in `main` and downstream.
:grey_question: `release/3.10.3` has no tag at its tip; not a released branch, skipped.
```

The grey question is because our maintenance branch is `maint/3.10.x` without
the `v`. Renaming it to `maint/v3.10.x` puts it back in the chain; the check
still verifies the release reached `main` in the meantime. The workflow triggers
on `maint/**` so it runs either way.

## CHANGELOG discipline

`CLAUDE.md` said every implemented task must be recorded, while the changelog's
own preamble scopes it to user-related modifications — leaving tooling, CI, tests
and refactors undecided. Replaced with the `zodl-swift-wallet-sdk` statement of
the same rules, retargeted from a library's consumers to the people who use the
app, plus an explicit list of what gets no entry. This PR takes no changelog
entry under that rule.

## Test plan

- `bats Scripts/test/` — 44 passing, including the CHANGELOG promotion against
  fixtures and a regression test that the library does not shadow bats' `run`.
- `bundle exec rake test` — 83 passing (run here as plain minitest; Ruby is not
  installed on my machine, so please confirm under the pinned toolchain).
- `shellcheck -x` clean on all three scripts; `zizmor --persona regular` clean on
  the workflow.
- `./Scripts/prepare-release.sh start --dry-run upstream 3.11.0` against current
  `main`: correctly identifies `3.10.2` as the base and warns about the absent
  `plutil` rather than failing.
- `promote_changelog` applied to the real `CHANGELOG.md`: inserts the heading,
  leaves `## [Unreleased]` in place, moves no entries.
- The merged-back check was run against the real refs of this repo,
  `zodl-swift-wallet-sdk` and `zodl-android` before committing.

**Not tested:** a real (non-dry-run) `start`, which needs macOS. The first live
release cut is the real test — do it with `--dry-run` first.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
