### PR TITLE
fix(utils): guard Array.chunked against non-positive size

### DIFF
--- a/secant/Sources/Utils/Array+Chunked.swift
+++ b/secant/Sources/Utils/Array+Chunked.swift
@@ -9,6 +9,13 @@ import Foundation
 
 extension Array {
     func chunked(into size: Int) -> [[Element]] {
+        // `stride(from:to:by:)` traps at runtime when `by` is 0
+        // ("Fatal error: Stride size must not be zero"), and a negative size is
+        // meaningless here. Guard both: a non-positive chunk size returns the
+        // whole array as a single chunk (empty stays empty) instead of crashing.
+        guard size > 0 else {
+            return isEmpty ? [] : [self]
+        }
         return stride(from: 0, to: count, by: size).map {
             Array(self[$0 ..< Swift.min($0 + size, count)])
         }

--- a/zodlTests/UtilTests/ArrayChunkedTests.swift
+++ b/zodlTests/UtilTests/ArrayChunkedTests.swift
@@ -25,6 +25,20 @@ import Testing
         #expect([Int]().chunked(into: 3) == [])
     }
 
+    @Test func chunkedWithZeroSizeReturnsWholeArrayInsteadOfTrapping() {
+        // `stride(from:to:by: 0)` traps at runtime; the guard must return the
+        // whole array as a single chunk rather than crash.
+        #expect([1, 2, 3].chunked(into: 0) == [[1, 2, 3]])
+    }
+
+    @Test func chunkedWithNegativeSizeReturnsWholeArray() {
+        #expect([1, 2, 3].chunked(into: -1) == [[1, 2, 3]])
+    }
+
+    @Test func chunkedEmptyArrayWithZeroSizeReturnsEmpty() {
+        #expect([Int]().chunked(into: 0) == [])
+    }
+
     @Test func removingDuplicatesKeepsFirstOccurrencePreservingOrder() {
         let items = [
             Item(id: 1, tag: "a"),


### PR DESCRIPTION
## What

`Array.chunked(into:)` forwards `size` straight to `stride(from:to:by:)`:

```swift
func chunked(into size: Int) -> [[Element]] {
    return stride(from: 0, to: count, by: size).map {
        Array(self[$0 ..< Swift.min($0 + size, count)])
    }
}
```

`stride(from:to:by:)` **traps at runtime when the step is `0`** — `Fatal error: Stride size must not be zero` — so `[1, 2, 3].chunked(into: 0)` crashes the app. A negative `size` is likewise meaningless here.

The existing tests cover sizes 2, 5, larger-than-count, and empty, but never a non-positive size, so the trap is uncovered. The current call sites pass static sizes, so this is a latent crash rather than a live one — but a computed chunk size that ever reaches `0` would take the wallet down.

## Fix

Guard the step before striding: a non-positive `size` returns the whole array as a single chunk (and an empty array stays `[]`), instead of trapping.

```swift
guard size > 0 else {
    return isEmpty ? [] : [self]
}
```

## Tests

Adds to `ArrayChunkedTests`:
- `chunkedWithZeroSizeReturnsWholeArrayInsteadOfTrapping` — `[1,2,3].chunked(into: 0) == [[1,2,3]]`
- `chunkedWithNegativeSizeReturnsWholeArray` — `[1,2,3].chunked(into: -1) == [[1,2,3]]`
- `chunkedEmptyArrayWithZeroSizeReturnsEmpty` — `[].chunked(into: 0) == []`

All existing chunked/removingDuplicates tests are unchanged.

## Verification

I don't have a macOS/Xcode toolchain locally, so I verified by review and reasoning and rely on the `pull-request` CI to run the `UtilTests`. The change is a single guard plus additive tests, no behavior change for any positive size. Commit is DCO signed-off per CONTRIBUTING. First-time contributor — happy to adjust the non-positive-size return shape (single-chunk vs empty) if you'd prefer a different convention.
