### PR TITLE
Deflake remaining waitUntil-polling test suites with event-driven spy signals

### DIFF
--- a/zodlTests/FlexaTests/FlexaSecurityTests.swift
+++ b/zodlTests/FlexaTests/FlexaSecurityTests.swift
@@ -163,7 +163,9 @@ import ComposableArchitecture
 
 @MainActor
 private func waitForFlexaStore(
-    timeoutNanoseconds: UInt64 = 15_000_000_000,
+    // Generous ceiling: starved CI runners have inflated trivially-fast tests to 60-120 s
+    // (unit_tests run 33367909253); the poll exits the moment the condition lands.
+    timeoutNanoseconds: UInt64 = 60_000_000_000,
     sourceLocation: SourceLocation = #_sourceLocation,
     condition: @escaping @MainActor () -> Bool
 ) async {

--- a/zodlTests/MigrationTests/MigrationBannerEntryTests.swift
+++ b/zodlTests/MigrationTests/MigrationBannerEntryTests.swift
@@ -34,7 +34,10 @@ import ComposableArchitecture
 /// Serialized: several tests here write `@Shared(.inMemory(.selectedWalletAccount))`, which is
 /// process-global — Swift Testing runs a suite's tests in parallel otherwise, and two of them
 /// installing/clearing the same account concurrently is a race, not a test.
-@Suite(.serialized) struct MigrationBannerEntryTests {
+/// `.timeLimit` records a republish that genuinely never lands as a failure — the idle wait in
+/// the reconcile test has no deadline of its own (see MigrationSweepBannerFreshnessTests' header
+/// for why wall-clock budgets were retired).
+@Suite(.serialized, .timeLimit(.minutes(3))) struct MigrationBannerEntryTests {
     private static let accountUUID = AccountUUID(id: [UInt8](repeating: 0x01, count: 16))
 
     /// Testnet NU6.3. The tip sits above it, as it does on any wallet that can see Ironwood at all.
@@ -301,20 +304,6 @@ import ComposableArchitecture
         )
     }
 
-    /// Short real-time polling for a condition driven by a concurrently-running `Task` — copied
-    /// from `MigrationSnapshotFreshnessTests`, and needed for the same reason: the republish
-    /// `reconcile()` schedules runs in a detached `Task`, so the test must wait for it to land
-    /// rather than assume it did. Sized generously for parallel test load.
-    private static func waitUntil(
-        timeoutNanoseconds: UInt64 = 10_000_000_000,
-        condition: @escaping @Sendable () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
-    }
-
     /// MOB-1749 (fix wave): what the residual screen's "Got it" exit actually depends on.
     ///
     /// `bannerVariant` is a WINDOW onto the published snapshot — it serves
@@ -367,8 +356,11 @@ import ComposableArchitecture
 
             // (c) The writer edge. `reconcile()` pushes state, which republishes the snapshot off a
             // fresh `getAccountsBalances` — now the locked shape, whose unlocked Orchard is zero.
+            // The republish is CLAIMED (coalescer `inFlight`) synchronously inside `reconcile()`,
+            // so suspending on the coalescer's own idle transition here cannot pass early — and,
+            // unlike the retired deadline poll, it takes exactly as long as the build does.
             await manager.reconcile()
-            await Self.waitUntil { manager.currentMigrationSnapshot(accountUUID: Self.accountUUID)?.banner == nil }
+            await manager.awaitSnapshotRepublishIdle(for: Self.accountUUID)
 
             let republished = manager.currentMigrationSnapshot(accountUUID: Self.accountUUID)
             #expect(republished != nil, "the republish must land a snapshot, not clear the channel")

--- a/zodlTests/MigrationTests/MigrationCoordFlowKeystoneScheduleStoreTests.swift
+++ b/zodlTests/MigrationTests/MigrationCoordFlowKeystoneScheduleStoreTests.swift
@@ -20,7 +20,10 @@ import Testing
 
 // Serialized: installs the process-global `@Shared(.inMemory(.selectedWalletAccount))` the
 // coordinator reads — the same shared-state discipline the sibling migration suites hold.
-@Suite(.serialized) @MainActor struct MigrationCoordFlowKeystoneScheduleStoreTests {
+// `.timeLimit` records a reconcile that genuinely never runs as a failure — the event-driven
+// wait below has no deadline of its own (see MigrationSweepBannerFreshnessTests' header for why
+// wall-clock budgets were retired).
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct MigrationCoordFlowKeystoneScheduleStoreTests {
     private static let accountUUID = AccountUUID(id: [UInt8](repeating: 0x0B, count: 16))
 
     private static func account() -> WalletAccount {
@@ -82,16 +85,6 @@ import Testing
         return state
     }
 
-    private func waitUntil(
-        timeoutNanoseconds: UInt64 = 5_000_000_000,
-        condition: @escaping @Sendable () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
-    }
-
     /// The P1 pin: both halves store, split positionally, and the committed schedule records —
     /// no deferral, no drop.
     @Test func lastRoundStoresBothHalvesAndRecordsTheSchedule() async {
@@ -101,7 +94,7 @@ import Testing
         let storedPreps = LockIsolated<[MigrationSignedTransferPczt]>([])
         let storedSchedule = LockIsolated<[MigrationSignedTransferPczt]>([])
         let recordedSchedules = LockIsolated<Int>(0)
-        let reconciles = LockIsolated<Int>(0)
+        let reconciles = SignalledRecords<Void>()
 
         let store = TestStore(initialState: Self.makeState()) {
             MigrationCoordFlow()
@@ -110,7 +103,7 @@ import Testing
 
             var client = MigrationManagerClient.noOp
             client.recordCommittedSchedule = { _, _ in recordedSchedules.withValue { $0 += 1 } }
-            client.reconcile = { reconciles.withValue { $0 += 1 } }
+            client.reconcile = { reconciles.recordCall() }
             client.armNextWindowNotifications = { _ in }
             client.migrationSummary = { _ in MigrationSummary.zero }
             $0.migrationManager = client
@@ -140,14 +133,14 @@ import Testing
                 guard case .keystoneSigningSubmitted = action else { return false }
                 return true
             },
-            timeout: .seconds(5)
+            timeout: .seconds(30)
         )
 
         #expect(storedPreps.value.map(\.id) == [0], "the preparation half stores by position")
         #expect(storedSchedule.value.map(\.id) == [4], "the schedule half stores by position — the audit's dropped payload")
         #expect(recordedSchedules.value == 1, "the committed schedule records exactly once")
-        await waitUntil { reconciles.value >= 1 }
-        #expect(reconciles.value >= 1, "reconcile runs after the stores")
+        await reconciles.countReached(1)
+        #expect(reconciles.count >= 1, "reconcile runs after the stores")
 
         await store.skipReceivedActions(strict: false)
         await store.skipInFlightEffects(strict: false)
@@ -197,7 +190,7 @@ import Testing
                 guard case .keystoneScanAbandoned = action else { return false }
                 return true
             },
-            timeout: .seconds(5)
+            timeout: .seconds(30)
         )
 
         #expect(recordedSchedules.value == 0, "a failed store must never record the schedule as committed")

--- a/zodlTests/MigrationTests/MigrationStatusRefreshPulseTests.swift
+++ b/zodlTests/MigrationTests/MigrationStatusRefreshPulseTests.swift
@@ -25,9 +25,12 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite(.serialized) @MainActor struct MigrationStatusRefreshPulseTests {
+// `.timeLimit` records a pulse that genuinely never fires as a failure — the event-driven waits
+// below have no deadline of their own (see MigrationSweepBannerFreshnessTests' header for why
+// wall-clock budgets were retired).
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct MigrationStatusRefreshPulseTests {
     private static func store(
-        refreshCount: LockIsolated<Int>,
+        refreshCount: SignalledRecords<Void>,
         testClock: TestClock<Swift.Duration>
     ) -> TestStoreOf<MigrationStatus> {
         let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
@@ -38,7 +41,7 @@ import ComposableArchitecture
 
             var client = MigrationManagerClient.noOp
             client.refreshMigrationSnapshot = { _ in
-                refreshCount.withValue { $0 += 1 }
+                refreshCount.recordCall()
             }
             client.currentMigrationSnapshot = { _ in nil }
             client.migrationSnapshotEvents = { _ in Empty().eraseToAnyPublisher() }
@@ -50,44 +53,30 @@ import ComposableArchitecture
         return store
     }
 
-    /// Bounded real-time polling for a condition driven by the store's own in-flight effects —
-    /// advancing a `TestClock` resumes suspended sleepers but does not itself guarantee the
-    /// resulting action has propagated by the time `advance(by:)` returns. Same helper shape as
-    /// `RootMigrationTickLoopTests`.
-    private func waitUntil(
-        timeoutNanoseconds: UInt64 = 5_000_000_000,
-        condition: @escaping @Sendable () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
-    }
-
     /// THE requirement (Michal, 2026-08-02): an OPEN progress screen re-derives on the pulse —
     /// never only on events, and never only on reopen. First pulse a full 30s after `onAppear`
     /// (whose own re-verify kick just ran; an immediate pulse would only race it), then every 30s
     /// for as long as the screen stays up.
     @Test func anOpenScreenReDerivesEveryThirtySeconds() async {
-        let refreshCount = LockIsolated(0)
+        let refreshCount = SignalledRecords<Void>()
         let testClock = TestClock()
         let store = Self.store(refreshCount: refreshCount, testClock: testClock)
 
         await store.send(.onAppear)
-        await waitUntil { refreshCount.value == 1 }
-        #expect(refreshCount.value == 1, "onAppear's own re-verify kick, exactly once")
+        await refreshCount.countReached(1)
+        #expect(refreshCount.count == 1, "onAppear's own re-verify kick, exactly once")
 
         await testClock.advance(by: .seconds(29))
         try? await Task.sleep(nanoseconds: 150_000_000)
-        #expect(refreshCount.value == 1, "no pulse before a full 30s has elapsed")
+        #expect(refreshCount.count == 1, "no pulse before a full 30s has elapsed")
 
         await testClock.advance(by: .seconds(1))
-        await waitUntil { refreshCount.value == 2 }
-        #expect(refreshCount.value == 2, "the first pulse fires at 30s")
+        await refreshCount.countReached(2)
+        #expect(refreshCount.count == 2, "the first pulse fires at 30s")
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { refreshCount.value == 3 }
-        #expect(refreshCount.value == 3, "and keeps firing every 30s while the screen is open")
+        await refreshCount.countReached(3)
+        #expect(refreshCount.count == 3, "and keeps firing every 30s while the screen is open")
 
         await store.skipReceivedActions(strict: false)
         await store.skipInFlightEffects(strict: false)
@@ -98,22 +87,22 @@ import ComposableArchitecture
     /// was gone — hundreds of TCA missing-element warnings per session, and a busy-loop of loads
     /// for a screen nobody could see.
     @Test func onDisappearStopsThePulse() async {
-        let refreshCount = LockIsolated(0)
+        let refreshCount = SignalledRecords<Void>()
         let testClock = TestClock()
         let store = Self.store(refreshCount: refreshCount, testClock: testClock)
 
         await store.send(.onAppear)
-        await waitUntil { refreshCount.value == 1 }
+        await refreshCount.countReached(1)
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { refreshCount.value == 2 }
-        #expect(refreshCount.value == 2, "the pulse runs while the screen is up")
+        await refreshCount.countReached(2)
+        #expect(refreshCount.count == 2, "the pulse runs while the screen is up")
 
         await store.send(.onDisappear)
 
         await testClock.advance(by: .seconds(120))
         try? await Task.sleep(nanoseconds: 150_000_000)
-        #expect(refreshCount.value == 2, "no pulse may fire after the screen has gone")
+        #expect(refreshCount.count == 2, "no pulse may fire after the screen has gone")
 
         await store.skipReceivedActions(strict: false)
         await store.skipInFlightEffects(strict: false)
@@ -122,13 +111,13 @@ import ComposableArchitecture
     /// The pulse belongs to the screen's lifecycle: before `onAppear`, no clock movement may ask
     /// for anything.
     @Test func noPulseBeforeTheScreenAppears() async {
-        let refreshCount = LockIsolated(0)
+        let refreshCount = SignalledRecords<Void>()
         let testClock = TestClock()
         let store = Self.store(refreshCount: refreshCount, testClock: testClock)
 
         await testClock.advance(by: .seconds(600))
         try? await Task.sleep(nanoseconds: 150_000_000)
-        #expect(refreshCount.value == 0, "no screen, no pulse")
+        #expect(refreshCount.count == 0, "no screen, no pulse")
 
         await store.skipReceivedActions(strict: false)
         await store.skipInFlightEffects(strict: false)
@@ -139,7 +128,7 @@ import ComposableArchitecture
     /// captions age with the wall clock whether or not the automatic loop exists. If someone later
     /// wires the pulse to the switch, this is the test that names the decision they are reversing.
     @Test func thePulseStillFiresWithTheTickLoopSwitchedOff() async {
-        let refreshCount = LockIsolated(0)
+        let refreshCount = SignalledRecords<Void>()
         let testClock = TestClock()
         let store = TestStore(initialState: MigrationStatus.State(presentation: .resume)) {
             MigrationStatus()
@@ -150,7 +139,7 @@ import ComposableArchitecture
 
             var client = MigrationManagerClient.noOp
             client.refreshMigrationSnapshot = { _ in
-                refreshCount.withValue { $0 += 1 }
+                refreshCount.recordCall()
             }
             client.currentMigrationSnapshot = { _ in nil }
             client.migrationSnapshotEvents = { _ in Empty().eraseToAnyPublisher() }
@@ -161,11 +150,11 @@ import ComposableArchitecture
         store.exhaustivity = .off
 
         await store.send(.onAppear)
-        await waitUntil { refreshCount.value == 1 }
+        await refreshCount.countReached(1)
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { refreshCount.value == 2 }
-        #expect(refreshCount.value == 2, "the pulse is not the tick loop and must survive its off switch")
+        await refreshCount.countReached(2)
+        #expect(refreshCount.count == 2, "the pulse is not the tick loop and must survive its off switch")
 
         await store.skipReceivedActions(strict: false)
         await store.skipInFlightEffects(strict: false)

--- a/zodlTests/MigrationTests/MigrationSweepBannerFreshnessTests.swift
+++ b/zodlTests/MigrationTests/MigrationSweepBannerFreshnessTests.swift
@@ -11,8 +11,30 @@
 //  retires.
 //
 //  Fixture conventions mirror MigrationSnapshotFreshnessTests (fixed-bytes AccountUUID, the tip/
-//  activation pair, `withDependencies`, `waitUntil` real-time polling, `.serialized` because the
-//  wallet-wide candidate set rides `@Shared(.inMemory(...))`).
+//  activation pair, `withDependencies`, `.serialized` because the wallet-wide candidate set rides
+//  `@Shared(.inMemory(...))`) — including its event-driven waits: `firstSnapshot(of:matching:
+//  storingIn:afterSubscribing:)` suspends until the expected snapshot is actually published, and
+//  `MigrationManagerImpl.awaitSnapshotRepublishIdle(for:)` suspends until the republish coalescer
+//  itself clears. An earlier version of THIS suite polled both conditions against a wall-clock
+//  deadline (`waitUntil`, 10 s) — the very pattern that sibling had already retired — and CI
+//  re-proved why: at the contended tail of a full parallel run a coalesced build that takes 0.07 s
+//  uncontended lost the fixed 10 s budget, so the precondition read `banner == nil` while the
+//  build was still queued (unit_tests runs 33360721267 and 33367930400, same failure on two
+//  branches). The event-driven waits scale with however long the build actually takes under load.
+//
+//  `.timeLimit` is a hang RECORDER, not a deadline the tests race: the waits themselves have no
+//  budget, so a coalescer that genuinely never publishes or never idles is reported as a failure
+//  at the limit instead of the run sitting in-progress until the CI job's own timeout. Two minutes
+//  where the sibling records at one: the immediate-sweep chain crosses two writer edges plus
+//  `reconcile()`, so a starved runner stacks more sequential builds into one test here.
+//
+//  One clock remains outside this file's control (the sibling documents the same for its lock
+//  test): `recordTransferBroadcast`'s awaited republish carries the PRODUCTION
+//  `lockRepublishTimeoutNanoseconds` bound (10 s), so under starvation extreme enough that bound
+//  can expire and the chain returns early by design — `theSweepSuccessChainOutrunsItsOwnRepublish`
+//  reads the banner immediately after the chain on purpose and would see the stale residual then.
+//  A recurrence there is that production bound doing its job under an even worse runner, not a
+//  deadline these waits reintroduce.
 //
 
 import Foundation
@@ -22,7 +44,7 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite(.serialized) struct MigrationSweepBannerFreshnessTests {
+@Suite(.serialized, .timeLimit(.minutes(2))) struct MigrationSweepBannerFreshnessTests {
     private static let accountUUID = AccountUUID(id: [UInt8](repeating: 0x5A, count: 16))
     private static let activationHeight: BlockHeight = 4_134_000
     private static let tip: BlockHeight = 4_200_000
@@ -106,13 +128,25 @@ import ComposableArchitecture
         return MigrationScheduleStorage(userDefaults: defaults)
     }
 
-    private static func waitUntil(
-        timeoutNanoseconds: UInt64 = 10_000_000_000,
-        condition: @escaping @Sendable () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
-            try? await Task.sleep(nanoseconds: 5_000_000)
+    /// Suspends until `publisher` emits a snapshot matching `predicate`, resumed by the emission
+    /// itself instead of polled against a wall-clock deadline — the sibling
+    /// MigrationSnapshotFreshnessTests' helper, replicated per this file's self-contained fixture
+    /// convention; see its header for why the deadline version proved flaky under CI load.
+    /// `afterSubscribing` runs the writer edge expected to produce the match from INSIDE the same
+    /// synchronous setup `withCheckedContinuation` runs, so the subscription is always live before
+    /// that edge's build can possibly publish.
+    private static func firstSnapshot(
+        of publisher: AnyPublisher<MigrationViewSnapshot?, Never>,
+        matching predicate: @escaping @Sendable (MigrationViewSnapshot?) -> Bool,
+        storingIn cancellables: inout Set<AnyCancellable>,
+        afterSubscribing trigger: () -> Void
+    ) async -> MigrationViewSnapshot? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<MigrationViewSnapshot?, Never>) in
+            publisher
+                .first(where: predicate)
+                .sink { snapshot in continuation.resume(returning: snapshot) }
+                .store(in: &cancellables)
+            trigger()
         }
     }
 
@@ -135,19 +169,23 @@ import ComposableArchitecture
         } operation: {
             let manager = MigrationManagerImpl(scheduleStorage: Self.makeEmptyScheduleStorage())
 
-            let received = LockIsolated<MigrationViewSnapshot?>(nil)
             var cancellables = Set<AnyCancellable>()
-            manager.migrationSnapshotEvents(accountUUID: Self.accountUUID)
-                .sink { snapshot in received.setValue(snapshot) }
-                .store(in: &cancellables)
-
-            manager.refreshMigrationSnapshot(accountUUID: Self.accountUUID)
-            await Self.waitUntil { received.value?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)) }
+            let preSweepSnapshot = await Self.firstSnapshot(
+                of: manager.migrationSnapshotEvents(accountUUID: Self.accountUUID),
+                matching: { $0?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)) },
+                storingIn: &cancellables
+            ) {
+                manager.refreshMigrationSnapshot(accountUUID: Self.accountUUID)
+            }
             #expect(
-                received.value?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)),
+                preSweepSnapshot?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)),
                 "precondition: the pre-sweep snapshot advertises the residual"
             )
-            await Self.waitUntil { manager.isSnapshotRepublishIdle(for: Self.accountUUID) }
+            // Two builds are queued above (the subscription's, and the refresh's coalesced
+            // follow-up); the wait above lands on the first publish, so the second can still be
+            // running. Suspend until the coalescer itself clears — the sweep below must start
+            // UNCONTENDED, or its awaited republish would coalesce into a pre-sweep build.
+            await manager.awaitSnapshotRepublishIdle(for: Self.accountUUID)
 
             // The sweep broadcast lands — from here on the SDK reports the immediate run.
             isSwept.setValue(true)
@@ -159,11 +197,9 @@ import ComposableArchitecture
             )
             await manager.reconcile()
 
-            await Self.waitUntil { manager.isSnapshotRepublishIdle(for: Self.accountUUID) }
-            #expect(
-                manager.isSnapshotRepublishIdle(for: Self.accountUUID),
-                "quiescence precondition timed out — raise waitUntil's deadline before suspecting the product"
-            )
+            // Quiescence before the published-value reads: resumed by the coalescer's own idle
+            // transition, so there is no deadline to time out under load.
+            await manager.awaitSnapshotRepublishIdle(for: Self.accountUUID)
 
             let published = manager.currentMigrationSnapshot(accountUUID: Self.accountUUID)
             #expect(
@@ -209,19 +245,19 @@ import ComposableArchitecture
         } operation: {
             let manager = MigrationManagerImpl(scheduleStorage: Self.makeEmptyScheduleStorage())
 
-            let received = LockIsolated<MigrationViewSnapshot?>(nil)
             var cancellables = Set<AnyCancellable>()
-            manager.migrationSnapshotEvents(accountUUID: Self.accountUUID)
-                .sink { snapshot in received.setValue(snapshot) }
-                .store(in: &cancellables)
-
-            manager.refreshMigrationSnapshot(accountUUID: Self.accountUUID)
-            await Self.waitUntil { received.value?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)) }
+            let preSweepSnapshot = await Self.firstSnapshot(
+                of: manager.migrationSnapshotEvents(accountUUID: Self.accountUUID),
+                matching: { $0?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)) },
+                storingIn: &cancellables
+            ) {
+                manager.refreshMigrationSnapshot(accountUUID: Self.accountUUID)
+            }
             #expect(
-                received.value?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)),
+                preSweepSnapshot?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)),
                 "precondition: the pre-sweep snapshot advertises the residual"
             )
-            await Self.waitUntil { manager.isSnapshotRepublishIdle(for: Self.accountUUID) }
+            await manager.awaitSnapshotRepublishIdle(for: Self.accountUUID)
 
             isSwept.setValue(true)
 
@@ -240,7 +276,7 @@ import ComposableArchitecture
             )
 
             // Drain the delayed build so it cannot leak into the next test.
-            await Self.waitUntil { manager.isSnapshotRepublishIdle(for: Self.accountUUID) }
+            await manager.awaitSnapshotRepublishIdle(for: Self.accountUUID)
         }
     }
 
@@ -269,19 +305,19 @@ import ComposableArchitecture
         } operation: {
             let manager = MigrationManagerImpl(scheduleStorage: Self.makeEmptyScheduleStorage())
 
-            let received = LockIsolated<MigrationViewSnapshot?>(nil)
             var cancellables = Set<AnyCancellable>()
-            manager.migrationSnapshotEvents(accountUUID: Self.accountUUID)
-                .sink { snapshot in received.setValue(snapshot) }
-                .store(in: &cancellables)
-
-            manager.refreshMigrationSnapshot(accountUUID: Self.accountUUID)
-            await Self.waitUntil { received.value?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)) }
+            let preSweepSnapshot = await Self.firstSnapshot(
+                of: manager.migrationSnapshotEvents(accountUUID: Self.accountUUID),
+                matching: { $0?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)) },
+                storingIn: &cancellables
+            ) {
+                manager.refreshMigrationSnapshot(accountUUID: Self.accountUUID)
+            }
             #expect(
-                received.value?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)),
+                preSweepSnapshot?.banner == MigrationBannerVariant.residual(amount: Zatoshi(800_000)),
                 "precondition: the pre-sweep snapshot advertises the residual"
             )
-            await Self.waitUntil { manager.isSnapshotRepublishIdle(for: Self.accountUUID) }
+            await manager.awaitSnapshotRepublishIdle(for: Self.accountUUID)
 
             isSwept.setValue(true)
 
@@ -291,7 +327,7 @@ import ComposableArchitecture
             )
             await manager.reconcile()
 
-            await Self.waitUntil { manager.isSnapshotRepublishIdle(for: Self.accountUUID) }
+            await manager.awaitSnapshotRepublishIdle(for: Self.accountUUID)
 
             let reread = await manager.bannerVariant(accountUUID: Self.accountUUID)
             #expect(

--- a/zodlTests/MigrationTests/MigrationTickDriverTests.swift
+++ b/zodlTests/MigrationTests/MigrationTickDriverTests.swift
@@ -33,7 +33,10 @@ import ComposableArchitecture
 // `MigrationDerivations.candidateAccountUUIDs` reads off `MigrationManagerImpl` — the same
 // process-global state `MigrationSyncCompleteEdgeTests`/`RootMigrationGateRefusalTests` serialize
 // their own suites over.
-@Suite(.serialized) struct MigrationTickDriverTests {
+// `.timeLimit` records an advance that genuinely never starts (or a gate never opened) as a
+// failure — the event-driven waits below have no deadline of their own (see
+// MigrationSweepBannerFreshnessTests' header for why wall-clock budgets were retired).
+@Suite(.serialized, .timeLimit(.minutes(3))) struct MigrationTickDriverTests {
     // MARK: - Fixtures
 
     private static let accountUUID = AccountUUID(id: [UInt8](repeating: 0x07, count: 16))
@@ -144,20 +147,6 @@ import ComposableArchitecture
             clearDeliveredMigrationNotifications: { },
             pendingMigrationNotifications: { [] }
         )
-    }
-
-    /// Short, repeated real-time polling for a condition driven by a concurrently-running `Task` —
-    /// mirrors `MigrationSyncCompleteEdgeTests`'s `waitUntil`, needed here to know a blocked
-    /// `advance` call has genuinely reached (and is parked inside) its engine read before this test
-    /// starts a second, concurrent call and makes claims about what that second call did or didn't do.
-    private static func waitUntil(
-        timeoutNanoseconds: UInt64 = 5_000_000_000,
-        condition: @escaping @Sendable () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
     }
 
     // MARK: - The mode belt
@@ -1227,8 +1216,8 @@ import ComposableArchitecture
     @Test func tickDuringAnInFlightAdvanceSkipsWithoutReadingTheEngine() async {
         Self.installCandidateAccount()
         let engineReadCount = LockIsolated<Int>(0)
-        let firstReadStarted = LockIsolated<Bool>(false)
-        let releaseFirstRead = LockIsolated<Bool>(false)
+        let firstReadStarted = SignalledRecords<Void>()
+        let releaseFirstRead = ResumableGate()
 
         await withDependencies {
             $0.sdkSynchronizer = .mocked(
@@ -1236,10 +1225,8 @@ import ComposableArchitecture
                 isSyncing: { false },
                 migrationAdvanceStep: { _ in
                     engineReadCount.withValue { $0 += 1 }
-                    firstReadStarted.setValue(true)
-                    while !releaseFirstRead.value {
-                        try? await Task.sleep(nanoseconds: 5_000_000)
-                    }
+                    firstReadStarted.recordCall()
+                    await releaseFirstRead.wait()
                     return MigrationAdvance(step: .waiting, next: nil)
                 }
             )
@@ -1253,13 +1240,13 @@ import ComposableArchitecture
             )
 
             let firstTask = Task { await manager.advance(phase: .beforeSync) }
-            await Self.waitUntil { firstReadStarted.value }
+            await firstReadStarted.countReached(1)
 
             let tickVerdict = await manager.advance(phase: .tick)
             #expect(tickVerdict == .skipped)
             #expect(engineReadCount.value == 1, "a skipped tick must not read the engine at all")
 
-            releaseFirstRead.setValue(true)
+            releaseFirstRead.open()
             _ = await firstTask.value
         }
     }
@@ -1269,8 +1256,8 @@ import ComposableArchitecture
     @Test func beforeSyncDuringAnInFlightAdvanceWaitsThenRuns() async {
         Self.installCandidateAccount()
         let engineReadCount = LockIsolated<Int>(0)
-        let firstReadStarted = LockIsolated<Bool>(false)
-        let releaseFirstRead = LockIsolated<Bool>(false)
+        let firstReadStarted = SignalledRecords<Void>()
+        let releaseFirstRead = ResumableGate()
 
         await withDependencies {
             $0.sdkSynchronizer = .mocked(
@@ -1282,10 +1269,8 @@ import ComposableArchitecture
                         return count
                     }
                     if thisRead == 1 {
-                        firstReadStarted.setValue(true)
-                        while !releaseFirstRead.value {
-                            try? await Task.sleep(nanoseconds: 5_000_000)
-                        }
+                        firstReadStarted.recordCall()
+                        await releaseFirstRead.wait()
                     }
                     return MigrationAdvance(step: .waiting, next: nil)
                 }
@@ -1302,7 +1287,7 @@ import ComposableArchitecture
             )
 
             let firstTask = Task { await manager.advance(phase: .beforeSync) }
-            await Self.waitUntil { firstReadStarted.value }
+            await firstReadStarted.countReached(1)
 
             let secondTask = Task { await manager.advance(phase: .afterSync) }
             // The second call must be genuinely PARKED, not running concurrently — prove it has not
@@ -1311,7 +1296,7 @@ import ComposableArchitecture
             try? await Task.sleep(nanoseconds: 100_000_000)
             #expect(engineReadCount.value == 1, "the second call must be parked behind the latch, not running concurrently")
 
-            releaseFirstRead.setValue(true)
+            releaseFirstRead.open()
             let firstVerdict = await firstTask.value
             let secondVerdict = await secondTask.value
 

--- a/zodlTests/RootTransactionsTests/RootPendingTransactionRefreshTests.swift
+++ b/zodlTests/RootTransactionsTests/RootPendingTransactionRefreshTests.swift
@@ -37,7 +37,11 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor struct RootPendingTransactionRefreshTests {
+// Three minutes, not one: the deliberately-unbounded pumps below are backstopped by this limit
+// alone, and a starved CI runner blew the 1-minute version on a healthy test (unit_tests run
+// 33371909793 — `cancellingThePollerPreventsAnyLaterTick`, ~16 s on an ordinary run). Sized above
+// the ~120 s worst healthy inflation observed fleet-wide.
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootPendingTransactionRefreshTests {
     private static func walletAccount(idByte: UInt8) -> WalletAccount {
         WalletAccount(
             Account(

--- a/zodlTests/RootTransactionsTests/RootSendCompletionRefreshTests.swift
+++ b/zodlTests/RootTransactionsTests/RootSendCompletionRefreshTests.swift
@@ -24,7 +24,10 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor struct RootSendCompletionRefreshTests {
+// Three minutes, not one — same rationale as RootPendingTransactionRefreshTests: the unbounded
+// pumps are backstopped by this limit alone, and starved CI runners have inflated healthy tests
+// past the 1-minute version (~120 s worst observed fleet-wide).
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootSendCompletionRefreshTests {
     private static func walletAccount(idByte: UInt8) -> WalletAccount {
         WalletAccount(
             Account(

--- a/zodlTests/TestSupport/TestSignals.swift
+++ b/zodlTests/TestSupport/TestSignals.swift
@@ -1,0 +1,129 @@
+//
+//  TestSignals.swift
+//  zodlTests
+//
+//  Event-driven wait primitives for test spies — the replacement for polling `LockIsolated`
+//  spies against wall-clock deadlines (the retired `waitUntil` helpers), which lose to starved
+//  CI runners: see MigrationSweepBannerFreshnessTests' header for the observed failures and the
+//  pattern's history. `MigrationSyncCompleteEdgeTests`' AsyncStream spy is the same idea for a
+//  first-occurrence wait; these types cover the general case — multiple sequential awaits over
+//  one spy's whole history, and gates mocked closures park on.
+//
+//  The waits here have NO deadline, deliberately: they scale with however long the awaited work
+//  actually takes under load. A suite adopting them should carry `.timeLimit` so a wait that
+//  genuinely never fires is RECORDED as a failure instead of running until the CI job's own
+//  timeout.
+//
+
+import Foundation
+import os
+
+/// Spy storage whose writes resume awaiting readers. `record(_:)` appends and resumes every
+/// waiter whose predicate the updated history now satisfies; `recorded(where:)` checks and
+/// registers under the SAME lock the writer takes, so a record landing between "check" and
+/// "register" can never strand a waiter (the `awaitSnapshotRepublishIdle` discipline).
+/// Predicates run under that lock — keep them cheap and side-effect free.
+final class SignalledRecords<Element: Sendable>: @unchecked Sendable {
+    private struct Waiter {
+        let predicate: @Sendable ([Element]) -> Bool
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private let state: OSAllocatedUnfairLock<(records: [Element], waiters: [Waiter])>
+
+    init() {
+        state = OSAllocatedUnfairLock(uncheckedState: (records: [], waiters: []))
+    }
+
+    var values: [Element] { state.withLockUnchecked { $0.records } }
+    var count: Int { state.withLockUnchecked { $0.records.count } }
+
+    /// Appends `element`, resumes every waiter the updated history now satisfies, and returns
+    /// the new record count (this call's ordinal, for mocks that branch on it).
+    @discardableResult
+    func record(_ element: Element) -> Int {
+        let (resumed, count) = state.withLockUnchecked { state -> ([CheckedContinuation<Void, Never>], Int) in
+            state.records.append(element)
+            let records = state.records
+            var kept: [Waiter] = []
+            var satisfied: [CheckedContinuation<Void, Never>] = []
+            for waiter in state.waiters {
+                if waiter.predicate(records) {
+                    satisfied.append(waiter.continuation)
+                } else {
+                    kept.append(waiter)
+                }
+            }
+            state.waiters = kept
+            return (satisfied, records.count)
+        }
+        resumed.forEach { $0.resume() }
+        return count
+    }
+
+    /// Suspends until the recorded history satisfies `predicate` — resumed by the `record` call
+    /// that makes it true, immediately if it already does.
+    func recorded(where predicate: @escaping @Sendable ([Element]) -> Bool) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let alreadySatisfied = state.withLockUnchecked { state -> Bool in
+                if predicate(state.records) {
+                    return true
+                }
+                state.waiters.append(Waiter(predicate: predicate, continuation: continuation))
+                return false
+            }
+            if alreadySatisfied {
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Suspends until at least `threshold` records exist.
+    func countReached(_ threshold: Int) async {
+        await recorded(where: { $0.count >= threshold })
+    }
+}
+
+extension SignalledRecords where Element == Void {
+    /// Counter sugar for spies that only count calls — returns this call's ordinal.
+    @discardableResult
+    func recordCall() -> Int {
+        record(())
+    }
+}
+
+/// A latching gate mocked closures park on: `wait()` suspends until `open()`, and once opened,
+/// later waits return immediately. Replaces `while !flag.value { try? await Task.sleep(...) }`
+/// busy-polls inside mocks, which burn the very cooperative pool a loaded test run is starving.
+final class ResumableGate: @unchecked Sendable {
+    private let state: OSAllocatedUnfairLock<(isOpen: Bool, waiters: [CheckedContinuation<Void, Never>])>
+
+    init() {
+        state = OSAllocatedUnfairLock(uncheckedState: (isOpen: false, waiters: []))
+    }
+
+    func wait() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let isOpen = state.withLockUnchecked { state -> Bool in
+                if state.isOpen {
+                    return true
+                }
+                state.waiters.append(continuation)
+                return false
+            }
+            if isOpen {
+                continuation.resume()
+            }
+        }
+    }
+
+    func open() {
+        let resumed = state.withLockUnchecked { state -> [CheckedContinuation<Void, Never>] in
+            state.isOpen = true
+            let waiters = state.waiters
+            state.waiters = []
+            return waiters
+        }
+        resumed.forEach { $0.resume() }
+    }
+}

--- a/zodlTests/UtilTests/RootInitializeSDKSingleFlightTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKSingleFlightTests.swift
@@ -25,8 +25,10 @@ import Testing
 //
 // `.initialSetups` logs through the process-global `LoggerProxy`, and the effects under test
 // mutate TCA `@Shared` in-memory state (`walletStatus`, `walletAccounts`), so this suite is
-// serialized per repo convention.
-@Suite(.serialized) @MainActor struct RootInitializeSDKSingleFlightTests {
+// serialized per repo convention. `.timeLimit` records a genuinely-never-arriving prepare as a
+// failure — the event-driven wait below has no deadline of its own (see
+// MigrationSweepBannerFreshnessTests' header for why wall-clock budgets were retired).
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootInitializeSDKSingleFlightTests {
     /// Resumable gate the mocked `prepareWith` suspends on, keeping the first prepare
     /// "in flight" for as long as the test needs the race window held open.
     private final class PrepareGate: @unchecked Sendable {
@@ -71,7 +73,7 @@ import Testing
     /// real SDK reports while a `prepare` call is still in flight. Every `prepareWith` call
     /// suspends on `gate` until the test opens it.
     private func makeStore(
-        prepareModes: LockIsolated<[String]>,
+        prepareModes: SignalledRecords<String>,
         gate: PrepareGate
     ) -> TestStore<Root.State, Root.Action> {
         let seedDerivedAccount = Self.seedDerivedAccount
@@ -126,7 +128,7 @@ import Testing
                 prepareWith: { _, _, _, _ in
                     // The SDK derives the init flow itself now, so there is no mode to record; what this
                     // test asserts is that exactly ONE prepare is dispatched per launch.
-                    prepareModes.withValue { $0.append("prepare") }
+                    prepareModes.record("prepare")
                     await gate.wait()
                     return .success
                 },
@@ -139,11 +141,12 @@ import Testing
         return store
     }
 
-    /// Polls until `condition` holds or the timeout elapses; the launch chain under test hops
-    /// between effects, so there is no single action to `receive` on deterministically with
-    /// exhaustivity off. Also used with an unmet condition as a bounded settle window when
-    /// proving an action does NOT happen.
-    private func waitUntil(iterations: Int = 200, _ condition: @escaping @Sendable () -> Bool) async {
+    /// Bounded SETTLE WINDOW for the negative check only ("a second prepare does NOT arrive") —
+    /// a non-event has no completion signal to await, so a window is the honest shape; under
+    /// load its failure mode is a false PASS (the late second dispatch lands after the window),
+    /// never a spurious red. Positive waits in this suite are event-driven
+    /// (`SignalledRecords.countReached`) and must not come back to this helper.
+    private func settleWindow(iterations: Int = 50, _ condition: @escaping @Sendable () -> Bool) async {
         for _ in 0..<iterations where !condition() {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
@@ -158,13 +161,13 @@ import Testing
     }
 
     @Test func foregroundWhileUnpreparedDoesNotDispatchSecondPrepare() async throws {
-        let prepareModes = LockIsolated<[String]>([])
+        let prepareModes = SignalledRecords<String>()
         let gate = PrepareGate()
         let store = makeStore(prepareModes: prepareModes, gate: gate)
 
         await store.send(.initialization(.appDelegate(.didFinishLaunching)))
-        await waitUntil { prepareModes.value.count >= 1 }
-        #expect(prepareModes.value == ["prepare"], "launch must reach exactly one prepareWith")
+        await prepareModes.countReached(1)
+        #expect(prepareModes.values == ["prepare"], "launch must reach exactly one prepareWith")
 
         // The first prepare is now suspended on the gate and the synchronizer still reports
         // `.unprepared` — as it does for the entire duration of a real in-flight prepare — so
@@ -174,9 +177,9 @@ import Testing
 
         // Bounded settle window: before the fix the second prepareWith arrived within a few
         // milliseconds of the re-entry, so a second dispatch would be observed here.
-        await waitUntil(iterations: 50) { prepareModes.value.count >= 2 }
+        await settleWindow { prepareModes.count >= 2 }
         #expect(
-            prepareModes.value == ["prepare"],
+            prepareModes.values == ["prepare"],
             "a foreground re-entry must not dispatch another prepareWith while one is in flight"
         )
 

--- a/zodlTests/UtilTests/RootIronwoodAnnouncementGateTests.swift
+++ b/zodlTests/UtilTests/RootIronwoodAnnouncementGateTests.swift
@@ -444,7 +444,9 @@ private struct GateTestStubError: Error { }
 
 @MainActor
 private func waitForGateStore(
-    timeoutNanoseconds: UInt64 = 5_000_000_000,
+    // Generous ceiling: starved CI runners have inflated trivially-fast tests to 60-120 s
+    // (unit_tests run 33367909253); the poll exits the moment the condition lands.
+    timeoutNanoseconds: UInt64 = 60_000_000_000,
     sourceLocation: SourceLocation = #_sourceLocation,
     condition: @escaping @MainActor () -> Bool
 ) async {

--- a/zodlTests/UtilTests/RootMigrationGateStopOnBlockTests.swift
+++ b/zodlTests/UtilTests/RootMigrationGateStopOnBlockTests.swift
@@ -61,7 +61,10 @@ import Testing
 // flag per test, plus the shared `selectedWalletAccount`/`walletAccounts` candidate keys every
 // `makeStore` call (re)installs — the same shared-state discipline
 // `MigrationTickDriverTests`/`RootMigrationTickLoopTests` serialize their own suites over.
-@Suite(.serialized) @MainActor struct RootMigrationGateStopOnBlockTests {
+// `.timeLimit` records a probe/stop that genuinely never fires as a failure — the spies'
+// event-driven waits have no deadline of their own (see MigrationSweepBannerFreshnessTests'
+// header for why wall-clock budgets were retired).
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootMigrationGateStopOnBlockTests {
     private static let accountUUID = AccountUUID(id: [UInt8](repeating: 0x08, count: 16))
     /// Only installed when a test passes `secondCandidateMode` to `makeStore` — the wallet-wide
     /// attribution shape (`aCandidateAccountEligibilityIsWalletWide`), where the SELECTED account
@@ -104,7 +107,7 @@ import Testing
     /// entry unless `secondCandidateMode` is passed, in which case `secondCandidateAccountUUID` is
     /// installed alongside it with its own independent mode — the wallet-wide attribution shape.
     private func makeStore(
-        stopCalls: LockIsolated<Int>,
+        stopCalls: SignalledRecords<Void>,
         syncStatus: SyncStatus,
         mode: MigrationMode?,
         advanceStep: @escaping @Sendable (AccountUUID) async throws -> MigrationAdvance?,
@@ -167,7 +170,7 @@ import Testing
                     return syncState
                 },
                 stop: {
-                    stopCalls.withValue { $0 += 1 }
+                    stopCalls.recordCall()
                 },
                 migrationAdvanceStep: advanceStep
             )
@@ -181,20 +184,6 @@ import Testing
     private func resetSharedResumeFlag() {
         @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
         $migrationStoppedSyncForBroadcast.withLock { $0 = false }
-    }
-
-    /// Bounded real-time polling for a condition driven by the store's own in-flight effects —
-    /// advancing a `TestClock` resumes suspended sleepers but does not itself guarantee the
-    /// resulting action/read has propagated by the time `advance(by:)` returns. Same helper shape
-    /// as `RootMigrationTickLoopTests`/`MigrationStatusRefreshPulseTests`.
-    private func waitUntil(
-        timeoutNanoseconds: UInt64 = 5_000_000_000,
-        condition: @escaping @Sendable () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
     }
 
     /// The pulse-suite teardown idiom (`MigrationStatusRefreshPulseTests`): the merged
@@ -216,13 +205,13 @@ import Testing
     /// machinery will restart sync later.
     @Test func probeStopsWhenADeliverableCandidateStepIsBroadcast() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
-        let stepReads = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
+        let stepReads = SignalledRecords<Void>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,            advanceStep: { _ in
-                stepReads.withValue { $0 += 1 }
+                stepReads.recordCall()
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             },
             // A stop-eligible candidate now also merges in `migrationTickLoopEffect`'s re-spawn
@@ -233,14 +222,14 @@ import Testing
         )
 
         await store.send(.migrationSyncGateChanged(true))
-        await waitUntil { stopCalls.value == 1 }
+        await stopCalls.countReached(1)
 
         // Attribution, not just outcome: the stop must be REACHED THROUGH the probe's own
         // `migrationAdvanceStep` read — a stop that fires without ever reading the engine is the
         // pre-probe unconditional behavior this suite exists to retire, and would otherwise pass
         // this test for the wrong reason.
-        #expect(stepReads.value >= 1, "the stop must be attributed through the probe's own migrationAdvanceStep read, not fired unconditionally")
-        #expect(stopCalls.value == 1, "a tick-deliverable candidate's .broadcast step must stop sync")
+        #expect(stepReads.count >= 1, "the stop must be attributed through the probe's own migrationAdvanceStep read, not fired unconditionally")
+        #expect(stopCalls.count == 1, "a tick-deliverable candidate's .broadcast step must stop sync")
         @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
         #expect(migrationStoppedSyncForBroadcast == true, "the stop must go through stopStartedSyncForMigrationGate, arming the resume half")
 
@@ -252,17 +241,14 @@ import Testing
     /// `.broadcast`. The probe must retry rather than give up on the first idle read.
     @Test func probeRetriesThroughTheScannedTipSkew() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
-        let stepReads = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
+        let stepReads = SignalledRecords<Void>()
         let testClock = TestClock()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,            advanceStep: { _ in
-                let callNumber = stepReads.withValue { value -> Int in
-                    value += 1
-                    return value
-                }
+                let callNumber = stepReads.recordCall()
                 return callNumber == 1
                     ? MigrationAdvance(step: .waiting, next: nil)
                     : MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
@@ -271,17 +257,17 @@ import Testing
         )
 
         await store.send(.migrationSyncGateChanged(true))
-        await waitUntil { stepReads.value >= 1 }
+        await stepReads.countReached(1)
 
         // Must NOT stop on the first, `.waiting` read — proves the probe retries rather than
         // (like the pre-probe unconditional stop) firing the instant a candidate is merely
         // eligible.
-        #expect(stopCalls.value == 0, "a .waiting first read must not stop sync — the probe must retry, not give up immediately")
+        #expect(stopCalls.count == 0, "a .waiting first read must not stop sync — the probe must retry, not give up immediately")
 
         await testClock.advance(by: .seconds(20))
-        await waitUntil { stopCalls.value == 1 }
+        await stopCalls.countReached(1)
 
-        #expect(stopCalls.value == 1, "the second attempt's .broadcast must stop sync once the skew clears")
+        #expect(stopCalls.count == 1, "the second attempt's .broadcast must stop sync once the skew clears")
 
         await teardown(store)
     }
@@ -291,14 +277,14 @@ import Testing
     /// running rather than paused for a broadcast nothing automatic will ever send.
     @Test func probeGivesUpOnAManualBlockerShape() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
-        let stepReads = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
+        let stepReads = SignalledRecords<Void>()
         let testClock = TestClock()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,            advanceStep: { _ in
-                stepReads.withValue { $0 += 1 }
+                stepReads.recordCall()
                 return MigrationAdvance(step: .waiting, next: nil)
             },
             testClock: testClock
@@ -306,10 +292,10 @@ import Testing
 
         await store.send(.migrationSyncGateChanged(true))
         await testClock.advance(by: .seconds(200))
-        await waitUntil { stepReads.value == 10 }
+        await stepReads.countReached(10)
 
-        #expect(stepReads.value == 10, "all ten attempts must be exhausted before giving up")
-        #expect(stopCalls.value == 0, "a blocker that never answers .broadcast must leave sync running")
+        #expect(stepReads.count == 10, "all ten attempts must be exhausted before giving up")
+        #expect(stopCalls.count == 0, "a blocker that never answers .broadcast must leave sync running")
 
         await teardown(store)
     }
@@ -318,31 +304,31 @@ import Testing
     /// and must not land a stop (or keep reading the engine) after it.
     @Test func falseEdgeCancelsThePendingProbe() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
-        let stepReads = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
+        let stepReads = SignalledRecords<Void>()
         let testClock = TestClock()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,            advanceStep: { _ in
-                stepReads.withValue { $0 += 1 }
+                stepReads.recordCall()
                 return MigrationAdvance(step: .waiting, next: nil)
             },
             testClock: testClock
         )
 
         await store.send(.migrationSyncGateChanged(true))
-        await waitUntil { stepReads.value >= 1 }
+        await stepReads.countReached(1)
 
         await store.send(.migrationSyncGateChanged(false))
-        let readsAtCancel = stepReads.value
+        let readsAtCancel = stepReads.count
 
         await testClock.advance(by: .seconds(200))
         try? await Task.sleep(nanoseconds: 150_000_000)
 
-        #expect(stopCalls.value == 0, "a cancelled probe must never stop sync")
+        #expect(stopCalls.count == 0, "a cancelled probe must never stop sync")
         #expect(
-            stepReads.value <= readsAtCancel + 1,
+            stepReads.count <= readsAtCancel + 1,
             "the false edge must cancel the pending probe — at most one already-in-flight read may land after it"
         )
 
@@ -363,22 +349,24 @@ import Testing
     /// `AddKeystoneHWWalletTests.unlockTappedIgnoresRetapsWhileImportInFlight`'s release stream.
     @Test func stepReadLandingAfterTheFalseEdgeMustNotStop() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let testClock = TestClock()
         let stepContinuation = LockIsolated<CheckedContinuation<MigrationAdvance?, Never>?>(nil)
+        let stepParked = SignalledRecords<Void>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,            advanceStep: { _ in
                 await withCheckedContinuation { continuation in
                     stepContinuation.setValue(continuation)
+                    stepParked.recordCall()
                 }
             },
             testClock: testClock
         )
 
         await store.send(.migrationSyncGateChanged(true))
-        await waitUntil { stepContinuation.value != nil }
+        await stepParked.countReached(1)
 
         // The false edge — cancels the probe's Task cooperatively while the read above is still
         // parked on the continuation, exactly the interleaving the guard exists for.
@@ -390,7 +378,7 @@ import Testing
 
         try? await Task.sleep(nanoseconds: 150_000_000)
 
-        #expect(stopCalls.value == 0, "a step read that lands after the false edge must not stop the just-cleared/resumed sync")
+        #expect(stopCalls.count == 0, "a step read that lands after the false edge must not stop the just-cleared/resumed sync")
 
         await teardown(store)
     }
@@ -406,7 +394,7 @@ import Testing
     /// narrow TWO wallet accounts down to the one the probe may read.
     @Test func aCandidateAccountEligibilityIsWalletWide() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let queriedAccountUUIDs = LockIsolated<[AccountUUID]>([])
         let store = makeStore(
             stopCalls: stopCalls,
@@ -420,9 +408,9 @@ import Testing
         )
 
         await store.send(.migrationSyncGateChanged(true))
-        await waitUntil { stopCalls.value == 1 }
+        await stopCalls.countReached(1)
 
-        #expect(stopCalls.value == 1, "a second candidate's privateScheduled run must stop sync although the selected account is immediate-mode")
+        #expect(stopCalls.count == 1, "a second candidate's privateScheduled run must stop sync although the selected account is immediate-mode")
         #expect(
             queriedAccountUUIDs.value == [RootMigrationGateStopOnBlockTests.secondCandidateAccountUUID],
             "only the eligible second candidate may ever be read — the ineligible selected account must never reach the probe"
@@ -437,13 +425,13 @@ import Testing
     /// the engine for it at all, let alone stop its sync.
     @Test func nonDeliverableWalletNeverReadsTheEngine() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
-        let stepReads = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
+        let stepReads = SignalledRecords<Void>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.immediate,            advanceStep: { _ in
-                stepReads.withValue { $0 += 1 }
+                stepReads.recordCall()
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             }
         )
@@ -451,8 +439,8 @@ import Testing
         await store.send(.migrationSyncGateChanged(true))
         try? await Task.sleep(nanoseconds: 150_000_000)
 
-        #expect(stopCalls.value == 0, "an immediate-mode run must keep today's behavior — no stop")
-        #expect(stepReads.value == 0, "a non-deliverable wallet must never read the engine at all")
+        #expect(stopCalls.count == 0, "an immediate-mode run must keep today's behavior — no stop")
+        #expect(stepReads.count == 0, "a non-deliverable wallet must never read the engine at all")
 
         await teardown(store)
     }
@@ -463,7 +451,7 @@ import Testing
     /// emission (the stream re-evaluates every 15 s) must not probe — or stop — again.
     @Test func repeatedBlockedEmissionsProbeOnlyOnce() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
@@ -475,11 +463,11 @@ import Testing
         )
 
         await store.send(.migrationSyncGateChanged(true))
-        await waitUntil { stopCalls.value == 1 }
+        await stopCalls.countReached(1)
         await store.send(.migrationSyncGateChanged(true))
         try? await Task.sleep(nanoseconds: 150_000_000)
 
-        #expect(stopCalls.value == 1, "only the false->true TRANSITION probes — repeated emissions are quiet")
+        #expect(stopCalls.count == 1, "only the false->true TRANSITION probes — repeated emissions are quiet")
 
         await teardown(store)
     }
@@ -487,7 +475,7 @@ import Testing
     /// The false edge (gate clearing) must never stop — it is the RESUME half's edge.
     @Test func clearingEdgeNeverStops() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
@@ -499,7 +487,7 @@ import Testing
         await store.send(.migrationSyncGateChanged(false))
         try? await Task.sleep(nanoseconds: 150_000_000)
 
-        #expect(stopCalls.value == 0, "the clearing edge belongs to the resume half — no stop")
+        #expect(stopCalls.count == 0, "the clearing edge belongs to the resume half — no stop")
 
         await teardown(store)
     }
@@ -511,13 +499,13 @@ import Testing
     /// the engine is NOT mid-scan — `.upToDate` is the actual field-caught wedge shape.
     @Test func aStoppedEngineIsLeftAlone() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
-        let stepReads = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
+        let stepReads = SignalledRecords<Void>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.stopped,
             mode: MigrationMode.privateScheduled,            advanceStep: { _ in
-                stepReads.withValue { $0 += 1 }
+                stepReads.recordCall()
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             },
             // See `probeStopsWhenADeliverableCandidateStepIsBroadcast`'s identical note — the
@@ -527,13 +515,13 @@ import Testing
         )
 
         await store.send(.migrationSyncGateChanged(true))
-        await waitUntil { stepReads.value >= 1 }
+        await stepReads.countReached(1)
 
         // The probe DOES run and DOES answer `.broadcast` — `stopStartedSyncForMigrationGate()`'s
         // own guard is what no-ops here, on `latestState().syncStatus` BEFORE ever calling the
         // mocked `stop()` closure this suite spies on. `stopCalls` staying 0 is therefore the
         // B12 contract, not a probe failure.
-        #expect(stopCalls.value == 0, "a stopped engine has nothing to stop — the helper's own guard no-ops before calling stop()")
+        #expect(stopCalls.count == 0, "a stopped engine has nothing to stop — the helper's own guard no-ops before calling stop()")
         @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
         #expect(!migrationStoppedSyncForBroadcast, "never arm the resume flag for a sync nobody paused")
 
@@ -547,13 +535,13 @@ import Testing
     /// in that shape, and the engine must not even be read.
     @Test func theTickLoopOffSwitchDisablesTheStop() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
-        let stepReads = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
+        let stepReads = SignalledRecords<Void>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
             mode: MigrationMode.privateScheduled,            advanceStep: { _ in
-                stepReads.withValue { $0 += 1 }
+                stepReads.recordCall()
                 return MigrationAdvance(step: .broadcast(MigrationBroadcastInstruction(id: 9)), next: nil)
             },
             tickInterval: Swift.Duration.zero
@@ -562,8 +550,8 @@ import Testing
         await store.send(.migrationSyncGateChanged(true))
         try? await Task.sleep(nanoseconds: 150_000_000)
 
-        #expect(stopCalls.value == 0, "with the tick loop disabled, nothing can ever consume the stop's silence")
-        #expect(stepReads.value == 0, "the off switch must short-circuit before ever reading the engine")
+        #expect(stopCalls.count == 0, "with the tick loop disabled, nothing can ever consume the stop's silence")
+        #expect(stepReads.count == 0, "the off switch must short-circuit before ever reading the engine")
 
         await teardown(store)
     }
@@ -575,9 +563,9 @@ import Testing
     /// stop with nothing left to use the silence it buys.
     @Test func blockedEdgeEnsuresTheTickLoopIsAlive() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let testClock = TestClock()
-        let advancePhases = LockIsolated<[MigrationOpenPhase]>([])
+        let advancePhases = SignalledRecords<MigrationOpenPhase>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
@@ -586,15 +574,15 @@ import Testing
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in
-            advancePhases.withValue { $0.append(phase) }
+            advancePhases.record(phase)
             return MigrationStepVerdict.idle
         }
 
         await store.send(.migrationSyncGateChanged(true))
         await testClock.advance(by: .seconds(30))
-        await waitUntil { advancePhases.value.contains(MigrationOpenPhase.tick) }
+        await advancePhases.recorded { $0.contains(MigrationOpenPhase.tick) }
 
-        #expect(advancePhases.value.contains(MigrationOpenPhase.tick), "the blocked edge must ensure the tick loop is alive")
+        #expect(advancePhases.values.contains(MigrationOpenPhase.tick), "the blocked edge must ensure the tick loop is alive")
 
         await teardown(store)
     }
@@ -604,9 +592,9 @@ import Testing
     /// loop for the identical reason the blocked edge does.
     @Test func flowFinishedRespawnsTheTickLoop() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let testClock = TestClock()
-        let advancePhases = LockIsolated<[MigrationOpenPhase]>([])
+        let advancePhases = SignalledRecords<MigrationOpenPhase>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
@@ -615,15 +603,15 @@ import Testing
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in
-            advancePhases.withValue { $0.append(phase) }
+            advancePhases.record(phase)
             return MigrationStepVerdict.idle
         }
 
         await store.send(.migrationCoordFlow(.flowFinished))
         await testClock.advance(by: .seconds(30))
-        await waitUntil { advancePhases.value.contains(MigrationOpenPhase.tick) }
+        await advancePhases.recorded { $0.contains(MigrationOpenPhase.tick) }
 
-        #expect(advancePhases.value.contains(MigrationOpenPhase.tick), "flowFinished must respawn the tick loop for a run committed mid-session")
+        #expect(advancePhases.values.contains(MigrationOpenPhase.tick), "flowFinished must respawn the tick loop for a run committed mid-session")
 
         await teardown(store)
     }
@@ -633,9 +621,9 @@ import Testing
     /// (a no-op when the flow committed, since confirm converts the snapshot).
     @Test func flowFinishedClearsTheProvisionalNetworkSnapshot() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let testClock = TestClock()
-        let clearedFor = LockIsolated<[AccountUUID?]>([])
+        let clearedFor = SignalledRecords<AccountUUID?>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
@@ -644,13 +632,13 @@ import Testing
             testClock: testClock
         )
         store.dependencies.migrationManager.clearProvisionalNetworkSnapshot = { accountUUID in
-            clearedFor.withValue { $0.append(accountUUID) }
+            clearedFor.record(accountUUID)
         }
 
         await store.send(.migrationCoordFlow(.flowFinished))
-        await waitUntil { !clearedFor.value.isEmpty }
+        await clearedFor.countReached(1)
 
-        #expect(clearedFor.value.count == 1, "flowFinished runs the provisional cleaner exactly once")
+        #expect(clearedFor.count == 1, "flowFinished runs the provisional cleaner exactly once")
 
         await teardown(store)
     }
@@ -664,9 +652,9 @@ import Testing
     /// `flowFinished` must run the driver once at the phase the commit missed.
     @Test func flowFinishedOnAnAtTipWalletDrivesTheAfterSyncPhaseOnce() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let testClock = TestClock()
-        let advancePhases = LockIsolated<[MigrationOpenPhase]>([])
+        let advancePhases = SignalledRecords<MigrationOpenPhase>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.upToDate,
@@ -675,15 +663,15 @@ import Testing
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in
-            advancePhases.withValue { $0.append(phase) }
+            advancePhases.record(phase)
             return MigrationStepVerdict.idle
         }
 
         await store.send(.migrationCoordFlow(.flowFinished))
-        await waitUntil { advancePhases.value.contains(MigrationOpenPhase.afterSync) }
+        await advancePhases.recorded { $0.contains(MigrationOpenPhase.afterSync) }
 
         #expect(
-            advancePhases.value.filter { $0 == MigrationOpenPhase.afterSync }.count == 1,
+            advancePhases.values.filter { $0 == MigrationOpenPhase.afterSync }.count == 1,
             "flowFinished on an at-tip wallet must drive the driver exactly once at .afterSync — the edge the commit missed"
         )
 
@@ -695,9 +683,9 @@ import Testing
     /// must not pre-empt it against a stale tip.
     @Test func flowFinishedWhileStillSyncingLeavesTheDriveToTheComingEdge() async {
         resetSharedResumeFlag()
-        let stopCalls = LockIsolated(0)
+        let stopCalls = SignalledRecords<Void>()
         let testClock = TestClock()
-        let advancePhases = LockIsolated<[MigrationOpenPhase]>([])
+        let advancePhases = SignalledRecords<MigrationOpenPhase>()
         let store = makeStore(
             stopCalls: stopCalls,
             syncStatus: SyncStatus.syncing(0.5, false),
@@ -706,7 +694,7 @@ import Testing
             testClock: testClock
         )
         store.dependencies.migrationManager.advance = { phase in
-            advancePhases.withValue { $0.append(phase) }
+            advancePhases.record(phase)
             return MigrationStepVerdict.idle
         }
 
@@ -714,7 +702,7 @@ import Testing
         try? await Task.sleep(nanoseconds: 150_000_000)
 
         #expect(
-            !advancePhases.value.contains(MigrationOpenPhase.afterSync),
+            !advancePhases.values.contains(MigrationOpenPhase.afterSync),
             "mid-sync, the coming .upToDate edge owns the .afterSync drive — flowFinished must leave it alone"
         )
 

--- a/zodlTests/UtilTests/RootMigrationTickLoopTests.swift
+++ b/zodlTests/UtilTests/RootMigrationTickLoopTests.swift
@@ -21,8 +21,11 @@ import Testing
 @testable import zodl_internal
 
 // Serialized per repo convention for suites driving lifecycle actions through a real TestStore —
-// see `RootMigrationGateRefusalTests`'s identical `@Suite(.serialized)` rationale.
-@Suite(.serialized) @MainActor struct RootMigrationTickLoopTests {
+// see `RootMigrationGateRefusalTests`'s identical `@Suite(.serialized)` rationale. `.timeLimit`
+// records a tick that genuinely never fires as a failure — the spy's event-driven waits have no
+// deadline of their own (see MigrationSweepBannerFreshnessTests' header for why wall-clock
+// budgets were retired).
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootMigrationTickLoopTests {
     private static let accountUUID = AccountUUID(id: [UInt8](repeating: 0x0A, count: 16))
 
     private static func account() -> WalletAccount {
@@ -44,7 +47,7 @@ import Testing
     /// included) so these tests exercise Root's loop-management reducer logic in isolation from the
     /// driver's own internals.
     private final class TickSpy: @unchecked Sendable {
-        let phases = LockIsolated<[MigrationOpenPhase]>([])
+        let phases = SignalledRecords<MigrationOpenPhase>()
         let verdict: LockIsolated<MigrationStepVerdict>
         private let ironwoodActivated: LockIsolated<Bool>
         private let mode: LockIsolated<MigrationMode?>
@@ -59,8 +62,22 @@ import Testing
             self.mode = LockIsolated(migrationMode)
         }
 
-        var tickCalls: Int { phases.value.filter { $0 == MigrationOpenPhase.tick }.count }
-        var nonTickCalls: Int { phases.value.filter { $0 != MigrationOpenPhase.tick }.count }
+        var tickCalls: Int { phases.values.filter { $0 == MigrationOpenPhase.tick }.count }
+        var nonTickCalls: Int { phases.values.filter { $0 != MigrationOpenPhase.tick }.count }
+
+        /// Event-driven waits, resumed by the spy's own `record` call — no deadline; the suite's
+        /// `.timeLimit` records the genuinely-never case.
+        func ticksReached(_ threshold: Int) async {
+            await phases.recorded { $0.filter { $0 == MigrationOpenPhase.tick }.count >= threshold }
+        }
+
+        func nonTicksReached(_ threshold: Int) async {
+            await phases.recorded { $0.filter { $0 != MigrationOpenPhase.tick }.count >= threshold }
+        }
+
+        func phaseSeen(_ phase: MigrationOpenPhase) async {
+            await phases.recorded { $0.contains(phase) }
+        }
 
         func install(_ values: inout DependencyValues) {
             var client = MigrationManagerClient.noOp
@@ -68,7 +85,7 @@ import Testing
             client.migrationMode = { [mode] _ in mode.value }
             client.visitKind = { .sync }
             client.advance = { [phases, verdict] phase in
-                phases.withValue { $0.append(phase) }
+                phases.record(phase)
                 return verdict.value
             }
             client.armNextWindowNotifications = { _ in }
@@ -169,20 +186,6 @@ import Testing
         await store.skipInFlightEffects(strict: false)
     }
 
-    /// Bounded real-time polling for a condition driven by the store's own concurrently-running
-    /// effects — needed because advancing a `TestClock` resumes suspended sleepers but does not
-    /// itself guarantee the resulting action has finished propagating through the store by the time
-    /// `advance(by:)` returns.
-    private func waitUntil(
-        timeoutNanoseconds: UInt64 = 5_000_000_000,
-        condition: @escaping @Sendable () -> Bool
-    ) async {
-        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
-    }
-
     // MARK: - Launch snapshot sweep (audit 2026-08-03, #6)
 
     /// The launch-time sweep the snapshot docs always named but nothing implemented: every
@@ -192,17 +195,17 @@ import Testing
         let spy = TickSpy()
         let testClock = TestClock()
         let store = makeStore(spy: spy, testClock: testClock)
-        let sweptFor = LockIsolated<[AccountUUID]>([])
+        let sweptFor = SignalledRecords<AccountUUID>()
         store.dependencies.migrationManager.clearAbandonedNetworkSnapshot = { accountUUID in
             if let accountUUID {
-                sweptFor.withValue { $0.append(accountUUID) }
+                sweptFor.record(accountUUID)
             }
         }
 
         await store.send(.initialization(.initializationSuccessfullyDone))
-        await waitUntil { !sweptFor.value.isEmpty }
+        await sweptFor.countReached(1)
 
-        #expect(sweptFor.value == [Self.accountUUID], "every candidate account gets the abandoned-snapshot sweep at launch")
+        #expect(sweptFor.values == [Self.accountUUID], "every candidate account gets the abandoned-snapshot sweep at launch")
 
         await drain(store)
     }
@@ -221,7 +224,7 @@ import Testing
         #expect(spy.tickCalls == 0, "the first tick must not fire before a full 30s has elapsed")
 
         await testClock.advance(by: .seconds(1))
-        await waitUntil { spy.tickCalls == 1 }
+        await spy.ticksReached(1)
         #expect(spy.tickCalls == 1)
 
         await drain(store)
@@ -247,7 +250,7 @@ import Testing
         #expect(spy.tickCalls == 0, "the foreground restart must reset the countdown, not merely continue the old one")
 
         await testClock.advance(by: .seconds(1))
-        await waitUntil { spy.tickCalls == 1 }
+        await spy.ticksReached(1)
         #expect(spy.tickCalls == 1, "exactly one tick once the RESTARTED countdown reaches 30s")
 
         await drain(store)
@@ -281,7 +284,7 @@ import Testing
         await store.send(.initialization(.initializationSuccessfullyDone))
 
         await testClock.advance(by: .seconds(90))
-        await waitUntil { spy.tickCalls >= 3 }
+        await spy.ticksReached(3)
 
         #expect(spy.tickCalls == 3, "three 30s wake-ups in 90s")
         #expect(spy.nonTickCalls == 0, ".initializationSuccessfullyDone alone must never call .beforeSync/.afterSync")
@@ -305,7 +308,7 @@ import Testing
         await store.send(.initialization(.initializationSuccessfullyDone))
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { spy.tickCalls == 1 }
+        await spy.ticksReached(1)
         #expect(spy.tickCalls == 1, "a committed immediate-mode run must tick — its preparations are engine-paced")
 
         await drain(store)
@@ -358,11 +361,11 @@ import Testing
         await store.send(.initialization(.initializationSuccessfullyDone))
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { spy.tickCalls == 1 }
+        await spy.ticksReached(1)
         #expect(spy.tickCalls == 1)
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { spy.tickCalls == 2 }
+        await spy.ticksReached(2)
         #expect(spy.tickCalls == 2, "a transient .notApplicable must not kill the loop — the next tick still fires")
 
         await drain(store)
@@ -376,7 +379,7 @@ import Testing
         await store.send(.initialization(.initializationSuccessfullyDone))
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { spy.tickCalls == 1 }
+        await spy.ticksReached(1)
         #expect(spy.tickCalls == 1)
 
         await testClock.advance(by: .seconds(300))
@@ -385,7 +388,7 @@ import Testing
 
         await store.send(.initialization(.appDelegate(.willEnterForeground)))
         await testClock.advance(by: .seconds(30))
-        await waitUntil { spy.tickCalls == 2 }
+        await spy.ticksReached(2)
         #expect(spy.tickCalls == 2, "a fresh foreground must respawn the loop")
 
         await drain(store)
@@ -425,7 +428,7 @@ import Testing
                 guard case .initialization(.retryStart) = action else { return false }
                 return true
             },
-            timeout: .seconds(5)
+            timeout: .seconds(30)
         )
 
         #expect(!migrationStoppedSyncForBroadcast, "the resume must clear the flag it consumed")
@@ -434,7 +437,7 @@ import Testing
         // second resume — a duplicated `.retryStart` means a duplicated `.beforeSync` driver call
         // (a second engine read and a second arming pass per resume). The spy counts the phase,
         // so the pin is on the observable consequence rather than the action stream.
-        await waitUntil { spy.nonTickCalls >= 1 }
+        await spy.nonTicksReached(1)
         try? await Task.sleep(nanoseconds: 300_000_000)
         #expect(spy.nonTickCalls == 1, "exactly ONE resume open — a second .beforeSync means a duplicated .retryStart")
 
@@ -457,7 +460,7 @@ import Testing
         await store.send(.initialization(.initializationSuccessfullyDone))
 
         await testClock.advance(by: .seconds(30))
-        await waitUntil { spy.tickCalls == 1 }
+        await spy.ticksReached(1)
 
         // The shape a LANDED broadcast produces regardless of whether the app had anything of its
         // own to stop: the SDK's post-broadcast gate blocks, then clears.
@@ -472,11 +475,11 @@ import Testing
                 guard case .initialization(.retryStart) = action else { return false }
                 return true
             },
-            timeout: .seconds(5)
+            timeout: .seconds(30)
         )
 
         // Parked-debt pin (2026-08-03), same rationale as (a) above: exactly one resume open.
-        await waitUntil { spy.nonTickCalls >= 1 }
+        await spy.nonTicksReached(1)
         try? await Task.sleep(nanoseconds: 300_000_000)
         #expect(spy.nonTickCalls == 1, "exactly ONE resume open — a second .beforeSync means a duplicated .retryStart")
 
@@ -524,10 +527,10 @@ import Testing
         let store = makeStore(spy: spy, testClock: testClock, tickInterval: Swift.Duration.zero)
 
         await store.send(.initialization(.appDelegate(.willEnterForeground)))
-        await waitUntil { spy.phases.value.contains(MigrationOpenPhase.beforeSync) }
+        await spy.phaseSeen(MigrationOpenPhase.beforeSync)
 
         #expect(
-            spy.phases.value.contains(MigrationOpenPhase.beforeSync),
+            spy.phases.values.contains(MigrationOpenPhase.beforeSync),
             "the open poke is a separate lane and must survive the zero switch"
         )
         #expect(spy.tickCalls == 0, "and still no tick, ever")

--- a/zodlTests/VotingTests/ConfirmSubmissionRequestedTests.swift
+++ b/zodlTests/VotingTests/ConfirmSubmissionRequestedTests.swift
@@ -245,9 +245,10 @@ import Testing
     @MainActor
     private func waitForStore(
         // Generous ceiling: suites run in parallel and effect delivery can lag well past
-        // a "reasonable" bound under full-suite load; the condition normally lands in
-        // milliseconds and a real regression still fails, just slower.
-        timeoutNanoseconds: UInt64 = 15_000_000_000,
+        // a "reasonable" bound under full-suite load — starved CI runners have inflated
+        // trivially-fast tests to 60-120 s (unit_tests run 33367909253); the condition
+        // normally lands in milliseconds and a real regression still fails, just slower.
+        timeoutNanoseconds: UInt64 = 60_000_000_000,
         sourceLocation: SourceLocation = #_sourceLocation,
         condition: @escaping @MainActor () -> Bool
     ) async {

--- a/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/zodlTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -2398,7 +2398,11 @@ import Testing
 
     @MainActor
     private func waitForStore(
-        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        // Generous ceiling, not a responsiveness claim: starved CI runners have inflated
+        // trivially-fast tests to 60-120 s (unit_tests runs 33367909253, 33371909793 — the
+        // 2 s budget this replaces lost twice), the poll exits the moment the condition
+        // lands, and a real regression still fails, just slower.
+        timeoutNanoseconds: UInt64 = 60_000_000_000,
         sourceLocation: SourceLocation = #_sourceLocation,
         condition: @escaping @MainActor () -> Bool
     ) async {


### PR DESCRIPTION
Follow-up to #2047, stacked on its branch: that PR fixed the suite that was actually failing CI; this one retires the same wall-clock-polling pattern from every remaining suite that still carries it, before a slow runner picks the next victim.

## Why now

CI run [33367909253](https://github.com/zodl-inc/zodl-ios/actions/runs/33367909253) showed runners slow enough to inflate trivially-fast tests to 60–120 s. Seven suites still waited on fixed 2–10 s wall-clock budgets with 5–10 ms polling (`waitUntil` helpers) for conditions their own spies could signal — every one of them a latent red under that kind of load. Two of the polls were worse than waits: a mock in `MigrationTickDriverTests` busy-polled a release flag at 5 ms *inside* the very cooperative pool the loaded run is starving.

## What changed

**New `zodlTests/TestSupport/TestSignals.swift`** (the `zodlTests` group is filesystem-synchronized; the target already shares cross-file helpers):

- `SignalledRecords<Element>` — spy storage whose `record(_:)` resumes waiters registered via `await recorded(where:)` / `await countReached(_:)`. Check-and-register happens under the same lock as the write, so a wakeup can never be missed. `record` returns the call ordinal for mocks that branch on it.
- `ResumableGate` — a latching park/release gate (`await wait()` / `open()`) replacing busy-poll release flags inside mocks.

**Migrated suites** — every positive poll now suspends on the spy's own signal:

- `RootInitializeSDKSingleFlightTests` (its first-prepare wait ran on a **2-second** budget, the tightest in the repo)
- `RootMigrationTickLoopTests` (11 waits; `TickSpy` gained `ticksReached`/`nonTicksReached`/`phaseSeen`)
- `RootMigrationGateStopOnBlockTests` (9 waits; the parked-continuation wait now signals at the parking site)
- `MigrationTickDriverTests` (started-signals + `ResumableGate`; the in-mock busy-poll is gone)
- `MigrationStatusRefreshPulseTests`, `MigrationCoordFlowKeystoneScheduleStoreTests`
- `MigrationBannerEntryTests` — now suspends on the manager's own `awaitSnapshotRepublishIdle(for:)` (the republish is claimed synchronously inside `reconcile()`, so the idle-await cannot pass early)

`MigrationSyncCompleteEdgeTests` was already event-driven (its AsyncStream spy is the in-repo precedent) and is untouched.

**Deliberately kept:** negative settle windows ("nothing fires within 150 ms") — a non-event has no completion signal, and their failure mode under load is a false *pass*, never a spurious red. Assert-only spies stay `LockIsolated`.

**Also:** short 5 s `TestStore.receive` timeouts raised to 30 s (positive waits — a longer bound costs nothing when healthy), and every migrated suite gains `@Suite(.timeLimit(.minutes(3)))` so a wait that genuinely never fires is *recorded* as a failure instead of running until the CI job's own timeout — sized above the ~120 s worst healthy inflation observed.

## Second commit: the fleet kept picking new victims

PR #2047's first `unit_tests` run ([33371909793](https://github.com/zodl-inc/zodl-ios/actions/runs/33371909793)) proved the point: the fixed sweep-banner suite **passed** (31 s under load — the waits scaled instead of losing), and the run failed on two *other* suites instead — `RootPendingTransactionRefreshTests` exceeded its 1-minute `.timeLimit` on a healthy test (~16 s ordinarily), and `VotingCoordFlowCoordinatorTests`' `waitForStore` lost its **2-second** deadline (its second casualty after run 33367909253). Those waits poll TCA store state — no spy to signal — so they get the generous-deadline fallback: `waitForStore`/`waitForFlexaStore`/`waitForGateStore` defaults raised to 60 s (from 2 s / 15 s / 15 s / 5 s; the poll exits the moment the condition lands, so healthy runs are unaffected), and both RootTransactions refresh suites' `.timeLimit` raised from 1 minute to 3 (their deliberately-unbounded pumps are backstopped by that limit alone).

## Verification

- All seven migrated suites green in isolation in one run (79 tests, 7.6 s).
- The six budget-amended suites green in isolation in one run (121 tests, 7.1 s).
- Full `zodlTests` green locally on the iPhone 17 simulator (1566 tests / 214 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
