### PR TITLE
[MOB-1749] Deflake freshness suites: writer-edge republish bound under test control

### DIFF
--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -361,6 +361,22 @@ final class MigrationManagerImpl: @unchecked Sendable {
     /// production read.
     let sessionOrdinalProvider: @Sendable () -> Int?
 
+    /// Final-review fix: the longest a writer edge (`lockMigrationDust`, `recordTransferBroadcast`)
+    /// will WAIT for its awaited republish. The bound exists for the pathological case only (a
+    /// wedged SDK read behind a server switch or a broadcast): past it the build keeps running
+    /// detached — cancelling it would leak the coalescer's claimed `inFlight` — and the SmartBanner
+    /// snapshot subscription delivers the late publish, the same heal path the coalescer's
+    /// contended branch already rides.
+    ///
+    /// Injectable (every production call site keeps the 10 s default) for the same reason as
+    /// `sessionOrdinalProvider`: the freshness suites read published state immediately after a
+    /// writer edge returns, and a starved CI runner can stretch a mocked build past any fixed
+    /// production bound — the chain then returns early by design and the read sees the pre-edge
+    /// snapshot (unit_tests run 33495197340). Those suites raise the bound past their own
+    /// `.timeLimit`, so the limit records a genuine hang while load alone can no longer expire a
+    /// writer edge mid-test.
+    let lockRepublishTimeoutNanoseconds: UInt64
+
     /// Internal (not private) with injectable storage so unit tests can exercise the real
     /// `reconcile()` against a scoped `UserDefaults` suite.
     init(
@@ -368,13 +384,15 @@ final class MigrationManagerImpl: @unchecked Sendable {
         scheduleStorage: MigrationScheduleStorage = MigrationScheduleStorage(),
         snapshotStorage: MigrationSnapshotStorage = MigrationSnapshotStorage(),
         failureRoutingStorage: MigrationFailureRoutingStorage = MigrationFailureRoutingStorage(),
-        sessionOrdinalProvider: @escaping @Sendable () -> Int? = { MigrationTrace.currentSessionOrdinal }
+        sessionOrdinalProvider: @escaping @Sendable () -> Int? = { MigrationTrace.currentSessionOrdinal },
+        lockRepublishTimeoutNanoseconds: UInt64 = 10_000_000_000
     ) {
         self.gateStorage = gateStorage
         self.scheduleStorage = scheduleStorage
         self.snapshotStorage = snapshotStorage
         self.failureRoutingStorage = failureRoutingStorage
         self.sessionOrdinalProvider = sessionOrdinalProvider
+        self.lockRepublishTimeoutNanoseconds = lockRepublishTimeoutNanoseconds
     }
 
     /// MOB-1496: one `CurrentValueSubject` per account `stateEvents` has ever been asked about,
@@ -1417,7 +1435,7 @@ final class MigrationManagerImpl: @unchecked Sendable {
         // `MigrationSweepBannerFreshnessTests`. The split-phase early return above keeps its
         // shape: preparation broadcasts already republish at both edges via the broadcast
         // session's own pokes.
-        await awaitBounded(nanoseconds: Self.lockRepublishTimeoutNanoseconds) { [weak self] in
+        await awaitBounded(nanoseconds: lockRepublishTimeoutNanoseconds) { [weak self] in
             await self?.republishSnapshotNow(for: resolvedAccountUUID)
         }
     }
@@ -1467,18 +1485,10 @@ final class MigrationManagerImpl: @unchecked Sendable {
         // is what frees every flow exit from carrying a reconcile barrier: by the time the user
         // can leave the screen, the snapshot already tells the post-lock truth, bounded — see
         // `lockRepublishTimeoutNanoseconds`.
-        await awaitBounded(nanoseconds: Self.lockRepublishTimeoutNanoseconds) { [weak self] in
+        await awaitBounded(nanoseconds: lockRepublishTimeoutNanoseconds) { [weak self] in
             await self?.republishSnapshotNow(for: resolvedAccountUUID)
         }
     }
-
-    /// Final-review fix: the longest a writer edge (`lockMigrationDust`, `recordTransferBroadcast`)
-    /// will WAIT for its awaited republish. The
-    /// bound exists for the pathological case only (a wedged SDK read behind a server switch or a
-    /// broadcast): past it the build keeps running detached — cancelling it would leak the
-    /// coalescer's claimed `inFlight` — and the SmartBanner snapshot subscription delivers the
-    /// late publish, the same heal path the coalescer's contended branch already rides.
-    private static let lockRepublishTimeoutNanoseconds: UInt64 = 10_000_000_000
 
     /// Awaits `operation` for at most `nanoseconds`, then returns while the operation keeps
     /// running unstructured. Never cancels the operation — see `lockRepublishTimeoutNanoseconds`.

--- a/zodlTests/MigrationTests/MigrationSnapshotFreshnessTests.swift
+++ b/zodlTests/MigrationTests/MigrationSnapshotFreshnessTests.swift
@@ -24,14 +24,14 @@
 //  work whose actual duration scales with CI load, so a busier-than-tested runner could always
 //  make the deadline lose even though nothing was wrong.
 //
-//  `.timeLimit` below is NOT the only clock left in this suite's path.
-//  `lockingRepublishesTheSnapshotBeforeReturning` still calls `lockMigrationDust`, which separately
-//  wraps its own awaited republish in the PRODUCTION `lockRepublishTimeoutNanoseconds` bound (10 s,
-//  `awaitBounded`, in MigrationManagerLiveKey.swift) — under starvation extreme enough, that budget
-//  can still lose to the mocked build, in which case `lockMigrationDust` returns early by design
-//  (its documented heal path) and this test's final `#expect(published.banner == nil)` would see
-//  the stale residual. A recurrence there is that production-side bound doing its job under an
-//  even worse runner, not a gap in the waits this file controls.
+//  `lockingRepublishesTheSnapshotBeforeReturning` crosses a writer edge whose awaited republish
+//  `lockMigrationDust` wraps in the `lockRepublishTimeoutNanoseconds` bound (`awaitBounded`,
+//  production default 10 s in MigrationManagerLiveKey.swift) — past it the lock returns early by
+//  design (its documented heal path) and the final `#expect(published.banner == nil)` would see
+//  the stale residual. The sweep sibling hit exactly that race under CI starvation (unit_tests run
+//  33495197340, `recordTransferBroadcast`'s twin of this bound), so this test now constructs its
+//  manager with the bound raised past `.timeLimit` through the init seam: the limit records a
+//  genuinely wedged build, and load alone can no longer expire the lock's awaited republish.
 //
 //  `.timeLimit` is also not a hang-preventer: both new awaits above are plain
 //  `withCheckedContinuation`s with no cancellation handler, so a coalescer that genuinely never
@@ -53,6 +53,11 @@ import ComposableArchitecture
     private static let activationHeight: BlockHeight = 4_134_000
     private static let tip: BlockHeight = 4_200_000
     private static let suiteName = "MigrationSnapshotFreshnessTests"
+
+    /// The lock test's awaited-republish bound: raised far past this suite's `.timeLimit` (1 min)
+    /// so the limit is what records a genuinely wedged build, and a merely starved one can never
+    /// expire `lockMigrationDust`'s awaited republish mid-test (see header).
+    private static let raisedRepublishBoundNanoseconds: UInt64 = 600_000_000_000
 
     private static func atTipState() -> SynchronizerState {
         var state = SynchronizerState.zero
@@ -268,7 +273,7 @@ import ComposableArchitecture
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
         } operation: {
-            let manager = MigrationManagerImpl()
+            let manager = MigrationManagerImpl(lockRepublishTimeoutNanoseconds: Self.raisedRepublishBoundNanoseconds)
 
             var cancellables = Set<AnyCancellable>()
             let preLockSnapshot = await Self.firstSnapshot(

--- a/zodlTests/MigrationTests/MigrationSweepBannerFreshnessTests.swift
+++ b/zodlTests/MigrationTests/MigrationSweepBannerFreshnessTests.swift
@@ -28,13 +28,15 @@
 //  where the sibling records at one: the immediate-sweep chain crosses two writer edges plus
 //  `reconcile()`, so a starved runner stacks more sequential builds into one test here.
 //
-//  One clock remains outside this file's control (the sibling documents the same for its lock
-//  test): `recordTransferBroadcast`'s awaited republish carries the PRODUCTION
-//  `lockRepublishTimeoutNanoseconds` bound (10 s), so under starvation extreme enough that bound
-//  can expire and the chain returns early by design — `theSweepSuccessChainOutrunsItsOwnRepublish`
-//  reads the banner immediately after the chain on purpose and would see the stale residual then.
-//  A recurrence there is that production bound doing its job under an even worse runner, not a
-//  deadline these waits reintroduce.
+//  The one clock that used to sit outside this file's control is now pinned too:
+//  `recordTransferBroadcast`'s awaited republish carries the `lockRepublishTimeoutNanoseconds`
+//  bound (production default 10 s), and CI re-proved the residual risk this header used to only
+//  predict — on a starved runner the mocked build outlasted the bound, the chain returned early by
+//  design, and `theSweepSuccessChainOutrunsItsOwnRepublish`'s deliberately-immediate re-read saw
+//  the stale residual (unit_tests run 33495197340). Every manager here is therefore constructed
+//  with the bound raised past this suite's `.timeLimit` through the init seam, so a genuinely
+//  wedged build is recorded by the limit while load alone can no longer expire a writer edge's
+//  awaited republish mid-test.
 //
 
 import Foundation
@@ -49,6 +51,12 @@ import ComposableArchitecture
     private static let activationHeight: BlockHeight = 4_134_000
     private static let tip: BlockHeight = 4_200_000
     private static let suiteName = "MigrationSweepBannerFreshnessTests"
+
+    /// The writer edges' awaited-republish bound for every manager this suite constructs: raised
+    /// far past the suite's `.timeLimit` (2 min) so the limit is what records a genuinely wedged
+    /// build, and a merely starved one can never expire the await mid-test the way the 10 s
+    /// production default did on CI (see header).
+    private static let raisedRepublishBoundNanoseconds: UInt64 = 600_000_000_000
 
     /// Caught up at the tip — the residual banner requires the offer gate open, and on the device
     /// the pre-broadcast stop no-ops on an idle-at-tip engine, so the status stays `.upToDate`
@@ -167,7 +175,10 @@ import ComposableArchitecture
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
         } operation: {
-            let manager = MigrationManagerImpl(scheduleStorage: Self.makeEmptyScheduleStorage())
+            let manager = MigrationManagerImpl(
+                scheduleStorage: Self.makeEmptyScheduleStorage(),
+                lockRepublishTimeoutNanoseconds: Self.raisedRepublishBoundNanoseconds
+            )
 
             var cancellables = Set<AnyCancellable>()
             let preSweepSnapshot = await Self.firstSnapshot(
@@ -243,7 +254,10 @@ import ComposableArchitecture
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
         } operation: {
-            let manager = MigrationManagerImpl(scheduleStorage: Self.makeEmptyScheduleStorage())
+            let manager = MigrationManagerImpl(
+                scheduleStorage: Self.makeEmptyScheduleStorage(),
+                lockRepublishTimeoutNanoseconds: Self.raisedRepublishBoundNanoseconds
+            )
 
             var cancellables = Set<AnyCancellable>()
             let preSweepSnapshot = await Self.firstSnapshot(
@@ -303,7 +317,10 @@ import ComposableArchitecture
             )
             $0.zcashSDKEnvironment.ironwoodActivationHeight = { Self.activationHeight }
         } operation: {
-            let manager = MigrationManagerImpl(scheduleStorage: Self.makeEmptyScheduleStorage())
+            let manager = MigrationManagerImpl(
+                scheduleStorage: Self.makeEmptyScheduleStorage(),
+                lockRepublishTimeoutNanoseconds: Self.raisedRepublishBoundNanoseconds
+            )
 
             var cancellables = Set<AnyCancellable>()
             let preSweepSnapshot = await Self.firstSnapshot(


### PR DESCRIPTION
Stacked on #2050's branch — fixes the `unit_tests` failure its second CI run hit (run [33495197340](https://github.com/zodl-inc/zodl-ios/actions/runs/33495197340)); the flake itself is independent of the SDK switch and this changes no production behavior.

## The failure

`MigrationSweepBannerFreshnessTests.theSweepSuccessChainOutrunsItsOwnRepublish` recorded one issue: the deliberately-immediate flow-close re-read saw the stale `.residual(800_000)` instead of nil. The same commit content had passed 30 minutes earlier; the failing run shows heavy starvation (sub-second tests inflated to 60–92 s).

## Root cause

The suite header predicted this exact recurrence as "the one clock outside this file's control": `recordTransferBroadcast` wraps its awaited republish in `awaitBounded(nanoseconds: lockRepublishTimeoutNanoseconds)` — a hardcoded 10 s production liveness bound, past which the chain returns while the build keeps running detached. Under that run's starvation the mocked snapshot build outlasted 10 s, the chain returned early by design, and the immediate re-read observed the pre-sweep snapshot.

**Verification of the diagnosis:** constructing the manager with the bound forced to 1 ns reproduces the CI failure signature byte for byte, deterministically. The bound is the clock that lost.

## The fix

Promote `lockRepublishTimeoutNanoseconds` from a `private static let` to an init-injected instance constant — the same seam pattern the init already uses for `sessionOrdinalProvider` ("deterministic under test without weakening the production read"). The production default stays 10 s and no live call site passes the parameter, so shipped behavior is byte-identical.

The two suites that cross the real manager's bounded writer edges now construct their managers with the bound raised to 600 s — far past their own `.timeLimit` (2 min / 1 min), so a genuinely wedged build is still recorded by the limit, while load alone can no longer expire an awaited republish mid-test:

- `MigrationSweepBannerFreshnessTests` — all three tests (the failed one reads immediately after `recordTransferBroadcast` on purpose; that immediacy is the regression being pinned, so weakening the assertion was not an option).
- `MigrationSnapshotFreshnessTests.lockingRepublishesTheSnapshotBeforeReturning` — the identical latent race via `lockMigrationDust`, which its own header admitted; fixed before it burns a run of its own.

Both suite headers are updated to say the clock is now pinned rather than carrying the "a recurrence is the bound doing its job" caveat. No other suite is exposed — the rest mock the `migrationManager` dependency closure or exercise `MigrationScheduleStorage` directly.

## Verification

- Bound forced to 1 ns → the exact CI failure, locally reproducible on demand.
- Real fix (600 s) → both suites green in one run: 6 tests, 2 suites, iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)