### PR TITLE
[MOB-1853] Apply automatic server switches only when sync is idle and cancel the refresh at background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 
 ### Fixed
+- [MOB-1853] Automatic server switching no longer restarts a sync that is actively in progress; if syncing stalls, the app now looks for a healthier server by itself.
 - [MOB-1831] Opening Send immediately after launching ZODL now shows the saved spendable balance while automatic server selection completes.
 - The Keystone hardware wallet connection screen now refers to Zodl instead of Zashi in the note that a previously connected wallet needs to sync to find its transaction history.
 

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -225,6 +225,11 @@ extension Root {
                 // (#7) The one-shot start-failure retry is a foreground mechanism, same as the
                 // tick loop: cancel it and reset its latch so the next foreground starts clean.
                 state.didScheduleStartFailureRetry = false
+                // MOB-1853: an unknown sync state must never read as idle (see
+                // `isSynchronizerIdleForSwitch`), so the gate closes at background and stays closed
+                // until a fresh `.synchronizerStateChanged` tick reports in next foreground.
+                state.lastKnownSyncStatus = nil
+                state.isSyncStalledSinceLastProgress = false
                 // Tear down ALL synchronizer-driven subscriptions (plus the pending-transactions
                 // poller) over the now-stopped synchronizer; `.retryStart` on foreground rebuilds
                 // every one of them.
@@ -232,6 +237,7 @@ extension Root {
                     .cancel(id: state.CancelStateId),
                     .cancel(id: state.CancelTransactionsStateId),
                     .cancel(id: state.CancelEventId),
+                    .cancel(id: state.CancelSyncStalledEventId),
                     .cancel(id: state.CancelPendingTxPollId),
                     // MOB-1466: the tick loop is a FOREGROUND-only mechanism — the app cannot poll
                     // anything once backgrounded (there is no background lane), so its whole reason
@@ -244,7 +250,11 @@ extension Root {
                     // gate emission ran the full resume (clearing the arming flags, sending
                     // `.retryStart`, restarting the sync this boundary just stopped). The next
                     // foreground's `.registerForSynchronizersUpdate` respawns it.
-                    .cancel(id: state.migrationSyncGateCancelId)
+                    .cancel(id: state.migrationSyncGateCancelId),
+                    // MOB-1853: a benchmark/apply-switch run still in flight when the app
+                    // backgrounds must not land later against the synchronizer `stop()` above just
+                    // tore down.
+                    .cancel(id: state.automaticServerRefreshCancelId)
                 )
 
             case .initialization(.appDelegate(.backgroundTask(let task))):
@@ -268,6 +278,26 @@ extension Root {
                 }
                 
             case .synchronizerStateChanged(let latestState):
+                // MOB-1853: feeds `Root.State.isSynchronizerIdleForSwitch` -- like the announcement
+                // gate below, this must run above every early return in this case body, on every
+                // tick, regardless of whether an account is selected or a background task is in
+                // flight. `.upToDate` and a `.syncing` tick whose progress advanced past the last
+                // one recorded both mean the engine is visibly making progress again, so either
+                // clears a stall the `.syncStalled` hook (`RootTransactions.swift`) may have armed.
+                let newSyncStatus = latestState.data.syncStatus
+                switch newSyncStatus {
+                case .upToDate:
+                    state.isSyncStalledSinceLastProgress = false
+                case .syncing(let progress, _):
+                    if let lastKnownSyncProgress = state.lastKnownSyncProgress, progress > lastKnownSyncProgress {
+                        state.isSyncStalledSinceLastProgress = false
+                    }
+                    state.lastKnownSyncProgress = progress
+                case .unprepared, .stopped, .error:
+                    break
+                }
+                state.lastKnownSyncStatus = newSyncStatus
+
                 // Must run above the `selectedWalletAccount` guard and the background-task
                 // branch below — both early-return, but the announcement gate has to keep
                 // evaluating on every sync tick regardless of whether an account is selected

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -39,6 +39,12 @@ struct Root {
         }
         
         var CancelEventId = UUID()
+        /// MOB-1853: the `.syncStalled` event channel's own cancel id -- a dedicated `.publisher`
+        /// branch in the same `.observeTransactions` `.merge`, kept separate from `CancelEventId`'s
+        /// transaction-event channel so the two can never silently drop each other's event under a
+        /// shared "latest wins" throttle window (see `RootTransactions.swift`). Cancelled everywhere
+        /// `CancelEventId` is cancelled at `.didEnterBackground`.
+        var CancelSyncStalledEventId = UUID()
         var CancelId = UUID()
         var CancelResyncStateId = UUID()
         var CancelStateId = UUID()
@@ -131,7 +137,29 @@ struct Root {
         var isLockedInKeychainUnavailableState = false
         var isRestoringWallet = false
         var isStaleWalletHealedAlertPending = false
+        /// MOB-1853: true from the stall hook's own reaction (`gaveUp || attempt >= 2`, see
+        /// `Root.Action.syncStalled`'s handler) until the next `.synchronizerStateChanged` reports
+        /// either `.upToDate` or `.syncing` progress past `lastKnownSyncProgress` -- i.e. the engine
+        /// visibly moving again. While true, `isSynchronizerIdleForSwitch` treats a `.syncing`
+        /// status as idle too, since a stalled sync has nothing left for an automatic switch to
+        /// interrupt. Reset at `.didEnterBackground`, same as `lastKnownSyncStatus`.
+        var isSyncStalledSinceLastProgress = false
         @Shared(.appStorage(.lastAuthenticationTimestamp)) var lastAuthenticationTimestamp: Int = 0
+        /// The most recent `.syncing` progress value seen via `.synchronizerStateChanged`, kept
+        /// solely so that handler can detect a NEW tick's progress advancing past this one and
+        /// clear `isSyncStalledSinceLastProgress`. Not reset at `.didEnterBackground` -- the first
+        /// `.syncing` tick after a foreground restart is compared against this stale pre-background
+        /// value BEFORE it gets overwritten with the fresh one. That comparison can spuriously
+        /// "clear" a stall that this session never armed, but it is harmless:
+        /// `isSyncStalledSinceLastProgress` is already `false` from that same `.didEnterBackground`
+        /// reset, so there is nothing left for it to (no-op) clear.
+        var lastKnownSyncProgress: Float?
+        /// The last sync status `.synchronizerStateChanged` reported, read by
+        /// `isSynchronizerIdleForSwitch`. `nil` (nothing observed yet this session, or just reset at
+        /// `.didEnterBackground`) deliberately does NOT count as idle -- an automatic switch must
+        /// never run against an unknown sync state. A later task (transaction-list guards) reads
+        /// this too, hence a plain optional here rather than something private to the switch gate.
+        var lastKnownSyncStatus: SyncStatus?
         var maxResetZashiAppAttempts = ResetZashiConstants.maxResetZashiAppAttempts
         var maxResetZashiSDKAttempts = ResetZashiConstants.maxResetZashiSDKAttempts
         var messageToBeShared = ""
@@ -212,9 +240,27 @@ struct Root {
             }
         }
 
-        /// The local-snapshot read is completed before a candidate reaches this gate.
+        /// True once the synchronizer has told us enough to believe an automatic switch (which
+        /// tears down and rebuilds the synchronizer) will not interrupt an active sync: either the
+        /// last known status carries no progress a switch could lose (`.upToDate`, `.stopped`,
+        /// `.unprepared`, `.error`), or the sync has stalled since its last observed progress. `nil`
+        /// -- nothing observed yet, or just cleared at `.didEnterBackground` -- is deliberately NOT
+        /// idle.
+        var isSynchronizerIdleForSwitch: Bool {
+            if isSyncStalledSinceLastProgress { return true }
+            guard let lastKnownSyncStatus else { return false }
+            switch lastKnownSyncStatus {
+            case .upToDate, .stopped, .unprepared, .error: return true
+            case .syncing: return false
+            }
+        }
+
+        /// The local-snapshot read is completed before a candidate reaches this gate. Also
+        /// requires the synchronizer to be idle (`isSynchronizerIdleForSwitch`) -- a switch tears
+        /// down and rebuilds the synchronizer, so it must never land while a sync is actively
+        /// making progress.
         var canApplyAutoServerSwitch: Bool {
-            bgTask == nil && !isServerSetupVisible && !isSensitiveFlowActive
+            bgTask == nil && !isServerSetupVisible && !isSensitiveFlowActive && isSynchronizerIdleForSwitch
         }
 
         /// Gate for taking the screen over with the one-time Ironwood announcement.
@@ -348,6 +394,12 @@ struct Root {
         case observeTransactions
         case foundTransactions([ZcashTransaction.Overview])
         case minedTransaction(ZcashTransaction.Overview)
+        /// MOB-1853: mapped from `SynchronizerEvent.syncStalled` (see `.observeTransactions`) --
+        /// sent right before each recovery restart (`attempt`, 1-based) and once more when
+        /// recovery gives up. The handler always logs it; only `gaveUp || attempt >= 2` unblocks
+        /// an automatic server switch, since attempt 1 is the SDK's own cheap same-server
+        /// reconnect and must get its chance first.
+        case syncStalled(attempt: Int, gaveUp: Bool)
         case fetchTransactionsForTheSelectedAccount
         case fetchedTransactions(AccountUUID, IdentifiedArrayOf<TransactionState>)
         case noChangeInTransactions
@@ -626,8 +678,9 @@ struct Root {
                         benchmarkedAt: benchmarkedAt
                     )
                     let hardGates = "bgTask: \(state.bgTask != nil), serverSetup: \(state.isServerSetupVisible)"
-                    let gates = "\(hardGates), sensitiveFlow: \(state.isSensitiveFlowActive)"
-                    LoggerProxy.event("[AutoServerSelection] Candidate deferred (\(gates))")
+                    let gates = "\(hardGates), sensitiveFlow: \(state.isSensitiveFlowActive), idle: \(state.isSynchronizerIdleForSwitch)"
+                    let status = String(describing: state.lastKnownSyncStatus)
+                    LoggerProxy.event("[AutoServerSelection] Candidate deferred (\(gates), lastKnownSyncStatus: \(status))")
                     return .none
                 }
                 state.pendingServerCandidate = nil

--- a/secant/Sources/Features/Root/RootTransactions.swift
+++ b/secant/Sources/Features/Root/RootTransactions.swift
@@ -35,6 +35,23 @@ extension Root {
                     }
                     .cancellable(id: state.CancelEventId, cancelInFlight: true),
                     .publisher {
+                        // MOB-1853: a channel of its own, separate from the transaction events above.
+                        // Sharing one "latest wins" throttle window with them let one kind of event
+                        // silently replace the other as "latest" -- a `minedTransaction` could drop a
+                        // `syncStalled`, and a `syncStalled` could just as easily drop a
+                        // `minedTransaction`. The SDK emits `gaveUp: true` exactly once per handle, so
+                        // losing it here would disable the stall escape hatch for that handle.
+                        sdkSynchronizer.eventStream()
+                            .compactMap {
+                                if case SynchronizerEvent.syncStalled(let attempt, let gaveUp) = $0 {
+                                    return Root.Action.syncStalled(attempt: attempt, gaveUp: gaveUp)
+                                }
+                                return nil
+                            }
+                            .throttle(for: .seconds(0.2), scheduler: mainQueue, latest: true)
+                    }
+                    .cancellable(id: state.CancelSyncStalledEventId, cancelInFlight: true),
+                    .publisher {
                         sdkSynchronizer.stateStream()
                             .throttle(for: .seconds(0.2), scheduler: mainQueue, latest: true)
                             .map {
@@ -56,6 +73,15 @@ extension Root {
                 
             case .minedTransaction:
                 return .send(.fetchTransactionsForTheSelectedAccount)
+
+            case .syncStalled(let attempt, let gaveUp):
+                LoggerProxy.event("[AutoServerSelection] Sync stalled (attempt: \(attempt), gaveUp: \(gaveUp))")
+                // Attempt 1 is the SDK's own cheap reconnect to the SAME server -- it must get its
+                // chance before the app tears the synchronizer down for a benchmarked switch. Only
+                // a second restart, or recovery giving up outright, unblocks the switch.
+                guard gaveUp || attempt >= 2 else { return .none }
+                state.isSyncStalledSinceLastProgress = true
+                return .send(.refreshAutomaticServer)
 
             case .fetchTransactionsForTheSelectedAccount:
                 guard let accountUUID = state.selectedWalletAccount?.id else {

--- a/zodlTests/UtilTests/AutoServerSelectionClientTests.swift
+++ b/zodlTests/UtilTests/AutoServerSelectionClientTests.swift
@@ -110,6 +110,9 @@ struct RootAutoServerCandidateTests {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             var state = Root.State.initial
+            // MOB-1853: `canApplyAutoServerSwitch` now also requires an idle sync status; seed one
+            // so this test still isolates the sensitive-flow term it is named for.
+            state.lastKnownSyncStatus = .upToDate
             #expect(state.canApplyAutoServerSwitch)
 
             let sensitivePaths: [Root.State.Path] = [
@@ -152,6 +155,11 @@ struct RootAutoServerCandidateTests {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
             var state = Root.State.initial
+            // MOB-1853: `canApplyAutoServerSwitch` now also requires an idle sync status; seed one
+            // so this test still isolates the server-setup term it is named for.
+            state.lastKnownSyncStatus = .upToDate
+            #expect(state.canApplyAutoServerSwitch)
+
             state.serverSetupViewBinding = true
             #expect(!state.canApplyAutoServerSwitch)
 
@@ -174,7 +182,11 @@ struct RootAutoServerCandidateTests {
                 streamingCallTimeoutInMillis: 0
             )
             let didApply = LockIsolated(false)
-            let store = TestStore(initialState: Root.State.initial) {
+            // MOB-1853: `canApplyAutoServerSwitch` now also requires an idle sync status; seed one
+            // so this test still isolates the snapshot-read gate it is named for.
+            var initialState = Root.State.initial
+            initialState.lastKnownSyncStatus = .upToDate
+            let store = TestStore(initialState: initialState) {
                 Root()
             } withDependencies: {
                 $0.autoServerSelection = AutoServerSelectionClient(
@@ -210,7 +222,11 @@ struct RootAutoServerCandidateTests {
             let snapshotReadStarted = AsyncStream<Void>.makeStream()
             let snapshotReadRelease = AsyncStream<Void>.makeStream()
             let didApply = LockIsolated(false)
-            let store = TestStore(initialState: Root.State.initial) {
+            // MOB-1853: `canApplyAutoServerSwitch` now also requires an idle sync status; seed one
+            // so this test still isolates the snapshot-read gate it is named for.
+            var initialState = Root.State.initial
+            initialState.lastKnownSyncStatus = .upToDate
+            let store = TestStore(initialState: initialState) {
                 Root()
             } withDependencies: {
                 $0.autoServerSelection = AutoServerSelectionClient(
@@ -260,7 +276,11 @@ struct RootAutoServerCandidateTests {
             )
             let benchmarkedAt = Date(timeIntervalSince1970: 1_000_000)
             let didApply = LockIsolated(false)
-            let store = TestStore(initialState: Root.State.initial) {
+            // MOB-1853: `canApplyAutoServerSwitch` now also requires an idle sync status; seed one
+            // so this test still isolates the empty-snapshot behavior it is named for.
+            var initialState = Root.State.initial
+            initialState.lastKnownSyncStatus = .upToDate
+            let store = TestStore(initialState: initialState) {
                 Root()
             } withDependencies: {
                 $0.autoServerSelection = AutoServerSelectionClient(

--- a/zodlTests/UtilTests/RootAutoServerIdleGateTests.swift
+++ b/zodlTests/UtilTests/RootAutoServerIdleGateTests.swift
@@ -1,0 +1,318 @@
+//
+//  RootAutoServerIdleGateTests.swift
+//  zodlTests
+//
+//  MOB-1853 — automatic server switches must not race an active sync. Covers
+//  `Root.State.isSynchronizerIdleForSwitch` / `canApplyAutoServerSwitch` picking up
+//  `lastKnownSyncStatus` (`RootStore.swift`), `.synchronizerStateChanged` recording it and
+//  clearing a recorded stall (`RootInitialization.swift`), `.didEnterBackground` cancelling an
+//  in-flight refresh and resetting both to their "unknown" state (`RootInitialization.swift`),
+//  and the `.syncStalled` stall hook that only unblocks a switch from the SDK's second recovery
+//  restart onward, or once it gives up outright (`RootTransactions.swift`).
+//
+//  Mirrors `RootAutoServerCandidateTests` (`AutoServerSelectionClientTests.swift`) for driving
+//  `Root` via `TestStore` with `exhaustivity = .off`, and `RootIronwoodAnnouncementGateTests`'
+//  `fixtureSyncState` for building a `RedactableSynchronizerState` off `SynchronizerState.zero`.
+//  `latestBlockHeight` is deliberately left at its `.zero` default throughout this file: the
+//  Ironwood announcement check inside `.synchronizerStateChanged` short-circuits on `tip > 0`
+//  before it would otherwise need `zcashSDKEnvironment.ironwoodActivationHeight` stubbed.
+//
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized, and each test additionally scopes a fresh `InMemoryStorage()` via
+// `withDependencies` — the same belt-and-suspenders precedent as `RootAutoServerCandidateTests`
+// for a suite driving `Root.State`'s process-global `@Shared(.inMemory(...))` keys.
+@Suite(.serialized) @MainActor struct RootAutoServerIdleGateTests {
+    // MARK: - Fixtures
+
+    private func endpoint(_ host: String) -> LightWalletEndpoint {
+        LightWalletEndpoint(address: host, port: 443, secure: true, streamingCallTimeoutInMillis: 0)
+    }
+
+    /// `latestBlockHeight` stays at `SynchronizerState.zero`'s default (0) -- see the file header
+    /// for why that keeps the Ironwood announcement check a no-op.
+    private func fixtureSyncState(_ status: SyncStatus) -> RedactableSynchronizerState {
+        var syncState = SynchronizerState.zero
+        syncState.syncStatus = status
+        return syncState.redacted
+    }
+
+    /// Builds a `Root` `TestStore`. `autoServerSelection` defaults to spy-free no-ops; individual
+    /// tests override `findBestServer`/`applySwitch` to observe what the gate actually did.
+    private func makeStore(
+        state: Root.State,
+        findBestServer: @escaping @Sendable () async -> LightWalletEndpoint? = { nil },
+        applySwitch: @escaping @Sendable (LightWalletEndpoint) async -> Bool = { _ in false }
+    ) -> TestStore<Root.State, Root.Action> {
+        let store = TestStore(initialState: state) {
+            Root()
+        } withDependencies: {
+            $0.autoServerSelection = AutoServerSelectionClient(
+                findBestServer: findBestServer,
+                applySwitch: applySwitch
+            )
+            $0.sdkSynchronizer = .mocked()
+            $0.date.now = { Date(timeIntervalSince1970: 1_000_000) }
+        }
+        store.exhaustivity = .off
+        return store
+    }
+
+    // MARK: - 1 & 2: a candidate is parked while syncing, then applied once sync reaches upToDate
+
+    @Test
+    func candidateArrivesWhileSyncingIsParkedThenAppliedOnceUpToDate() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.5, false)
+            // Isolates this test from the migration-reconcile edge `.synchronizerStateChanged`
+            // also runs on an `.upToDate` tick -- not what this test is about.
+            state.wasSyncUpToDateForMigration = true
+
+            let applyCallCount = LockIsolated(0)
+            let store = makeStore(
+                state: state,
+                applySwitch: { _ in
+                    applyCallCount.withValue { $0 += 1 }
+                    return true
+                }
+            )
+
+            let candidate = endpoint("na.zec.rocks")
+            let benchmarkedAt = Date(timeIntervalSince1970: 1_000_000)
+
+            // 1. A candidate arriving while syncing is parked, not applied: `.syncing` is not idle.
+            await store.send(.autoServerCandidateReady(candidate, benchmarkedAt))
+            #expect(store.state.pendingServerCandidate?.endpoint.host == candidate.host)
+            #expect(applyCallCount.value == 0)
+
+            // 2. Sync reaching `.upToDate` flips `canApplyAutoServerSwitch` true; `Root.body`'s
+            // `onChange` re-feeds the parked candidate and it applies exactly once.
+            await store.send(.synchronizerStateChanged(fixtureSyncState(.upToDate)))
+            await store.finish()
+
+            #expect(applyCallCount.value == 1)
+            #expect(store.state.pendingServerCandidate == nil)
+        }
+    }
+
+    // MARK: - 3: an unknown sync status keeps the gate closed
+
+    @Test
+    func nilSyncStatusClosesTheGate() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            // `Root.State.initial` leaves `lastKnownSyncStatus` at its `nil` default -- nothing
+            // observed yet this session.
+            let state = Root.State.initial
+            let applyCallCount = LockIsolated(0)
+            let store = makeStore(
+                state: state,
+                applySwitch: { _ in
+                    applyCallCount.withValue { $0 += 1 }
+                    return true
+                }
+            )
+
+            let candidate = endpoint("na.zec.rocks")
+            await store.send(.autoServerCandidateReady(candidate, Date(timeIntervalSince1970: 1_000_000)))
+
+            #expect(store.state.pendingServerCandidate?.endpoint.host == candidate.host)
+            #expect(applyCallCount.value == 0, "an unknown sync status must never read as idle")
+        }
+    }
+
+    // MARK: - 4: backgrounding cancels a running refresh
+
+    @Test
+    func backgroundingCancelsTheRefreshEffect() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .upToDate
+
+            // Deliberately never resolves on its own (a real benchmark call could easily run
+            // longer than a background transition) -- this proves the effect is CANCELLED by
+            // `.didEnterBackground`, not merely outraced by a faster stub.
+            let store = makeStore(
+                state: state,
+                findBestServer: {
+                    try? await Task.sleep(nanoseconds: 60 * NSEC_PER_SEC)
+                    return nil
+                }
+            )
+
+            await store.send(.refreshAutomaticServer)
+            await store.send(.initialization(.appDelegate(.didEnterBackground)))
+
+            // `TestStore.finish()` is bounded by its own 1s default timeout: if the cancel above
+            // never reached `automaticServerRefreshCancelId`'s effect, this reports the
+            // still-in-flight effect as a failure instead of hanging on the 60s stub.
+            await store.finish()
+        }
+    }
+
+    // MARK: - 5: the stall hook only unblocks a switch from the second restart, or a give-up
+
+    @Test
+    func firstAttemptStallIsLoggedOnlyAndLeavesTheGateClosed() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.5, false)
+            // `store.exhaustivity = .off` means `store.finish()` alone would silently accept an
+            // unreceived `.refreshAutomaticServer` -- that proves nothing about whether the effect
+            // actually ran. Wiring a spy into `findBestServer` (the first thing `.refreshAutomaticServer`
+            // does) and asserting it was never invoked is what actually proves "no refresh happened".
+            let findBestServerCallCount = LockIsolated(0)
+            let store = makeStore(
+                state: state,
+                findBestServer: {
+                    findBestServerCallCount.withValue { $0 += 1 }
+                    return nil
+                }
+            )
+
+            await store.send(.syncStalled(attempt: 1, gaveUp: false))
+            await store.finish()
+
+            #expect(!store.state.isSyncStalledSinceLastProgress, "attempt 1 is the SDK's own cheap reconnect and must get its chance first")
+            #expect(findBestServerCallCount.value == 0, "attempt 1 must not trigger a refresh")
+        }
+    }
+
+    @Test
+    func secondAttemptStallOpensTheGateAndSendsARefresh() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.5, false)
+            let store = makeStore(state: state)
+
+            await store.send(.syncStalled(attempt: 2, gaveUp: false)) {
+                $0.isSyncStalledSinceLastProgress = true
+            }
+            await store.receive(\.refreshAutomaticServer)
+            await store.finish()
+        }
+    }
+
+    @Test
+    func gaveUpStallOpensTheGateAndSendsARefresh() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.5, false)
+            let store = makeStore(state: state)
+
+            // Same shape as attempt 2: a give-up unblocks the switch regardless of the attempt
+            // count that reached it.
+            await store.send(.syncStalled(attempt: 3, gaveUp: true)) {
+                $0.isSyncStalledSinceLastProgress = true
+            }
+            await store.receive(\.refreshAutomaticServer)
+            await store.finish()
+        }
+    }
+
+    // MARK: - 6: `.synchronizerStateChanged` clears a recorded stall once the engine visibly
+    // makes progress again (`RootInitialization.swift`'s `.upToDate`/`.syncing` handling)
+
+    @Test
+    func stalledFlagClearsOnUpToDate() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.5, false)
+            state.isSyncStalledSinceLastProgress = true
+            // Isolates this test from the migration-reconcile edge `.synchronizerStateChanged`
+            // also runs on an `.upToDate` tick -- not what this test is about (same precedent as
+            // test 1&2's fixture above).
+            state.wasSyncUpToDateForMigration = true
+            let store = makeStore(state: state)
+
+            await store.send(.synchronizerStateChanged(fixtureSyncState(.upToDate))) {
+                $0.isSyncStalledSinceLastProgress = false
+            }
+            await store.finish()
+        }
+    }
+
+    @Test
+    func stalledFlagClearsWhenSyncingProgressAdvancesPastLastRecorded() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.3, false)
+            state.lastKnownSyncProgress = 0.3
+            state.isSyncStalledSinceLastProgress = true
+            let store = makeStore(state: state)
+
+            await store.send(.synchronizerStateChanged(fixtureSyncState(.syncing(0.4, false)))) {
+                $0.isSyncStalledSinceLastProgress = false
+                $0.lastKnownSyncProgress = 0.4
+            }
+            await store.finish()
+        }
+    }
+
+    @Test
+    func stalledFlagStaysSetWhenSyncingProgressIsUnchanged() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.4, false)
+            state.lastKnownSyncProgress = 0.4
+            state.isSyncStalledSinceLastProgress = true
+            let store = makeStore(state: state)
+
+            await store.send(.synchronizerStateChanged(fixtureSyncState(.syncing(0.4, false))))
+            await store.finish()
+
+            #expect(store.state.isSyncStalledSinceLastProgress, "equal progress is not forward movement")
+            #expect(store.state.lastKnownSyncProgress == 0.4)
+        }
+    }
+
+    @Test
+    func firstSyncingTickRecordsProgressAndFlagClearsOnNextHigherTick() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Root.State.initial
+            state.lastKnownSyncStatus = .syncing(0.2, false)
+            state.lastKnownSyncProgress = nil
+            state.isSyncStalledSinceLastProgress = true
+            let store = makeStore(state: state)
+
+            // First tick: nothing recorded yet to compare against, so the flag must NOT clear --
+            // but the progress DOES get recorded, for the next tick to compare against.
+            await store.send(.synchronizerStateChanged(fixtureSyncState(.syncing(0.2, false)))) {
+                $0.lastKnownSyncProgress = 0.2
+            }
+            #expect(store.state.isSyncStalledSinceLastProgress, "nothing to compare against on the very first observed tick")
+
+            // Second, higher tick: now clears against the just-recorded progress.
+            await store.send(.synchronizerStateChanged(fixtureSyncState(.syncing(0.3, false)))) {
+                $0.isSyncStalledSinceLastProgress = false
+                $0.lastKnownSyncProgress = 0.3
+            }
+            await store.finish()
+        }
+    }
+}


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1853.

**What:** automatic server switches now apply only while the synchronizer is idle (`upToDate`, `stopped`, `unprepared`, `error`), tracked from the state stream; a candidate that arrives mid-sync is parked and re-applied by the existing gate observer when sync settles. The automatic refresh is cancelled when the app goes to background, so a benchmark started before backgrounding cannot switch servers later. When the SDK reports that a sync pass stalled and its own reconnect did not help (second attempt or give-up), the app treats the sync as idle and runs a benchmark, so a healthier server can be chosen without waiting for the next foreground. The stall signal has its own event channel, separate from the throttled transaction events.

**Why:** the gate never checked whether a pass was in flight, so a switch could tear down a sync in progress; and once switches are idle-only, a stalled pass would otherwise block the only recovery an app that gives the engine no alternate servers has.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `RootAutoServerIdleGateTests` (new, 10 tests): candidate parked while syncing and applied once on `upToDate`; `nil` status keeps the gate closed; background cancels the refresh effect; attempt-1 stall is logged only (no benchmark call); attempt-2 and give-up open the gate and trigger a refresh; the stalled flag clears on `upToDate` and on progress. `AutoServerSelectionClientTests`, `RootAutoServerCandidateTests` and the four `RootTransactionsTests` suites pass.
- Manual (testnet): while a restore is syncing, change nothing and watch the log — a benchmark winner is logged as deferred with `idle: false` and applied after the sync reaches `upToDate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)