### PR TITLE
[MOB-1854] Guard retryStart against re-entry

### DIFF
--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -240,7 +240,10 @@ extension SDKSynchronizerClient {
         latestState: @escaping @Sendable () -> SynchronizerState = { .zero },
         latestScannedHeight: @escaping @Sendable () -> BlockHeight = { 0 },
         prepareWith: @escaping @Sendable ([UInt8], BlockHeight?, String, String?) async throws -> Initializer.InitializationResult = { _, _, _, _ in .success },
-        start: @escaping @Sendable (_ retry: Bool) throws -> Void = { _ in },
+        // MOB-1854: `async` (matching `SDKSynchronizerClient.start`'s real type) so a test's stub can
+        // genuinely suspend (e.g. on a gate) rather than only throw/return synchronously — every
+        // existing call site passes a non-awaiting closure, which stays valid under this wider type.
+        start: @escaping @Sendable (_ retry: Bool) async throws -> Void = { _ in },
         stop: @escaping @Sendable () -> Void = { },
         isSyncing: @escaping @Sendable () -> Bool = { false },
         isInitialized: @escaping @Sendable () -> Bool = { false },

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -89,6 +89,7 @@ extension Root {
         case synchronizerStartFailed(ZcashError)
         case registerForSynchronizersUpdate
         case retryStart
+        case retryStartFinished
         case walletConfigChanged(WalletConfig)
     }
 
@@ -230,6 +231,9 @@ extension Root {
                 // until a fresh `.synchronizerStateChanged` tick reports in next foreground.
                 state.lastKnownSyncStatus = nil
                 state.isSyncStalledSinceLastProgress = false
+                // MOB-1854: a pipeline whose finishing `send(.retryStartFinished)` was dropped by
+                // cancellation (store teardown) must never wedge the next foreground's retryStart.
+                state.isRetryStartInFlight = false
                 // Tear down ALL synchronizer-driven subscriptions (plus the pending-transactions
                 // poller) over the now-stopped synchronizer; `.retryStart` on foreground rebuilds
                 // every one of them.
@@ -757,6 +761,16 @@ extension Root {
                 state.syncDeferredByMigrationGate = false
                 @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
                 $migrationStoppedSyncForBroadcast.withLock { $0 = false }
+                // MOB-1854: drop a re-entrant retryStart rather than cancelling the in-flight
+                // pipeline — `SlipstreamSynchronizer.start()` has no cancellation points, so
+                // cancelling it mid-flight would let it run to completion anyway and a second
+                // pipeline would then call `start()` again, draining and restarting the engine. The
+                // in-flight pipeline performs the same work this one would have.
+                guard !state.isRetryStartInFlight else {
+                    LoggerProxy.event("[Root] retryStart ignored: a start pipeline is already in flight")
+                    return .none
+                }
+                state.isRetryStartInFlight = true
                 return .run { [state] send in
                     do {
                         // ZIP 318 session separation, decided BEFORE the wire is touched: if any
@@ -879,6 +893,10 @@ extension Root {
                         // the list observing what its own broadcast creates.
                         await send(.observeTransactions)
                         await send(.refreshAutomaticServer)
+                        // MOB-1854: clears `isRetryStartInFlight` — must be the LAST statement of
+                        // this exit path so a re-entrant retryStart is only ever dropped while this
+                        // pipeline is genuinely still doing something.
+                        await send(.initialization(.retryStartFinished))
                     } catch {
                         if state.bgTask != nil {
                             LoggerProxy.event("BGTask synchronizer.start() failed \(error.toZcashError())")
@@ -890,8 +908,15 @@ extension Root {
                         // emissions, no resume until the next background→foreground round trip.
                         await send(.initialization(.registerForSynchronizersUpdate))
                         await send(.initialization(.synchronizerStartFailed(error.toZcashError())))
+                        // MOB-1854: same latch clear as the success path above — the last statement
+                        // of this exit path too, so a start failure can't leave retryStart wedged.
+                        await send(.initialization(.retryStartFinished))
                     }
                 }
+
+            case .initialization(.retryStartFinished):
+                state.isRetryStartInFlight = false
+                return .none
 
             case .initialization(.registerForSynchronizersUpdate):
                 let stateStreamEffect = Effect.publisher {

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -136,6 +136,11 @@ struct Root {
         var isInitializingSDK = false
         var isLockedInKeychainUnavailableState = false
         var isRestoringWallet = false
+        /// MOB-1854: single-flight latch for `.initialization(.retryStart)` — `start()` has no
+        /// cancellation points, so a re-entrant retryStart is dropped (and logged) rather than
+        /// cancelling the in-flight pipeline. Reset at `.didEnterBackground` so a pipeline whose
+        /// finishing `send` was dropped by cancellation can never wedge the next foreground.
+        var isRetryStartInFlight = false
         var isStaleWalletHealedAlertPending = false
         /// MOB-1853: true from the stall hook's own reaction (`gaveUp || attempt >= 2`, see
         /// `Root.Action.syncStalled`'s handler) until the next `.synchronizerStateChanged` reports

--- a/zodlTests/UtilTests/RootRetryStartReentrancyTests.swift
+++ b/zodlTests/UtilTests/RootRetryStartReentrancyTests.swift
@@ -1,0 +1,219 @@
+//
+//  RootRetryStartReentrancyTests.swift
+//  zodlTests
+//
+//  MOB-1854: guards `.initialization(.retryStart)` against re-entry. `.retryStart` is sent from
+//  several independent sites (foreground, the background task, the start-failure retry, the
+//  migration gate resume), so two start pipelines can overlap. `SlipstreamSynchronizer.start()` has
+//  no cancellation points, so cancelling the first pipeline mid-`start()` would let it run to
+//  completion anyway and the second pipeline would then call `start()` again — draining and
+//  restarting the engine. `Root.State.isRetryStartInFlight` makes the FIRST pipeline win instead: a
+//  re-entrant `.retryStart` is dropped (and logged) while a pipeline is already running, and
+//  `.retryStartFinished` — sent as the last statement of both the success and failure exits of the
+//  `.run` effect — clears the latch once that pipeline is done.
+//
+//  This suite holds `sdkSynchronizer.start` open on a gate to drive the race directly, mirroring
+//  `RootInitializeSDKSingleFlightTests`' `PrepareGate` pattern (itself the single-flight precedent
+//  for `isInitializingSDK`/`initializeSDKFinished`) and reusing `RootMigrationGateRefusalTests`'
+//  proven dependency stub set for a full, successful sync-branch `.retryStart` pass.
+//
+
+@preconcurrency import Combine
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+// Serialized per repo convention for suites driving `.retryStart`/`.didEnterBackground` through a
+// real TestStore — see RootMigrationGateRefusalTests' identical `@Suite(.serialized)` rationale.
+// `.timeLimit` records a gate that genuinely never opens (or a finishing action that genuinely never
+// arrives) as a failure instead of hanging the run.
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootRetryStartReentrancyTests {
+    private static let seedDerivedAccount = WalletAccount(
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 0x01, count: 16)),
+            name: "Zashi",
+            keySource: "zashi",
+            seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    )
+
+    /// Builds a `Root` `TestStore` wired for a full, successful sync-branch `.retryStart` pass —
+    /// the same dependency shape as `RootMigrationGateRefusalTests.syncPassStillReRegistersSynchronizerStreams`.
+    /// Every `sdkSynchronizer.start` call is recorded into `startCalls` and then suspends on `gate`
+    /// until the test releases it, holding the pipeline "in flight" for as long as the race needs
+    /// the window held open.
+    private func makeStore(
+        startCalls: SignalledRecords<Void>,
+        gate: ResumableGate
+    ) -> TestStore<Root.State, Root.Action> {
+        let seedDerivedAccount = RootRetryStartReentrancyTests.seedDerivedAccount
+        let initialState = Root.State(
+            destinationState: Root.DestinationState(internalDestination: .home),
+            exportLogsState: ExportLogs.State(),
+            onboardingState: RestoreWalletCoordFlow.State(),
+            phraseDisplayState: RecoveryPhraseDisplay.State(),
+            walletConfig: .initial,
+            welcomeState: Welcome.State()
+        )
+
+        let store = TestStore(
+            initialState: initialState
+        ) {
+            Root()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            $0.continuousClock = TestClock()
+
+            $0.exchangeRate = .noOp
+            $0.autolockHandler = .noOp
+            $0.shieldingProcessor = ShieldingProcessorClient(
+                observe: { Empty().eraseToAnyPublisher() },
+                shieldFunds: { }
+            )
+
+            $0.mnemonic = .noOp
+            $0.databaseFiles = .noOp
+
+            $0.walletStorage = .noOp
+            $0.walletStorage.exportWallet = { .placeholder }
+
+            $0.flexaHandler = .noOp
+            $0.flexaHandler.signOut = { }
+
+            $0.userStoredPreferences.removeAll = { }
+            $0.readTransactionsStorage = .noOp
+
+            $0.userDefaults.objectForKey = { _ in nil }
+            $0.userDefaults.remove = { _ in }
+            $0.userDefaults.setValue = { _, _ in }
+
+            $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
+            $0.userMetadataProvider.load = { _ in }
+
+            $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+
+            $0.sdkSynchronizer = .mocked(
+                stateStream: { Empty().eraseToAnyPublisher() },
+                latestState: {
+                    var syncState = SynchronizerState.zero
+                    syncState.syncStatus = .upToDate
+                    return syncState
+                },
+                prepareWith: { _, _, _, _ in .success },
+                start: { _ in
+                    startCalls.recordCall()
+                    await gate.wait()
+                },
+                getAllTransactions: { _ in [] },
+                isSeedRelevantToAnyDerivedAccount: { _ in true },
+                walletAccounts: { [seedDerivedAccount] }
+            )
+        }
+        store.exhaustivity = .off
+        return store
+    }
+
+    /// Lets the rest of a cascade (SmartBanner evaluation, contacts, user metadata, the battery-state
+    /// subscription, the migration gate stream, …) settle without asserting on any of it — identical
+    /// rationale to RootMigrationGateRefusalTests' `drain`.
+    private func drain(_ store: TestStore<Root.State, Root.Action>) async {
+        await store.send(.cancelAllRunningEffects)
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+    }
+
+    // MARK: - A re-entrant retryStart is dropped: start() is called exactly once
+
+    @Test func secondRetryStartWhileFirstInFlightDropsWithoutCallingStartAgain() async throws {
+        let startCalls = SignalledRecords<Void>()
+        let gate = ResumableGate()
+        let store = makeStore(startCalls: startCalls, gate: gate)
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        await startCalls.countReached(1)
+
+        // The first pipeline is still parked on the gate — a second retryStart arriving now must be
+        // dropped: no second `start()` call, and (under .off exhaustivity) no unexpected state change
+        // since the guard's `else` branch is a bare `return .none`.
+        await store.send(.initialization(.retryStart))
+
+        #expect(startCalls.count == 1, "a retryStart arriving while a pipeline is in flight must not call start() again")
+        #expect(store.state.isRetryStartInFlight, "the in-flight pipeline's own latch must be untouched by the dropped duplicate")
+
+        gate.open()
+        await drain(store)
+    }
+
+    // MARK: - retryStartFinished clears the latch; the next retryStart proceeds normally
+
+    @Test func retryStartFinishedClearsTheLatchAndAllowsTheNextPipelineToCallStartAgain() async throws {
+        let startCalls = SignalledRecords<Void>()
+        let gate = ResumableGate()
+        let store = makeStore(startCalls: startCalls, gate: gate)
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        await startCalls.countReached(1)
+
+        gate.open()
+
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStartFinished) = action else { return false }
+                return true
+            },
+            timeout: .seconds(10)
+        ) {
+            $0.isRetryStartInFlight = false
+        }
+
+        // A THIRD retryStart, sent only after the finishing action cleared the latch, must call
+        // start() again — the guard is a single-flight latch, not a one-shot.
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        await startCalls.countReached(2)
+        #expect(startCalls.count == 2, "retryStart after the latch clears must call start() again")
+
+        gate.open()
+        await drain(store)
+    }
+
+    // MARK: - didEnterBackground resets the latch even if the in-flight pipeline never finished
+
+    @Test func retryStartAfterDidEnterBackgroundProceedsEvenIfThePreviousPipelineNeverFinished() async throws {
+        let startCalls = SignalledRecords<Void>()
+        let gate = ResumableGate()
+        let store = makeStore(startCalls: startCalls, gate: gate)
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        await startCalls.countReached(1)
+
+        // Background WITHOUT releasing the gate — the first pipeline's `.run` effect carries no
+        // `.cancellable` id of its own, so it stays parked, and its finishing send never arrives.
+        // This is exactly the "dropped by cancellation (store teardown)" scenario the background
+        // reset exists to guard against — reproduced here directly via a pipeline that simply never
+        // completes.
+        await store.send(.initialization(.appDelegate(.didEnterBackground)))
+        #expect(!store.state.isRetryStartInFlight, "backgrounding must reset the latch even though the in-flight pipeline never finished")
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        await startCalls.countReached(2)
+        #expect(startCalls.count == 2, "a retryStart after backgrounding must proceed even though the previous pipeline never finished")
+
+        gate.open()
+        await drain(store)
+    }
+}


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1854.

**What:** the `retryStart` pipeline (migration visit, synchronizer start, stream registration, automatic server refresh) now runs one at a time. A `retryStart` that arrives while one is in flight is logged and dropped; the in-flight pipeline performs the same work. The flag is cleared by a finishing action on both exit paths of the effect and reset when the app goes to background, so a dropped send can never wedge the next foreground.

**Why:** `retryStart` is sent from the foreground transition, the background task, the start-failure retry and the migration-gate resume, so two start pipelines could overlap and each could tear down and restart the sync. Cancelling the first pipeline was rejected: the SDK's `start()` has no cancellation points, so the first start would complete anyway and the second would restart the pass.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `RootRetryStartReentrancyTests` (new, 3 tests, real suspension gate on `start`): two back-to-back `retryStart` call `start` once; a third after the finishing action proceeds; after background a `retryStart` proceeds even if the previous pipeline never finished. Full `zodlTests`: 1597 tests passed (2 pre-existing known issues).
- The `SDKSynchronizerClient.mocked(start:)` test helper now accepts an `async throws` closure to match the real dependency; existing callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)