### PR TITLE
[MOB-1855] Keep the transaction list through spurious empty fetches and clear invalidation on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 
 ### Fixed
+- [MOB-1855] The transaction list no longer empties or stays stuck on placeholders while the wallet is still catching up on sync.
 - [MOB-1853] Automatic server switching no longer restarts a sync that is actively in progress; if syncing stalls, the app now looks for a healthier server by itself.
 - [MOB-1831] Opening Send immediately after launching ZODL now shows the saved spendable balance while automatic server selection completes.
 - The Keystone hardware wallet connection screen now refers to Zodl instead of Zashi in the note that a previously connected wallet needs to sync to find its transaction history.

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -407,6 +407,17 @@ struct Root {
         case syncStalled(attempt: Int, gaveUp: Bool)
         case fetchTransactionsForTheSelectedAccount
         case fetchedTransactions(AccountUUID, IdentifiedArrayOf<TransactionState>)
+        /// MOB-1855: sent from `.fetchTransactionsForTheSelectedAccount`'s `catch` when
+        /// `getAllTransactions` throws, carrying the account the failed fetch was for. The handler
+        /// applies the same provenance guard as `.fetchedTransactions` above -- a failure for an
+        /// account the user has since switched away from must change nothing, or it would clear the
+        /// NEWLY selected account's `isInvalidated` flags and re-arm the poller using the PREVIOUS
+        /// account's leftover `state.transactions`, marking the new account "loaded" while the old
+        /// rows are still what is on screen. For the current account, the list keeps its previous
+        /// contents either way, but a failed fetch must still clear any list still showing its
+        /// loading placeholder and re-arm the reconciliation poller from the KEPT rows -- see
+        /// `RootTransactions.swift`.
+        case transactionsFetchFailed(accountUUID: AccountUUID)
         case noChangeInTransactions
         
         // Address Book

--- a/secant/Sources/Features/Root/RootTransactions.swift
+++ b/secant/Sources/Features/Root/RootTransactions.swift
@@ -85,6 +85,7 @@ extension Root {
 
             case .fetchTransactionsForTheSelectedAccount:
                 guard let accountUUID = state.selectedWalletAccount?.id else {
+                    LoggerProxy.event("[RootTransactions] fetch skipped: no selected account yet")
                     return .none
                 }
                 // This id exists so an account switch can cancel whatever fetch is still running
@@ -108,10 +109,13 @@ extension Root {
                         // decode (field, 2026-08-04 — NULL trust_status meeting a strict decode)
                         // rendered as an EMPTY transaction list with no trace anywhere, reading as
                         // data loss. The list keeps its previous contents; the error goes to the
-                        // log where the next investigation can find it. No user-facing alert: the
-                        // pending-transactions poller and the next synchronizer event both retry
-                        // this fetch.
+                        // log where the next investigation can find it. No user-facing alert:
+                        // `.transactionsFetchFailed` (below) still clears any list left showing its
+                        // loading placeholder and re-arms the reconciliation poller from the KEPT
+                        // rows, so together with the pending-transactions poller and the next
+                        // synchronizer event, this fetch gets retried.
                         LoggerProxy.event("[RootTransactions] getAllTransactions FAILED — \(error.toZcashError())")
+                        await send(.transactionsFetchFailed(accountUUID: accountUUID))
                     }
                 }
                 .cancellable(id: state.CancelTransactionsFetchId)
@@ -126,26 +130,6 @@ extension Root {
                 guard accountUUID == state.selectedWalletAccount?.id else {
                     return .none
                 }
-
-                // ZIP 318 labels: Activity now PRESENTS migration transactions instead of hiding
-                // them — a stored-but-unmined row renders as "Migrating…"/"Splitting Balance…"
-                // with the coins-swap glyph (Figma "Transaction Statuses/Labels — Final Designs"),
-                // so the store-at-prove rows that once looked like phantom "Sending…" sends now
-                // tell the true in-flight story right on the list. This supersedes the M3 Part A
-                // filter that removed them. This is still the single canonical list build, so
-                // every consumer of the shared `$transactions` sees the same truth.
-                //
-                // M3 B2 (unchanged): the SAME rows are what the SDK's pending-balance lanes count
-                // for the whole prove→mine window, so their received value is still published
-                // beside the canonical list — one pass, one clock — for the balance-breakdown
-                // sheet to remove from its displayed "Pending" row. `totalReceived` is exactly a
-                // migration transaction's contribution to the pending lanes (all its real outputs
-                // are internal, and its spent side never enters them); a nil reads as zero, which
-                // under-corrects — conservative, never future-tense.
-                let unminedMigrationPending = transactions
-                    .filter { $0.isUnminedMigrationTransaction }
-                    .reduce(Zatoshi.zero) { $0 + ($1.totalReceived ?? Zatoshi.zero) }
-                state.$unminedMigrationPendingValue.withLock { $0 = unminedMigrationPending }
 
                 let mempoolHeight = sdkSynchronizer.latestState().latestBlockHeight + 1
 
@@ -199,29 +183,60 @@ extension Root {
                 // a mined transaction rendered as "Sending…" forever). Re-read the local database
                 // every 30 seconds until nothing is pending — a cheap SQLite read, no network.
                 // Managed on every completed fetch, including ones whose payload equals the current
-                // state, so an unchanged list keeps the poller alive.
-                //
-                // Deliberately restricted to `.zcash` transactions, whose pending state is
-                // `minedHeight == nil` and therefore resolvable by exactly the local re-read this
-                // poller performs. For every other type `isPending` reports the SWAP status
-                // (`TransactionState.isPending`), which is owned by the swap provider's metadata and
-                // refreshed by `.autoUpdateCandidatesSwapDetails` in `RootSwaps` — re-reading the
-                // SDK database can never resolve it. Including those here would leave a swap parked
-                // in `.pending`/`.incomplete` (an abandoned or stalled swap never has to resolve)
-                // polling every 30 seconds for the rest of the session, with no state it could
-                // possibly settle.
-                let pendingTransactionsPoller: Effect<Root.Action>
-                if identifiedArray.contains(where: { $0.type == .zcash && $0.isPending }) {
-                    pendingTransactionsPoller = .run { send in
-                        while !Task.isCancelled {
-                            try await mainQueue.sleep(for: .seconds(30))
-                            await send(.fetchTransactionsForTheSelectedAccount)
-                        }
-                    }
-                    .cancellable(id: state.CancelPendingTxPollId, cancelInFlight: true)
-                } else {
-                    pendingTransactionsPoller = .cancel(id: state.CancelPendingTxPollId)
+                // state, so an unchanged list keeps the poller alive. Extracted into
+                // `reconciliationPoller(for:state:)` below so the ignored-empty-fetch and
+                // fetch-failure paths can arm it from the KEPT `state.transactions` instead of a
+                // fetch result they never apply.
+                let pendingTransactionsPoller = reconciliationPoller(for: identifiedArray, state: state)
+
+                // MOB-1855: a spurious empty fetch must never blank a list that already has rows.
+                // `getAllTransactions` can legitimately race a reorg/rescan window mid-sync and
+                // answer with zero rows for an account that plainly has transactions; only trust an
+                // empty result once the synchronizer itself reports `.upToDate`, or once a list is
+                // already invalidated and therefore has nothing correct left to lose. Tests the RAW
+                // fetched `transactions`, not `identifiedArray`: `mixedTransactions` above
+                // unconditionally appends one synthetic row per in-flight swap-to-ZEC, so a
+                // genuinely empty on-chain fetch would otherwise still produce a non-empty
+                // `identifiedArray` and defeat this guard for any user with such a swap pending.
+                // Both lists still get `transactionsUpdated` so one that WAS mid-load can clear its
+                // placeholder, and the poller is armed from the KEPT `state.transactions`, never
+                // from this fetch's result, so a still-pending kept row keeps its 30 s reconciler.
+                let listsAreInvalidated = state.homeState.transactionListState.isInvalidated
+                    || state.transactionsCoordFlowState.transactionsManagerState.isInvalidated
+                if transactions.isEmpty && !state.transactions.isEmpty && !listsAreInvalidated && !isUpToDate(state.lastKnownSyncStatus) {
+                    LoggerProxy.event("[RootTransactions] ignored an empty fetch while sync is not up to date; kept \(state.transactions.count) rows")
+                    return .merge(
+                        reconciliationPoller(for: state.transactions, state: state),
+                        .send(.home(.transactionList(.transactionsUpdated))),
+                        .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated)))
+                    )
                 }
+
+                // ZIP 318 labels: Activity now PRESENTS migration transactions instead of hiding
+                // them — a stored-but-unmined row renders as "Migrating…"/"Splitting Balance…"
+                // with the coins-swap glyph (Figma "Transaction Statuses/Labels — Final Designs"),
+                // so the store-at-prove rows that once looked like phantom "Sending…" sends now
+                // tell the true in-flight story right on the list. This supersedes the M3 Part A
+                // filter that removed them. This is still the single canonical list build, so
+                // every consumer of the shared `$transactions` sees the same truth.
+                //
+                // M3 B2 (unchanged): the SAME rows are what the SDK's pending-balance lanes count
+                // for the whole prove→mine window, so their received value is still published
+                // beside the canonical list — one pass, one clock — for the balance-breakdown
+                // sheet to remove from its displayed "Pending" row. `totalReceived` is exactly a
+                // migration transaction's contribution to the pending lanes (all its real outputs
+                // are internal, and its spent side never enters them); a nil reads as zero, which
+                // under-corrects — conservative, never future-tense.
+                //
+                // MOB-1855: computed here, AFTER the empty-fetch guard above, rather than at the
+                // top of this case -- an ignored spurious-empty fetch must not zero this figure for
+                // one tick either. `transactions` is unaffected by anything in between: the
+                // swap-relabeling loop above only mutates existing rows' `type`/`swapStatus`, never
+                // their count or `totalReceived`.
+                let unminedMigrationPending = transactions
+                    .filter { $0.isUnminedMigrationTransaction }
+                    .reduce(Zatoshi.zero) { $0 + ($1.totalReceived ?? Zatoshi.zero) }
+                state.$unminedMigrationPendingValue.withLock { $0 = unminedMigrationPending }
 
                 // Update transactions
                 if state.transactions != identifiedArray {
@@ -257,8 +272,66 @@ extension Root {
                     .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated)))
                 )
 
+            case .transactionsFetchFailed(let accountUUID):
+                // Same provenance guard as `.fetchedTransactions` above, and for the same reason:
+                // without it, a stale failure for an account the user has since switched away from
+                // would clear the NEWLY selected account's `isInvalidated` flags and re-arm the
+                // poller from ITS `state.transactions` -- which at that point may still be the
+                // PREVIOUS account's leftover rows -- marking the new account "loaded" while the
+                // wrong rows are still on screen.
+                guard accountUUID == state.selectedWalletAccount?.id else {
+                    return .none
+                }
+                // The list keeps its previous contents (nothing to overwrite here at all), but
+                // either list may already be showing its loading placeholder -- clear it exactly
+                // like every other completed-fetch path, and keep the reconciliation poller alive
+                // for whatever `state.transactions` still holds.
+                return .merge(
+                    reconciliationPoller(for: state.transactions, state: state),
+                    .send(.home(.transactionList(.transactionsUpdated))),
+                    .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated)))
+                )
+
             default: return .none
             }
+        }
+    }
+
+    /// Builds the reconciliation-poller effect for `transactions`: while any `.zcash` row is
+    /// pending (`minedHeight == nil`), a 30 s local-database re-read backstops a lost push signal
+    /// (a dropped event, or a missed `.upToDate` tick) that would otherwise leave a mined
+    /// transaction rendered as "Sending…" forever; the poller cancels itself once nothing meets
+    /// that condition. Takes the transactions to inspect as a parameter, rather than always
+    /// reading `state.transactions` directly, so a caller that keeps the existing list -- on a
+    /// spurious empty fetch, or on a failed fetch -- can still arm the reconciler from those KEPT
+    /// rows instead of from a fetch result it never applies. Restricted to `.zcash` transactions,
+    /// whose pending state is resolvable by exactly the local re-read this poller performs; every
+    /// other type's `isPending` reports the SWAP status, owned by the swap provider's metadata and
+    /// refreshed elsewhere (`.autoUpdateCandidatesSwapDetails` in `RootSwaps`) -- re-reading the SDK
+    /// database can never resolve it, and an abandoned or stalled swap never has to resolve, so
+    /// arming this poller on one would poll forever against state it cannot possibly settle.
+    private func reconciliationPoller(for transactions: IdentifiedArrayOf<TransactionState>, state: Root.State) -> Effect<Root.Action> {
+        if transactions.contains(where: { $0.type == .zcash && $0.isPending }) {
+            return .run { send in
+                while !Task.isCancelled {
+                    try await mainQueue.sleep(for: .seconds(30))
+                    await send(.fetchTransactionsForTheSelectedAccount)
+                }
+            }
+            .cancellable(id: state.CancelPendingTxPollId, cancelInFlight: true)
+        } else {
+            return .cancel(id: state.CancelPendingTxPollId)
+        }
+    }
+
+    /// True only once the synchronizer itself has reported `.upToDate`; `nil` (nothing observed
+    /// yet this session, or just cleared at `.didEnterBackground`) is deliberately NOT up to date,
+    /// matching `Root.State.isSynchronizerIdleForSwitch`'s treatment of the same optional.
+    private func isUpToDate(_ status: SyncStatus?) -> Bool {
+        guard let status else { return false }
+        switch status {
+        case .upToDate: return true
+        case .unprepared, .syncing, .stopped, .error: return false
         }
     }
 }

--- a/zodlTests/RootTransactionsTests/RootTransactionsEmptyFetchTests.swift
+++ b/zodlTests/RootTransactionsTests/RootTransactionsEmptyFetchTests.swift
@@ -1,0 +1,364 @@
+//
+//  RootTransactionsEmptyFetchTests.swift
+//  zodlTests
+//
+//  `.fetchedTransactions` (`RootTransactions.swift`) used to trust every fetch result
+//  unconditionally: whenever the freshly fetched array differed from `state.transactions`, it
+//  overwrote the shared list, even with an EMPTY array. `getAllTransactions` can legitimately race
+//  a reorg/rescan window mid-sync and answer with zero rows for an account that plainly has
+//  transactions -- that raced empty answer blanked a list that was correct a moment before, or
+//  left it stuck showing placeholders, with nothing to tell it to trust its own kept rows over a
+//  transient miss. A parallel gap sat in the failure path: a THROWN `getAllTransactions` only
+//  logged, so a list already showing its loading placeholder (freshly invalidated by an account
+//  switch, say) never got the completion signal it needed to clear that placeholder, even though
+//  the kept rows underneath were perfectly fine.
+//
+//  Covers both: an empty fetch is now trusted only once the synchronizer itself reports
+//  `.upToDate`, or once a list is already invalidated and therefore has nothing correct left to
+//  lose; a failed fetch still notifies both lists and re-arms the reconciliation poller from the
+//  rows that were kept, exactly as an ignored empty fetch does.
+//
+//  Mirrors `RootPendingTransactionRefreshTests.swift`'s established pattern: a plain `Store` (not
+//  `TestStore`) driven with `LockIsolated` spies, with time-dependent behavior (the 30 s
+//  reconciliation poller) run on a `DispatchQueue.test` scheduler injected as `mainQueue`,
+//  advanced in small steps interleaved with real-time yields so the poller's effect Task gets a
+//  chance to register its sleep on the scheduler before the clock advances past it.
+//
+//  `.serialized`: constructing/driving `Root.State` touches the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` / `.inMemory(.transactions)` keys, same precedent
+//  as the other Root-level suites in this directory.
+//
+
+@preconcurrency import Combine
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor struct RootTransactionsEmptyFetchTests {
+    private static func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func tx(id: String, status: TransactionState.Status) -> TransactionState {
+        TransactionState(fee: Zatoshi(10), id: id, status: status, zecAmount: Zatoshi(100_000))
+    }
+
+    private struct FetchStubError: Error { }
+
+    // MARK: - (1) A spurious empty fetch mid-sync, with neither list invalidated, must be ignored
+
+    /// The core guard: sync still in progress (not `.upToDate`), neither Home's nor See All's
+    /// transaction list already invalidated, and the fetch came back empty while the kept list is
+    /// not -- the fetch must be treated as spurious. The list is kept untouched, but both lists
+    /// still get their own `transactionsUpdated` so a list that WAS mid-load has something to
+    /// clear its placeholder with, and the 30 s reconciliation poller stays armed from the KEPT
+    /// pending row, never from the empty fetch result.
+    @Test func emptyFetchMidSyncWithValidListsKeepsTheListAndStillNotifiesBothLists() async {
+        let account = Self.walletAccount(idByte: 100)
+        let scheduler = DispatchQueue.test
+        let fetchCalls = LockIsolated<Int>(0)
+        let keptTransaction = tx(id: "kept-pending-tx", status: .sending)
+        let keptTransactions = IdentifiedArrayOf<TransactionState>(uniqueElements: [keptTransaction])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.$transactions.withLock { $0 = keptTransactions }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+        initialState.lastKnownSyncStatus = .syncing(0.3, false)
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.mainQueue = scheduler.eraseToAnyScheduler()
+            $0.sdkSynchronizer.getAllTransactions = { _ in
+                fetchCalls.withValue { $0 += 1 }
+                return []
+            }
+        }
+
+        store.send(.fetchedTransactions(account.id, []))
+
+        // The ignore path's early return never touches `state.transactions` -- true synchronously,
+        // before any of the returned effects below have had a chance to run.
+        #expect(store.state.transactions == keptTransactions, "a spurious empty fetch mid-sync must never blank a non-empty list")
+
+        // `transactionsUpdated` reaches each list via a returned `.send` effect, not a synchronous
+        // mutation -- give it a moment to land before reading each list's own derived state.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(
+            store.state.homeState.transactionListState.latestTransactionId == "kept-pending-tx",
+            "Home's transactionsUpdated was not received on the ignored-empty-fetch path"
+        )
+        #expect(
+            store.state.transactionsCoordFlowState.transactionsManagerState.searchedTransactionsList == keptTransactions,
+            "See All's transactionsUpdated was not received on the ignored-empty-fetch path"
+        )
+
+        // The reconciliation poller must still be armed from the KEPT rows. Advance in small steps
+        // interleaved with real-time yields so the poller's sleep registers on the scheduler before
+        // the clock advances past its deadline -- unbounded on purpose, the suite's `.timeLimit`
+        // backstops a poller that genuinely never ticks.
+        while fetchCalls.value < 1 {
+            await scheduler.advance(by: .seconds(1))
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(fetchCalls.value >= 1, "the reconciliation poller was not scheduled for the kept pending row")
+    }
+
+    // MARK: - (2) The same empty fetch, once the synchronizer is up to date, must be trusted
+
+    /// Once `.synchronizerStateChanged` has reported `.upToDate`, an empty result is no longer a
+    /// transient sync artifact -- it is the wallet's settled answer, and must be applied exactly
+    /// like the pre-existing behavior for every other differing fetch result.
+    @Test func emptyFetchOnceUpToDateEmptiesTheList() async {
+        let account = Self.walletAccount(idByte: 101)
+        let keptTransaction = tx(id: "kept-pending-tx", status: .sending)
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.$transactions.withLock { $0 = IdentifiedArrayOf<TransactionState>(uniqueElements: [keptTransaction]) }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+        initialState.lastKnownSyncStatus = .upToDate
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+        }
+
+        store.send(.fetchedTransactions(account.id, []))
+
+        #expect(store.state.transactions.isEmpty, "an empty fetch once the synchronizer is up to date must be trusted and applied")
+    }
+
+    // MARK: - (3) The same empty fetch, with ONE list already invalidated, must be trusted (OR boundary)
+
+    /// A list already invalidated (an account switch just happened, say) is already showing its
+    /// loading placeholder and has nothing correct left to lose -- the guard must not hold an empty
+    /// fetch back in that case, or the placeholder would never clear. Deliberately invalidates only
+    /// Home's list, not See All's: `listsAreInvalidated` in the guard is an OR of the two, so this
+    /// exercises that either flag alone is enough to bypass the guard. `accountSwitchedEffect`
+    /// (`RootCoordinator.swift`) itself invalidates BOTH lists on a real account switch -- this test
+    /// does not reproduce that combination, only the OR boundary the guard actually branches on.
+    @Test func emptyFetchWithAnInvalidatedListEmptiesTheList() async {
+        let account = Self.walletAccount(idByte: 102)
+        let keptTransaction = tx(id: "kept-pending-tx", status: .sending)
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.$transactions.withLock { $0 = IdentifiedArrayOf<TransactionState>(uniqueElements: [keptTransaction]) }
+        // Only Home is invalidated here (see the doc comment above) -- deliberately narrower than
+        // what `accountSwitchedEffect` (`RootCoordinator.swift`) does on a real account switch.
+        initialState.homeState.transactionListState.isInvalidated = true
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+        initialState.lastKnownSyncStatus = .syncing(0.3, false)
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+        }
+
+        store.send(.fetchedTransactions(account.id, []))
+
+        #expect(store.state.transactions.isEmpty, "an empty fetch for an already-invalidated list has nothing correct to lose, and must apply")
+    }
+
+    // MARK: - (4) A failed fetch must still notify both lists and re-arm the poller
+
+    /// A thrown `getAllTransactions` must never leave a list stranded on its loading placeholder:
+    /// both lists still receive `transactionsUpdated` (clearing `isInvalidated`), and the
+    /// reconciliation poller is armed from whatever `state.transactions` still holds, so a pending
+    /// row that was kept through the failure keeps its 30 s reconciler.
+    @Test func fetchFailureClearsInvalidationAndReArmsThePollerFromTheKeptList() async {
+        let account = Self.walletAccount(idByte: 103)
+        let scheduler = DispatchQueue.test
+        let fetchCalls = LockIsolated<Int>(0)
+        let keptTransaction = tx(id: "kept-pending-tx", status: .sending)
+        let keptTransactions = IdentifiedArrayOf<TransactionState>(uniqueElements: [keptTransaction])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.$transactions.withLock { $0 = keptTransactions }
+        initialState.homeState.transactionListState.isInvalidated = true
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = true
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.mainQueue = scheduler.eraseToAnyScheduler()
+            $0.sdkSynchronizer.getAllTransactions = { _ in
+                fetchCalls.withValue { $0 += 1 }
+                throw FetchStubError()
+            }
+        }
+
+        store.send(.fetchTransactionsForTheSelectedAccount)
+        while fetchCalls.value < 1 {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        // The failure's own completion signal reaches both lists via returned `.send` effects --
+        // give them a moment to land.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(store.state.transactions == keptTransactions, "a failed fetch must never clear the kept list")
+        #expect(!store.state.homeState.transactionListState.isInvalidated, "a failed fetch must still clear Home's invalidation")
+        #expect(
+            !store.state.transactionsCoordFlowState.transactionsManagerState.isInvalidated,
+            "a failed fetch must still clear See All's invalidation"
+        )
+
+        let fetchesBeforePoll = fetchCalls.value
+        while fetchCalls.value < fetchesBeforePoll + 1 {
+            await scheduler.advance(by: .seconds(1))
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(fetchCalls.value > fetchesBeforePoll, "the reconciliation poller was not re-armed from the kept list after a failed fetch")
+    }
+
+    // MARK: - (5) A failed fetch for a NON-selected account must change nothing
+
+    /// `.transactionsFetchFailed` must apply the same provenance guard as `.fetchedTransactions`:
+    /// a failure for an account the user has since switched away from must never touch the
+    /// CURRENTLY selected account's lists. Without the guard, this stale failure would clear the
+    /// newly-selected account's `isInvalidated` flags and re-arm the reconciliation poller from ITS
+    /// `state.transactions` -- which at that point may still be the previous account's leftover
+    /// rows -- marking the new account "loaded" while the wrong rows are still on screen.
+    @Test func fetchFailureForANonSelectedAccountChangesNothing() async {
+        let selectedAccount = Self.walletAccount(idByte: 104)
+        let staleAccount = Self.walletAccount(idByte: 105)
+        let scheduler = DispatchQueue.test
+        let fetchCalls = LockIsolated<Int>(0)
+        let keptTransaction = tx(id: "kept-pending-tx", status: .sending)
+        let keptTransactions = IdentifiedArrayOf<TransactionState>(uniqueElements: [keptTransaction])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = selectedAccount }
+        initialState.$transactions.withLock { $0 = keptTransactions }
+        // Mirrors `accountSwitchedEffect` (`RootCoordinator.swift`): the newly-selected account's
+        // lists stay invalidated until ITS OWN fetch completes -- a stale failure for the account
+        // just switched away from must not be what clears them.
+        initialState.homeState.transactionListState.isInvalidated = true
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = true
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.mainQueue = scheduler.eraseToAnyScheduler()
+            $0.sdkSynchronizer.getAllTransactions = { _ in
+                fetchCalls.withValue { $0 += 1 }
+                throw FetchStubError()
+            }
+        }
+
+        store.send(.transactionsFetchFailed(accountUUID: staleAccount.id))
+
+        // The guard's early return is synchronous -- true before any wrongly-returned effect could
+        // possibly land.
+        #expect(store.state.transactions == keptTransactions, "a stale failure must never touch the kept list")
+        #expect(
+            store.state.homeState.transactionListState.isInvalidated,
+            "a stale failure must not clear the CURRENTLY selected account's Home invalidation"
+        )
+        #expect(
+            store.state.transactionsCoordFlowState.transactionsManagerState.isInvalidated,
+            "a stale failure must not clear the CURRENTLY selected account's See All invalidation"
+        )
+
+        // Confirm no reconciliation poller was armed either -- if the guard had NOT fired, this
+        // poller WOULD tick, because `keptTransactions` holds a pending row.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        await scheduler.advance(by: .seconds(30))
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        #expect(fetchCalls.value == 0, "a stale failure must not re-arm the reconciliation poller")
+    }
+
+    // MARK: - (6) An empty on-chain fetch with an in-flight swap-to-ZEC must still keep the on-chain rows
+
+    /// The emptiness check in the guard must test the RAW fetched `transactions`, not the
+    /// `identifiedArray` built after `mixedTransactions` appends one synthetic row per in-flight
+    /// swap-to-ZEC. Otherwise a genuinely empty on-chain fetch, for a user with such a swap
+    /// pending, would still produce a non-empty `identifiedArray` (the synthetic row alone),
+    /// defeating the guard and overwriting the kept on-chain rows with a list containing only that
+    /// synthetic row.
+    @Test func emptyOnChainFetchWithInFlightSwapToZecKeepsTheOnChainRows() async {
+        let account = Self.walletAccount(idByte: 106)
+        let keptTransaction = tx(id: "kept-pending-tx", status: .sending)
+        let keptTransactions = IdentifiedArrayOf<TransactionState>(uniqueElements: [keptTransaction])
+
+        // An in-flight swap TO Zec -- `mixedTransactions` (`RootTransactions.swift`) appends a
+        // synthetic `TransactionState` for exactly this, regardless of how many on-chain rows the
+        // fetch itself returned.
+        let swapToZec = UMSwapId(
+            depositAddress: "swap-to-zec-deposit-address",
+            provider: "near",
+            totalFees: 0,
+            totalUSDFees: "0",
+            lastUpdated: 0,
+            fromAsset: "near.usdc.usdc",
+            toAsset: SwapConstants.zecAssetIdOnNear,
+            exactInput: true,
+            status: SwapConstants.processing,
+            amountOutFormatted: "0.1"
+        )
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.$transactions.withLock { $0 = keptTransactions }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+        initialState.lastKnownSyncStatus = .syncing(0.3, false)
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.userMetadataProvider.allSwaps = { [swapToZec] }
+        }
+
+        store.send(.fetchedTransactions(account.id, []))
+
+        #expect(
+            store.state.transactions == keptTransactions,
+            "an empty on-chain fetch must keep the on-chain rows even with an in-flight swap-to-ZEC synthetic row in play"
+        )
+    }
+}
+
+/// Shared no-op dependency baseline for every test in this file. Kept as a private, file-scoped
+/// helper rather than something shared globally, the same way the other suites in this directory
+/// keep theirs. `mainQueue` is deliberately NOT set here -- only the tests that exercise the
+/// reconciliation poller inject their own `DispatchQueue.test` scheduler.
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.autoServerSelection.findBestServer = { nil }
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mnemonic = .mock
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.allSwaps = { [] }
+    values.userMetadataProvider.load = { _ in }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1855.

**What:** `.fetchedTransactions` no longer replaces a non-empty transaction list with an empty fetch result while the synchronizer is not up to date and neither list is invalidated by an account switch. On that path the rows are kept, the event is logged, both lists still receive `transactionsUpdated`, and the 30 s reconciliation poller is computed from the kept rows instead of the empty array. A failed `getAllTransactions` now sends a new `transactionsFetchFailed(accountUUID:)` action that clears both lists' loading placeholders and re-arms the poller, after the same account-provenance guard the success path uses. The seed fetch logs its early return when no account is selected yet.

**Why:** during a restore or a restart of the sync engine the database can briefly report zero rows while the engine still holds unreconciled transactions; overwriting the list with that result reads as data loss. The emptiness test is made on the raw on-chain rows rather than the merged array, because the merged array also carries one synthetic row per in-flight swap-to-ZEC, which would defeat the guard. A thrown fetch used to leave the loading placeholders on screen indefinitely and arm no poller. The provenance guard on the failure path prevents a stale failure for an account the user just switched away from marking the new account's lists as loaded while the old rows are still shown.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `RootTransactionsEmptyFetchTests` (new, 6 tests): empty fetch while syncing keeps the rows and keeps the poller; empty fetch while up to date empties the list; empty fetch while a list is invalidated replaces the list; fetch failure clears both `isInvalidated` flags and schedules the poller; failure for a non-selected account changes nothing; empty on-chain fetch with an in-flight swap-to-ZEC keeps the on-chain rows. The four sibling `RootTransactionsTests` suites still pass (29 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)