### PR TITLE
[MOB-1856] Read transaction outputs once per row and coalesce concurrent refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 
 ### Fixed
+- [MOB-1856] The app stays responsive while it catches up on a long transaction history.
 - [MOB-1855] The transaction list no longer empties or stays stuck on placeholders while the wallet is still catching up on sync.
 - [MOB-1853] Automatic server switching no longer restarts a sync that is actively in progress; if syncing stalls, the app now looks for a healthier server by itself.
 - [MOB-1831] Opening Send immediately after launching ZODL now shows the saved spendable balance while automatic server selection completes.

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -736,7 +736,10 @@ extension SDKSynchronizerClient {
                 currentChainTip: currentChainTip
             )
 
-            let recipients = await synchronizer.getRecipients(for: clearedTransaction)
+            // MOB-1856: the SDK's `getRecipients(for:)` is itself just
+            // `getTransactionOutputs(for:).map { $0.recipient }` -- reuse the `outputs` already read
+            // above instead of a second call that re-reads the exact same rows from the database.
+            let recipients = outputs.map(\.recipient)
             let addresses = recipients.compactMap {
                 if case let .address(address) = $0 {
                     return address

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerTest.swift
@@ -302,7 +302,11 @@ extension SDKSynchronizerClient {
         },
         rescanFrom: @escaping @Sendable (BlockHeight) async throws -> Void = { _ in },
         rewind: @escaping @Sendable (RewindPolicy) -> AnyPublisher<Void, Error> = { _ in return Empty<Void, Error>().eraseToAnyPublisher() },
-        getAllTransactions: @escaping @Sendable (AccountUUID?) -> IdentifiedArrayOf<TransactionState> = { _ in
+        // MOB-1856: `async throws` (matching `SDKSynchronizerClient.getAllTransactions`'s real type,
+        // `SDKSynchronizerInterface.swift`) so a test's stub can genuinely suspend (e.g. on a gate)
+        // or fail -- every existing call site passes a synchronous, non-throwing closure, which
+        // stays valid under this wider type. Same widening `mocked(start:)` already got for MOB-1854.
+        getAllTransactions: @escaping @Sendable (AccountUUID?) async throws -> IdentifiedArrayOf<TransactionState> = { _ in
             let mockedCleared: [TransactionStateMockHelper] = [
                 TransactionStateMockHelper(date: 1651039202, amount: Zatoshi(1), status: .paid, uuid: "aa11"),
                 TransactionStateMockHelper(date: 1651039101, amount: Zatoshi(2), uuid: "bb22"),

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -721,6 +721,14 @@ extension Root {
         state.autoUpdateSwapCandidates.removeAll()
         state.homeState.transactionListState.isInvalidated = true
         state.transactionsCoordFlowState.transactionsManagerState.isInvalidated = true
+        // MOB-1856: the `.cancel` below drops whatever fetch is still running for the account just
+        // left -- TCA drops actions sent from a cancelled effect, so neither `.fetchedTransactions`
+        // nor `.transactionsFetchFailed` ever arrives for it to reset the coalescing gate itself
+        // (see `RootTransactions.swift`). Without this reset, `isTransactionsFetchInFlight` would
+        // stick `true` forever and the fresh fetch sent below would be coalesced as dirty instead of
+        // actually starting -- parking the newly-selected account's fetch forever.
+        state.isTransactionsFetchInFlight = false
+        state.isTransactionsFetchDirty = false
         return .merge(
             .send(.home(.smartBanner(.walletAccountChanged))),
             .send(.home(.walletBalances(.updateBalances))),

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -149,6 +149,22 @@ struct Root {
         /// status as idle too, since a stalled sync has nothing left for an automatic switch to
         /// interrupt. Reset at `.didEnterBackground`, same as `lastKnownSyncStatus`.
         var isSyncStalledSinceLastProgress = false
+        /// MOB-1856: single-flight coalescing latch for `.fetchTransactionsForTheSelectedAccount`.
+        /// During catch-up sync this fetch is re-dispatched on every throttled synchronizer event
+        /// (`.observeTransactions` -- see `RootTransactions.swift`), and on a long transaction
+        /// history `getAllTransactions` can easily take longer than one throttle window, so without
+        /// this latch concurrent full-history fetches piled up. While `true`, a fresh dispatch sets
+        /// `isTransactionsFetchDirty` and returns immediately instead of starting another fetch; the
+        /// in-flight fetch's own completion (`.fetchedTransactions`/`.transactionsFetchFailed`)
+        /// clears this flag and, if dirty, sends exactly one follow-up fetch. Also reset by
+        /// `accountSwitchedEffect` (`RootCoordinator.swift`), whose `.cancel` drops any pending
+        /// completion for the fetch it just cancelled -- see that reset's own comment for why.
+        var isTransactionsFetchInFlight = false
+        /// Set by `.fetchTransactionsForTheSelectedAccount` when a dispatch arrives while
+        /// `isTransactionsFetchInFlight` is already `true`. Cleared by the in-flight fetch's own
+        /// completion, which folds every dispatch coalesced during its run into exactly one
+        /// follow-up fetch for whichever account is selected at that point.
+        var isTransactionsFetchDirty = false
         @Shared(.appStorage(.lastAuthenticationTimestamp)) var lastAuthenticationTimestamp: Int = 0
         /// The most recent `.syncing` progress value seen via `.synchronizerStateChanged`, kept
         /// solely so that handler can detect a NEW tick's progress advancing past this one and

--- a/secant/Sources/Features/Root/RootTransactions.swift
+++ b/secant/Sources/Features/Root/RootTransactions.swift
@@ -88,18 +88,29 @@ extension Root {
                     LoggerProxy.event("[RootTransactions] fetch skipped: no selected account yet")
                     return .none
                 }
-                // This id exists so an account switch can cancel whatever fetch is still running
+                // MOB-1856: refreshes are coalesced -- at most one `getAllTransactions` fetch runs
+                // at a time. During a sync, `sdkSynchronizer.eventStream()` is throttled to one
+                // event per 0.2s and every `foundTransactions`/`minedTransaction` re-dispatches this
+                // action (see above); on a wallet with a long transaction history,
+                // `getAllTransactions` reads the WHOLE history and can easily take longer than that
+                // 0.2s interval, so before this guard, every throttled tick started its own
+                // concurrent full-history fetch and they piled up for the whole sync, each one
+                // competing for the same SQLite connection and CPU the sync itself needed. A
+                // dispatch that arrives while one is already running just marks the request dirty
+                // and returns; the in-flight fetch's own completion below (`.fetchedTransactions`/
+                // `.transactionsFetchFailed`) folds every dispatch coalesced during its run into
+                // exactly one follow-up fetch, for whichever account is selected at that point. This
+                // id still exists so an account switch can cancel whatever fetch is still running
                 // for the account just left (see `accountSwitchedEffect` in `RootCoordinator.swift`,
-                // which explicitly `.cancel`s this id before sending a fresh fetch for the new
-                // account). `cancelInFlight` is deliberately NOT used here: during a sync,
-                // `sdkSynchronizer.eventStream()` is throttled to one event per 0.2s and every
-                // `foundTransactions`/`minedTransaction` re-dispatches this action (see above) -- on
-                // a wallet where `getAllTransactions` takes longer than that 0.2s interval,
-                // `cancelInFlight` would cancel every one of those fetches before it could complete,
-                // starving `.fetchedTransactions` for the whole sync. Letting concurrent fetches for
-                // the same account run to completion is harmless: the `.fetchedTransactions`
+                // which explicitly `.cancel`s this id -- and resets the coalescing flags below --
+                // before sending a fresh fetch for the new account); the `.fetchedTransactions`
                 // provenance guard below still drops any payload for an account other than the one
-                // currently selected.
+                // currently selected, as a second line of defense.
+                if state.isTransactionsFetchInFlight {
+                    state.isTransactionsFetchDirty = true
+                    return .none
+                }
+                state.isTransactionsFetchInFlight = true
                 return .run { send in
                     do {
                         let transactions = try await sdkSynchronizer.getAllTransactions(accountUUID)
@@ -121,6 +132,20 @@ extension Root {
                 .cancellable(id: state.CancelTransactionsFetchId)
 
             case .fetchedTransactions(let accountUUID, var transactions):
+                // MOB-1856: the coalescing gate's own completion signal -- the effect that set
+                // `isTransactionsFetchInFlight` has now finished, whichever account it was for, so
+                // the gate must open before anything else below (including the provenance guard's
+                // own early return) or a fetch coalesced during this run would stay parked forever.
+                // A dirty request folds into exactly one follow-up, for whichever account is
+                // selected NOW -- which is exactly right even when this very completion is for a
+                // stale account.
+                state.isTransactionsFetchInFlight = false
+                var coalescedFollowUp: Effect<Root.Action> = .none
+                if state.isTransactionsFetchDirty {
+                    state.isTransactionsFetchDirty = false
+                    coalescedFollowUp = .send(.fetchTransactionsForTheSelectedAccount)
+                }
+
                 // Load-bearing provenance guard -- drop a payload that belongs to an account other
                 // than the one currently selected. Closes the race even when the cancel id above
                 // misses (the fetch's own effect completed anyway): during sync, BOTH accounts'
@@ -128,7 +153,7 @@ extension Root {
                 // for the account that was JUST switched away from can still land after the switch.
                 // Never merge/reconcile a stale payload -- always drop it whole.
                 guard accountUUID == state.selectedWalletAccount?.id else {
-                    return .none
+                    return coalescedFollowUp
                 }
 
                 let mempoolHeight = sdkSynchronizer.latestState().latestBlockHeight + 1
@@ -208,7 +233,8 @@ extension Root {
                     return .merge(
                         reconciliationPoller(for: state.transactions, state: state),
                         .send(.home(.transactionList(.transactionsUpdated))),
-                        .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated)))
+                        .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated))),
+                        coalescedFollowUp
                     )
                 }
 
@@ -245,7 +271,8 @@ extension Root {
                     }
                     return .merge(
                         pendingTransactionsPoller,
-                        .send(.home(.smartBanner(.evaluatePriority6)))
+                        .send(.home(.smartBanner(.evaluatePriority6))),
+                        coalescedFollowUp
                     )
                 }
                 // The fetch still completed even though its result is identical to what's already in
@@ -264,15 +291,28 @@ extension Root {
                 // query. Nothing is waiting on the signal once both flags are already clear.
                 guard state.homeState.transactionListState.isInvalidated
                     || state.transactionsCoordFlowState.transactionsManagerState.isInvalidated else {
-                    return pendingTransactionsPoller
+                    return .merge(pendingTransactionsPoller, coalescedFollowUp)
                 }
                 return .merge(
                     pendingTransactionsPoller,
                     .send(.home(.transactionList(.transactionsUpdated))),
-                    .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated)))
+                    .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated))),
+                    coalescedFollowUp
                 )
 
             case .transactionsFetchFailed(let accountUUID):
+                // MOB-1856: same coalescing-gate reset as `.fetchedTransactions` above, and for the
+                // same reason -- this completion also ends the effect that set
+                // `isTransactionsFetchInFlight`, whichever account it was for, so the gate must open
+                // before the provenance guard below can return early, or a fetch coalesced during
+                // this run would stay parked forever.
+                state.isTransactionsFetchInFlight = false
+                var coalescedFollowUp: Effect<Root.Action> = .none
+                if state.isTransactionsFetchDirty {
+                    state.isTransactionsFetchDirty = false
+                    coalescedFollowUp = .send(.fetchTransactionsForTheSelectedAccount)
+                }
+
                 // Same provenance guard as `.fetchedTransactions` above, and for the same reason:
                 // without it, a stale failure for an account the user has since switched away from
                 // would clear the NEWLY selected account's `isInvalidated` flags and re-arm the
@@ -280,7 +320,7 @@ extension Root {
                 // PREVIOUS account's leftover rows -- marking the new account "loaded" while the
                 // wrong rows are still on screen.
                 guard accountUUID == state.selectedWalletAccount?.id else {
-                    return .none
+                    return coalescedFollowUp
                 }
                 // The list keeps its previous contents (nothing to overwrite here at all), but
                 // either list may already be showing its loading placeholder -- clear it exactly
@@ -289,7 +329,8 @@ extension Root {
                 return .merge(
                     reconciliationPoller(for: state.transactions, state: state),
                     .send(.home(.transactionList(.transactionsUpdated))),
-                    .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated)))
+                    .send(.transactionsCoordFlow(.transactionsManager(.transactionsUpdated))),
+                    coalescedFollowUp
                 )
 
             default: return .none

--- a/zodlTests/RootTransactionsTests/RootTransactionsAccountSwitchTests.swift
+++ b/zodlTests/RootTransactionsTests/RootTransactionsAccountSwitchTests.swift
@@ -18,11 +18,23 @@
 //  dependency baseline, file-scoped rather than shared, the same way that file keeps its own
 //  private helpers local to itself.
 //
+//  MOB-1856: this file used to also guard a shared-cancellable-id race with a test named
+//  `earlierFetchDispatchSurvivesALaterDispatchAndLandsItsOwnResult` -- two SAME-account dispatches
+//  of `.fetchTransactionsForTheSelectedAccount` each starting their own concurrent
+//  `getAllTransactions` call, with the later one required not to cancel the earlier. MOB-1856's
+//  single-flight coalescing gate (`RootTransactions.swift`) makes that scenario unreachable: a
+//  second same-account dispatch while one is already in flight no longer starts a competing effect
+//  at all -- it just marks the request dirty and returns, so there is nothing left for a shared
+//  cancellable id to race. That test was removed as part of MOB-1856; the coalescing behavior it
+//  is superseded by is covered in `RootTransactionsCoalescingTests.swift`. The account-SWITCH
+//  cancellation this file covers below (`switchingAccountsCancelsInFlightFetchForThePreviousAccount`)
+//  is a different, still-live scenario -- a cross-account cancel, not a same-account race -- and is
+//  unaffected.
+//
 //  NOTHING here waits on the clock. An earlier version of this file polled shared state behind
 //  wall-clock budgets (3-5s), which made it load-sensitive: measured on a contended box, the whole
-//  suite went from 1.4s to 23.1s and `earlierFetchDispatchSurvivesALaterDispatchAndLandsItsOwnResult`
-//  alone from 0.099s to 7.384s -- a 75x stretch that walks right up to a 5s budget, and past it on
-//  a busier machine. The stretch is not specific to the waits: `staleFetchFromPreviousAccountIsDroppedAfterSwitch`,
+//  suite went from 1.4s to 23.1s -- a stretch that walks right up to a 5s budget, and past it on a
+//  busier machine. The stretch is not specific to the waits: `staleFetchFromPreviousAccountIsDroppedAfterSwitch`,
 //  which awaits nothing at all, still went 0.079s -> 2.236s, because TCA runs every `.run` effect
 //  body on the MAIN ACTOR (`Core.swift`'s `Task(name:priority:) { @MainActor ... }`), so every
 //  effect in every parallel suite queues behind the same actor. Widening the budgets would only
@@ -31,8 +43,7 @@
 //   - "a fetch has entered the mock" is an `AsyncStream` the mocked `getAllTransactions` yields to;
 //   - "this dispatch is completely finished" is `StoreTask.finish()`, which awaits the whole effect
 //     tree including effects of actions the effect itself sent (`Core.swift` appends those nested
-//     tasks to the same list the returned task awaits);
-//   - "call #1 may now return" is an `AsyncStream` the test yields to, not a polled flag.
+//     tasks to the same list the returned task awaits).
 //
 //  A machine 100x slower runs these to the same verdict, just later. `.timeLimit` is the only clock
 //  left, and it exists purely so a genuinely never-resolving condition fails instead of hanging
@@ -193,107 +204,6 @@ import ComposableArchitecture
         #expect(aFetchCancelled.value)
         #expect(!aFetchCompleted.value)
         #expect(callsStarted.value.contains(accountA.id))
-    }
-
-    // MARK: - A later fetch dispatch during a sync must not starve an earlier one
-
-    /// Two traps an earlier draft of this test fell into -- both worth naming so they don't come
-    /// back:
-    ///
-    /// 1. A FINITE burst of dispatches is not a valid regression guard. Whichever dispatch is
-    ///    LAST has nothing after it to cancel it, so it always survives to completion under both
-    ///    the shared-id `cancelInFlight: true` bug and the fix -- asserting only that "a" result
-    ///    landed passes either way and proves nothing. The assertion has to be about a SPECIFIC
-    ///    earlier dispatch's own result landing, never about any result landing.
-    /// 2. A wall-clock window is not safe either. An earlier draft mocked `getAllTransactions` to
-    ///    sleep, kept re-dispatching faster than that sleep from a background loop, and asserted
-    ///    the result showed up within a fixed time budget. Swift Testing runs suites in parallel,
-    ///    and under the load of the full suite that budget can blow even with the fix in place --
-    ///    the test needs to tell "never" apart from "eventually", not "fast" apart from "slow".
-    ///
-    /// This version replaces both the burst and the clock with explicit gates:
-    ///  - the mocked `getAllTransactions` hands out a distinct call index per invocation (a
-    ///    `LockIsolated<Int>` counter) and returns a transaction identified by that index alone
-    ///    (`"fetch-1"`, `"fetch-2"`, ...), announcing each start on an `AsyncStream`;
-    ///  - call #1 PARKS on a second `AsyncStream` until the test releases it, then rethrows any
-    ///    cancellation via `Task.checkCancellation()` -- load-bearing, because if the shared-id bug
-    ///    cancels this effect the instant dispatch B registers, that cancellation has to leave this
-    ///    closure as a thrown error so the result is dropped rather than silently returned;
-    ///  - call #2 (and any later call) returns immediately.
-    ///
-    /// The sequence: dispatch A, await call #1's start, dispatch B -- the exact moment the shared-id
-    /// bug would cancel A -- await call #2's start, await B's dispatch to FINISH (so B's `"fetch-2"`
-    /// is already written and A's write is unambiguously the later one), and only THEN release call
-    /// #1 and await A's own dispatch to finish. Under the fix, A survives B untouched and lands
-    /// `"fetch-1"` over what B wrote. Under the bug, A was cancelled the instant B was dispatched,
-    /// so `"fetch-1"` can never land -- `"fetch-2"` stays, which is exactly why the assertion names
-    /// the id instead of accepting any result.
-    ///
-    /// Every step above is a signal, not a duration -- no budget to blow. `StoreTask.finish()`
-    /// covers the whole effect tree, including the `.fetchedTransactions` each fetch sends back
-    /// into the store, so "A finished" really does mean "A's write has landed".
-    @Test func earlierFetchDispatchSurvivesALaterDispatchAndLandsItsOwnResult() async {
-        let account = Self.walletAccount(idByte: 69)
-
-        let callIndex = LockIsolated<Int>(0)
-        let (callStarted, callStartedContinuation) = AsyncStream<Int>.makeStream()
-        let (releaseFirstCall, releaseFirstCallContinuation) = AsyncStream<Void>.makeStream()
-
-        var initialState = Root.State.initial
-        initialState.$selectedWalletAccount.withLock { $0 = account }
-        initialState.$transactions.withLock { $0 = [] }
-
-        let store = Store(initialState: initialState) {
-            Root()
-        } withDependencies: {
-            baseNoOpDependencies(&$0)
-            $0.sdkSynchronizer.getAllTransactions = { _ in
-                let index = callIndex.withValue { value -> Int in
-                    value += 1
-                    return value
-                }
-                callStartedContinuation.yield(index)
-
-                if index == 1 {
-                    // Parks until the test releases this call -- no polling, no flag, no clock.
-                    // Cancellation is load-bearing: if the shared-id bug cancels this effect the
-                    // moment dispatch B registers, the stream ends without ever yielding and
-                    // `checkCancellation` rethrows it, so this call drops its result instead of
-                    // returning one. Swallowing it (a `try?`) would hide the very bug under test.
-                    for await _ in releaseFirstCall { break }
-                    try Task.checkCancellation()
-                }
-
-                let transaction = TransactionState(
-                    fee: Zatoshi(10),
-                    id: "fetch-\(index)",
-                    status: .received,
-                    zecAmount: Zatoshi(100_000)
-                )
-                return IdentifiedArrayOf<TransactionState>(uniqueElements: [transaction])
-            }
-        }
-
-        var started = callStarted.makeAsyncIterator()
-
-        let earlierDispatch = store.send(.fetchTransactionsForTheSelectedAccount)
-        #expect(await started.next() == 1)
-
-        // The exact moment the shared-id/`cancelInFlight` bug would cancel call #1.
-        let laterDispatch = store.send(.fetchTransactionsForTheSelectedAccount)
-        #expect(await started.next() == 2)
-        // B is completely done -- `"fetch-2"` is in `state.transactions` -- BEFORE call #1 is
-        // released, so A's write is unambiguously the last one. (The old wall-clock version left
-        // the two writes free to race: B landing after A would have overwritten `"fetch-1"` and
-        // failed the assertion for a reason that had nothing to do with the bug under test.)
-        await laterDispatch.finish()
-        #expect(store.state.transactions.contains { $0.id == "fetch-2" })
-
-        releaseFirstCallContinuation.yield(())
-        releaseFirstCallContinuation.finish()
-        await earlierDispatch.finish()
-
-        #expect(store.state.transactions.contains { $0.id == "fetch-1" })
     }
 
     // MARK: - (c) Keystone-connect auto-select parity

--- a/zodlTests/RootTransactionsTests/RootTransactionsCoalescingTests.swift
+++ b/zodlTests/RootTransactionsTests/RootTransactionsCoalescingTests.swift
@@ -1,0 +1,313 @@
+//
+//  RootTransactionsCoalescingTests.swift
+//  zodlTests
+//
+//  MOB-1856: `.fetchTransactionsForTheSelectedAccount` (`RootTransactions.swift`) is dispatched on
+//  every throttled synchronizer event during a sync -- `.observeTransactions` throttles to one
+//  event per 0.2s, and every `foundTransactions`/`minedTransaction` re-dispatches this action. On a
+//  wallet with a long transaction history, `getAllTransactions` reads the WHOLE history and can
+//  easily take longer than that 0.2s window, so every throttled tick started its own concurrent
+//  full-history fetch -- they piled up for the whole catch-up sync, each one competing for the same
+//  SQLite connection and CPU the sync itself needed.
+//
+//  The fix is a single-flight coalescing gate: `Root.State.isTransactionsFetchInFlight` lets at
+//  most one `getAllTransactions` fetch run at a time; a dispatch that arrives while one is already
+//  running just marks `isTransactionsFetchDirty` and returns, and the in-flight fetch's own
+//  completion (`.fetchedTransactions` or `.transactionsFetchFailed`) folds every dispatch coalesced
+//  during its run into exactly one follow-up fetch, for whichever account is selected at that
+//  point.
+//
+//  A pre-dispatch amendment closes a corollary gap: `accountSwitchedEffect`
+//  (`RootCoordinator.swift`) is the only site that `.cancel`s the fetch effect -- TCA drops actions
+//  sent from a cancelled effect, so neither completion action ever arrives for a fetch cancelled by
+//  a switch. Without its own reset, `isTransactionsFetchInFlight` would stick `true` forever and the
+//  fresh fetch `accountSwitchedEffect` sends right after would be coalesced as dirty instead of
+//  actually starting -- parking the newly-selected account's fetch forever.
+//
+//  Mirrors `RootPendingTransactionRefreshTests.swift`/`RootTransactionsEmptyFetchTests.swift`'s
+//  established pattern for this directory: a plain `Store` (not `TestStore`) driven with a
+//  file-scoped `baseNoOpDependencies` (copied from `RootTransactionsAccountSwitchTests.swift`,
+//  since the account-switch test here needs the SAME dependency shape `.home(.walletAccountTapped)`
+//  already exercises there). The suspension/counting mechanics instead borrow
+//  `TestSupport/TestSignals.swift`'s `ResumableGate`/`SignalledRecords` -- the same event-driven,
+//  no-clock primitives `RootRetryStartReentrancyTests.swift` uses to hold a mocked dependency open
+//  on a gate and count calls, rather than re-deriving that machinery with ad hoc `LockIsolated`
+//  counters and `AsyncStream`s.
+//
+//  Once a gate opens and a coalesced chain is released, completion is awaited with the relevant
+//  dispatch's own `StoreTask.finish()` -- exactly `RootTransactionsAccountSwitchTests.swift`'s
+//  documented mechanism (its header explains why: `finish()` awaits the whole effect tree,
+//  including every nested action the effect itself sends, so it is deterministic all the way down
+//  a coalescing chain, not just for the one dispatch it was called on). The few `Task.sleep`s left
+//  in this file each guard a NEGATIVE only -- "no extra call landed" -- where there is deliberately
+//  nothing positive left to wait for; none of them gate a positive assertion.
+//
+//  `.serialized`: constructing/driving `Root.State` touches the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` / `.inMemory(.transactions)` /
+//  `.inMemory(.walletAccounts)` keys, same precedent as every other Root-level suite in this
+//  directory.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized, .timeLimit(.minutes(2))) @MainActor struct RootTransactionsCoalescingTests {
+    private static func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    /// A distinguishable, non-empty fetch result -- see `coalescesConcurrentDispatchesIntoExactlyOneInFlightFetchAndOneFollowUp`,
+    /// which uses it to prove the in-flight fetch's own payload actually reaches `state.transactions`,
+    /// not just that call counts add up. Mirrors `RootTransactionsAccountSwitchTests.swift`'s `tx(id:)`.
+    private static func tx(id: String) -> TransactionState {
+        TransactionState(fee: Zatoshi(10), id: id, status: .received, zecAmount: Zatoshi(100_000))
+    }
+
+    private struct FetchStubError: Error { }
+
+    // MARK: - (1) Three dispatches before the first fetch completes coalesce into one call, then one follow-up
+
+    /// The core coalescing behavior: three `.fetchTransactionsForTheSelectedAccount` dispatches
+    /// land back-to-back, none awaited, before the first fetch has any chance to complete. The
+    /// in-flight/dirty guard is plain state set synchronously inside the reducer -- before the
+    /// `.run` effect's own Task is even scheduled -- so by the time dispatch #2 and #3 run their
+    /// reducers, dispatch #1 has already flipped `isTransactionsFetchInFlight`; this is
+    /// deterministic on any machine, not a timing-dependent race. Only the first dispatch may ever
+    /// call `getAllTransactions`; releasing it must fold the two coalesced dispatches into exactly
+    /// one follow-up fetch, and that follow-up's own completion must not chase a third.
+    @Test func coalescesConcurrentDispatchesIntoExactlyOneInFlightFetchAndOneFollowUp() async {
+        let account = Self.walletAccount(idByte: 90)
+        let fetchCalls = SignalledRecords<Void>()
+        let gate = ResumableGate()
+        // A distinguishable, non-empty result every stub in this call returns -- proves the
+        // in-flight fetch's own payload actually reaches `state.transactions`, not just that call
+        // counts add up. Both the in-flight fetch and its coalesced follow-up return the identical
+        // payload, so the final assertion holds regardless of which of the two writes it.
+        let inFlightTransactions = IdentifiedArrayOf<TransactionState>(uniqueElements: [Self.tx(id: "in-flight-tx")])
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.$transactions.withLock { $0 = [] }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getAllTransactions: { _ in
+                    let ordinal = fetchCalls.recordCall()
+                    if ordinal == 1 {
+                        await gate.wait()
+                    }
+                    return inFlightTransactions
+                }
+            )
+        }
+
+        let firstDispatch = store.send(.fetchTransactionsForTheSelectedAccount)
+        store.send(.fetchTransactionsForTheSelectedAccount)
+        store.send(.fetchTransactionsForTheSelectedAccount)
+
+        // Synchronous: true before any effect Task has had a chance to run at all.
+        #expect(store.state.isTransactionsFetchInFlight, "the first dispatch must mark the gate in flight")
+        #expect(store.state.isTransactionsFetchDirty, "the two coalesced dispatches must mark the gate dirty")
+
+        await fetchCalls.countReached(1)
+        // A moment for a wrongly-started duplicate to land -- if the guard were missing, a second
+        // (or third) call would already be sitting here, well before the gate is ever released.
+        // Negative-only: the one in-flight call is deliberately still parked on the gate, so there
+        // is no positive completion to wait on yet, only the absence of an extra call to prove.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(fetchCalls.count == 1, "a dispatch coalesced while a fetch is in flight must never start its own getAllTransactions call")
+
+        // Release the in-flight fetch. `finish()` on the FIRST dispatch's own `StoreTask` awaits
+        // its whole effect tree, including every nested action it sends -- its own
+        // `.fetchedTransactions`, the coalesced follow-up fetch that spawns from it, and THAT
+        // fetch's own `.fetchedTransactions` in turn -- so by the time this returns, the follow-up
+        // has both started and fully completed. No wall clock stands between "released" and
+        // "settled" (see `RootTransactionsAccountSwitchTests.swift`'s header for why this is safe).
+        gate.open()
+        await firstDispatch.finish()
+        #expect(
+            fetchCalls.count == 2,
+            "the coalesced dispatches must fold into exactly one follow-up fetch, and that follow-up's own completion must not chase a third"
+        )
+        #expect(!store.state.isTransactionsFetchInFlight, "the follow-up fetch's completion must clear the in-flight gate")
+        #expect(!store.state.isTransactionsFetchDirty)
+        #expect(
+            store.state.transactions == inFlightTransactions,
+            "the in-flight fetch's own payload must reach state.transactions once the coalescing gate settles"
+        )
+    }
+
+    // MARK: - (2) The same coalescing behavior off the failure path
+
+    /// Identical shape to the success-path test above, but the in-flight fetch THROWS, driving
+    /// `.transactionsFetchFailed` instead of `.fetchedTransactions`. The coalescing gate must reset
+    /// and chase exactly one follow-up fetch off the failure path too -- a wallet whose fetch keeps
+    /// failing must never let dispatches from a busy sync pile up behind it.
+    @Test func coalescesConcurrentDispatchesIntoExactlyOneFollowUpAfterAFailingFetch() async {
+        let account = Self.walletAccount(idByte: 91)
+        let fetchCalls = SignalledRecords<Void>()
+        let gate = ResumableGate()
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.$transactions.withLock { $0 = [] }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getAllTransactions: { _ in
+                    let ordinal = fetchCalls.recordCall()
+                    if ordinal == 1 {
+                        await gate.wait()
+                    }
+                    throw FetchStubError()
+                }
+            )
+        }
+
+        let firstDispatch = store.send(.fetchTransactionsForTheSelectedAccount)
+        store.send(.fetchTransactionsForTheSelectedAccount)
+        store.send(.fetchTransactionsForTheSelectedAccount)
+
+        #expect(store.state.isTransactionsFetchInFlight)
+        #expect(store.state.isTransactionsFetchDirty, "the two coalesced dispatches must mark the gate dirty even on the failure path")
+
+        await fetchCalls.countReached(1)
+        // Negative-only, same as the success-path test: nothing positive to wait on while the one
+        // in-flight call is still parked on the gate.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(fetchCalls.count == 1, "a dispatch coalesced while a failing fetch is in flight must never start its own call")
+
+        // `finish()` on the first dispatch's own `StoreTask` awaits the whole nested chain -- its
+        // own `.transactionsFetchFailed`, the coalesced follow-up fetch it spawns, and that
+        // follow-up's own completion -- deterministically, with no wall clock between "released"
+        // and "settled".
+        gate.open()
+        await firstDispatch.finish()
+        #expect(
+            fetchCalls.count == 2,
+            "a failed fetch must still fold its coalesced dispatches into one follow-up fetch, with no third call chased afterward"
+        )
+        #expect(!store.state.isTransactionsFetchInFlight, "a failed follow-up fetch must still clear the in-flight gate")
+        #expect(!store.state.isTransactionsFetchDirty)
+    }
+
+    // MARK: - (2b) An account switch while a fetch is in flight starts the new account's fetch immediately
+
+    /// The pre-dispatch amendment's own regression guard. A fetch for account A is parked in
+    /// flight (its gate is never released in this test -- that A's completion never has to land is
+    /// exactly the point); the user then switches to account B. `accountSwitchedEffect` cancels A's
+    /// fetch and, immediately after, sends a fresh fetch for B -- which must actually start (a
+    /// second, distinct `getAllTransactions` call for B) rather than being coalesced as "dirty"
+    /// behind a gate only A's own cancelled-and-dropped completion could ever have cleared.
+    /// Finally, releasing A's stale fetch must change nothing and must not produce a third call.
+    @Test func accountSwitchWhileAFetchIsInFlightStartsTheNewAccountsFetchWithoutWaitingForTheStaleOne() async {
+        let accountA = Self.walletAccount(idByte: 92)
+        let accountB = Self.walletAccount(idByte: 93)
+        let fetchCalls = SignalledRecords<AccountUUID>()
+        let gate = ResumableGate()
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = accountA }
+        initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+        initialState.$transactions.withLock { $0 = [] }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getAllTransactions: { accountUUID in
+                    guard let accountUUID else { return [] }
+                    let ordinal = fetchCalls.record(accountUUID)
+                    if ordinal == 1 {
+                        // Never released in this test -- proving the switch's fresh fetch needs no
+                        // release of this one is exactly what this test guards.
+                        await gate.wait()
+                    }
+                    return []
+                }
+            )
+        }
+
+        store.send(.fetchTransactionsForTheSelectedAccount)
+        await fetchCalls.recorded(where: { $0 == [accountA.id] })
+        #expect(store.state.isTransactionsFetchInFlight)
+
+        // The switch: cancels A's in-flight fetch and, after resetting the coalescing gate,
+        // immediately sends a fresh fetch for B -- all while A's gate stays closed. `finish()` on
+        // this dispatch's own `StoreTask` awaits its whole effect tree, including B's fetch
+        // actually running to completion and its `.fetchedTransactions` landing -- deterministic,
+        // and it cannot hang on A's still-gated mock: `.cancel(id:)` only flips A's Task's
+        // cancelled flag and returns, it never waits for that Task to actually unwind (see
+        // `RootTransactionsAccountSwitchTests.swift`'s header for the general mechanism).
+        let switchTask = store.send(.home(.walletAccountTapped(accountB)))
+        await switchTask.finish()
+
+        #expect(
+            fetchCalls.values == [accountA.id, accountB.id],
+            "the switch must start B's fetch as an immediate second call, not park it behind A's still-open gate"
+        )
+        #expect(store.state.selectedWalletAccount == accountB)
+        #expect(!store.state.isTransactionsFetchInFlight, "B's own fetch must have completed and cleared the in-flight gate")
+        #expect(!store.state.isTransactionsFetchDirty)
+
+        // Release A's stale fetch. `Send.callAsFunction` checks `Task.isCancelled` and silently
+        // drops an action sent from a cancelled effect, so A's `.fetchedTransactions` never even
+        // reaches the reducer -- there is no positive completion signal left to wait on, only the
+        // absence of a third call to prove. A short, clearly-labelled sleep is the right tool for
+        // that negative check alone.
+        gate.open()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        #expect(fetchCalls.count == 2, "the stale, cancelled fetch for A must never produce a third getAllTransactions call")
+    }
+}
+
+/// Shared no-op dependency baseline for every test in this file. Kept as a private, file-scoped
+/// helper rather than something shared globally, the same way the other suites in this directory
+/// keep theirs. Copied from `RootTransactionsAccountSwitchTests.swift` rather than the
+/// Empty/PendingRefresh files' baseline: this file's account-switch test drives
+/// `.home(.walletAccountTapped)`, exactly the action that baseline is already proven to support
+/// (`loadContacts`/`resolveMetadataEncryptionKeys`/`loadUserMetadata` all need real no-op
+/// dependencies, not just `sdkSynchronizer`'s). `mainQueue = .immediate`: none of the tests here
+/// exercise throttle windows or the reconciliation poller, so there is no need for a controllable
+/// test scheduler.
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1856.

**What:** the transaction-state mapping in the live synchronizer dependency reads each transaction's outputs once and derives the recipients from them, instead of issuing a second per-row query. Transaction-list refreshes are now coalesced: while one `getAllTransactions` fetch is in flight, further `fetchTransactionsForTheSelectedAccount` requests only mark the state dirty, and a single follow-up fetch is dispatched when the in-flight one completes (success or failure). The account-switch path resets the coalescing flags before it cancels the running fetch, because actions sent from a cancelled effect are dropped and would otherwise leave the gate closed. The comment that used to justify the missing `cancelInFlight` now explains the coalescing and why the account-provenance guard stays.

**Why:** during catch-up sync every throttled synchronizer event re-dispatched a full-history refresh, and each refresh queried the wallet database twice per transaction. Those fetches piled up while the sync engine was writing the same database, which is one of the contention sources behind the stalls and the sluggish UI on wallets with long histories. The SDK's `getRecipients` is defined as the outputs mapped to their recipient, so the mapping result is unchanged.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `RootTransactionsCoalescingTests` (new, 3 tests, real suspension gate on the mocked fetch): three dispatches before completion make one call and exactly one follow-up afterwards, and the in-flight fetch's own payload still lands; the failure path coalesces the same way; an account switch while a fetch is parked starts the new account's fetch immediately and the stale completion changes nothing. Assertions await the dispatch's `StoreTask`, not wall-clock sleeps; passed in three consecutive runs.
- The pre-existing test that asserted two concurrent same-account fetches both land is removed: coalescing makes that scenario impossible by design, and the property it protected (the running fetch's own result lands after a later dispatch) is now asserted in the new suite.
- `SDKSynchronizerClient.mocked(getAllTransactions:)` now takes an `async throws` closure to match the real dependency; existing callers are unaffected.
- The seven suites under `RootTransactionsTests` plus `RootRetryStartReentrancyTests`: 40 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)