### PR TITLE
[MOB-1857] Detect insufficient funds by error kind and never swallow a send failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 
 ### Fixed
+- [MOB-1857] Sending with insufficient funds shows the proper message again, and a failed payment request always shows an error instead of doing nothing.
 - [MOB-1856] The app stays responsive while it catches up on a long transaction history.
 - [MOB-1855] The transaction list no longer empties or stays stuck on placeholders while the wallet is still catching up on sync.
 - [MOB-1853] Automatic server switching no longer restarts a sync that is actively in progress; if syncing stalls, the app now looks for a healthier server by itself.

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -415,14 +415,12 @@ struct SendForm {
                     }
                 }
                 
-            case let .sendFailed(error, confirmationType):
+            case let .sendFailed(error, _):
                 if error.isInsufficientBalance {
                     state.isInsufficientBalance = error.isInsufficientBalance
                     return .none
                 }
-                if confirmationType == .send {
-                    state.alert = AlertState.sendFailure(error)
-                }
+                state.alert = AlertState.sendFailure(error)
                 return .none
 
             case .confirmationRequired:

--- a/secant/Sources/Utils/ZcashError+DetailedMessage.swift
+++ b/secant/Sources/Utils/ZcashError+DetailedMessage.swift
@@ -27,8 +27,12 @@ extension ZcashError {
     }
     
     var isInsufficientBalance: Bool {
-        detailedMessage.lowercased().contains("insufficient balance")
-        || detailedMessage.lowercased().contains("the transaction requires an additional change output of zatbalance")
+        if case .rustProposalInsufficientFunds = self {
+            return true
+        }
+        let text = detailedMessage.lowercased()
+        return text.contains("insufficient balance")
+            || text.contains("the transaction requires an additional change output of zatbalance")
     }
 
     /// Server-validation failures the SDK raises from `ValidateServerAction` on every sync attempt:

--- a/zodlTests/SendFormTests/SendFormSendFailedAlertTests.swift
+++ b/zodlTests/SendFormTests/SendFormSendFailedAlertTests.swift
@@ -1,0 +1,29 @@
+//
+//  SendFormSendFailedAlertTests.swift
+//  zodlTests
+//
+//  Covers SendForm's `.sendFailed` handling (Features/SendForm/SendFormStore.swift): a
+//  non-insufficient-balance failure must always surface the fallback alert, not only when
+//  `confirmationType == .send`. The `.getProposal` catch also sends `.sendFailed` with
+//  `.requestPayment` (a failed payment-request scan), and no other reducer presents that
+//  failure — so gating the alert on `.send` silently swallowed it.
+//
+
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct SendFormSendFailedAlertTests {
+    @MainActor @Test func sendFailedAlwaysSetsAlertRegardlessOfConfirmationType() async {
+        let store = TestStore(initialState: SendForm.State.initial) {
+            SendForm()
+        }
+
+        let error = ZcashError.rustProposalScanRequired
+
+        await store.send(.sendFailed(error, .requestPayment)) {
+            $0.alert = AlertState.sendFailure(error)
+        }
+    }
+}

--- a/zodlTests/UtilTests/ZcashErrorInsufficientBalanceTests.swift
+++ b/zodlTests/UtilTests/ZcashErrorInsufficientBalanceTests.swift
@@ -1,0 +1,33 @@
+//
+//  ZcashErrorInsufficientBalanceTests.swift
+//  zodlTests
+//
+//  Covers ZcashError.isInsufficientBalance (Utils/ZcashError+DetailedMessage.swift). The typed
+//  `.rustProposalInsufficientFunds` case must be detected directly — the redacted Rust errors no
+//  longer produce the legacy detailedMessage text this flag used to match on. The old text match
+//  is kept as a fallback for any error that still carries it (e.g. from an older SDK build), and
+//  an unrelated typed error must not be flagged.
+//
+
+import Testing
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct ZcashErrorInsufficientBalanceTests {
+    @Test func typedInsufficientFundsCaseIsDetected() {
+        let error = ZcashError.rustProposalInsufficientFunds(Zatoshi(1), Zatoshi(2))
+        #expect(error.isInsufficientBalance)
+    }
+
+    @Test func legacyDetailedMessageTextIsStillDetectedAsFallback() {
+        let error = ZcashError.rustCreateToAddress(
+            RedactedRustError(kind: .unclassified, message: "Insufficient balance for this transaction")
+        )
+        #expect(error.isInsufficientBalance)
+    }
+
+    @Test func unrelatedTypedErrorIsNotInsufficientBalance() {
+        let error = ZcashError.rustProposalScanRequired
+        #expect(!error.isInsufficientBalance)
+    }
+}


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1857.

**What:** `ZcashError.isInsufficientBalance` now recognises the SDK's typed `rustProposalInsufficientFunds` case first and keeps the two legacy text matches as a fallback. In the Send form, a failed send or payment request always presents the failure alert; previously the alert was shown only for the `.send` confirmation type.

**Why:** the SDK redacts Rust error text, so the string match no longer fires for a real insufficient-funds proposal and the user saw a generic failure instead of the dedicated message. For the `.requestPayment` path no reducer presented the failure at all, so tapping Send could silently do nothing. The coordinator that also observes this failure only pops the navigation path and does not present an alert, so there is no double alert.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `ZcashErrorInsufficientBalanceTests` (new, 3 tests): the typed case is detected, the legacy message text is still detected, `rustProposalScanRequired` is not.
- `SendFormSendFailedAlertTests` (new): a failure with the `.requestPayment` confirmation type sets the alert.
- The existing `SendFormAddressValidationTests` and `SendFormMaxButtonTests` still pass; 17 tests across the four suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)