### PR TITLE
[MOB-1859] Stop writing a fresh diversifier on every account load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 
 ### Fixed
+- [MOB-1859] Opening the wallet no longer generates a fresh receive address for every account on each load, so loading is faster during sync.
 - [MOB-1857] Sending with insufficient funds shows the proper message again, and a failed payment request always shows an error instead of doing nothing.
 - [MOB-1856] The app stays responsive while it catches up on a long transaction history.
 - [MOB-1855] The transaction list no longer empties or stays stuck on placeholders while the wallet is still catching up on sync.

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -378,19 +378,18 @@ extension SDKSynchronizerClient: DependencyKey {
                 var walletAccounts = try await synchronizer.listAccounts().map {
                     WalletAccount($0)
                 }
-                
-                // Enrich the WalletAccounts with UnifiedAddresses
+
+                // Enrich the WalletAccounts with the default UnifiedAddress only. The rotation
+                // stash (`nextPrivateUA`) is deliberately left nil here (MOB-1859): generating it
+                // is a wallet-database write, and doing that for every account on every single
+                // load contended with the sync engine during catch-up. Callers merge in whatever
+                // stash the previous in-memory accounts already had
+                // (`WalletAccount.mergingPrivateUAStash`) and refill a still-empty one lazily in
+                // the background — see `PrivateUAStash`.
                 for i in 0..<walletAccounts.count {
                     walletAccounts[i].defaultUA = try? await synchronizer.getUnifiedAddress(accountUUID: walletAccounts[i].id)
-                    // This fills the rotation stash (`nextPrivateUA`), not the displayed slot:
-                    // `privateUA` is only ever set by promotion at tap time, so a Receive/Swap
-                    // visit never re-shows an address that was already on screen (MOB-1803).
-                    walletAccounts[i].nextPrivateUA = try? await synchronizer.getCustomUnifiedAddress(
-                        accountUUID: walletAccounts[i].id,
-                        receivers: walletAccounts[i].vendor == .keystone ? [.orchard] : [.sapling, .orchard]
-                    )
                 }
-                
+
                 // Put the Zashi account to the top
                 let sortedWalletAccounts = walletAccounts.sorted { $0.vendor.rawValue > $1.vendor.rawValue }
 

--- a/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
+++ b/secant/Sources/Features/AddKeystoneHWWallet/AddHWWalletStore.swift
@@ -178,8 +178,13 @@ struct AddKeystoneHWWallet {
                 return .none
 
             case let .loadedWalletAccounts(walletAccounts, uuid):
-                state.$walletAccounts.withLock { $0 = walletAccounts }
-                for walletAccount in walletAccounts {
+                // MOB-1859: preserve any rotation stash the in-memory accounts already carried —
+                // `walletAccounts()` no longer generates one on every load (that was a
+                // wallet-database write per account). The newly-imported account has none yet
+                // either way; it gets one lazily at its first Receive/Swap visit.
+                let mergedWalletAccounts = WalletAccount.mergingPrivateUAStash(from: state.walletAccounts, into: walletAccounts)
+                state.$walletAccounts.withLock { $0 = mergedWalletAccounts }
+                for walletAccount in mergedWalletAccounts {
                     if walletAccount.id == uuid {
                         state.$selectedWalletAccount.withLock { $0 = walletAccount }
                         break

--- a/secant/Sources/Features/Home/HomeStore.swift
+++ b/secant/Sources/Features/Home/HomeStore.swift
@@ -177,9 +177,7 @@ struct Home {
                 guard let account = state.selectedWalletAccount else {
                     return .send(.receiveTapped)
                 }
-                let isKeystone = account.vendor == .keystone
                 let uuid = account.id
-                let receivers: Set<ReceiverType> = isKeystone ? [.orchard] : [.sapling, .orchard]
                 // Rotate-ahead by one (MOB-1803): `getCustomUnifiedAddress` is a wallet-DB write
                 // that can stall for seconds behind the sync engine, so it must never be awaited
                 // before navigating. Promote the pre-generated stash into the displayed slot
@@ -190,36 +188,55 @@ struct Home {
                 state.$selectedWalletAccount.withLock {
                     let stash = $0?.nextPrivateUA
                     $0?.privateUA = stash
-                    $0?.nextPrivateUA = nil
                 }
+                // Clear the consumed stash in the `walletAccounts` array entry too, not only the
+                // selected copy — otherwise switching away and back (`WalletAccountsSheet`
+                // installs the ARRAY entry as the new selection) could re-install and re-show
+                // `stash`, the address just promoted above, breaking the MOB-1803 guarantee.
+                PrivateUAStash.write(
+                    nil,
+                    forAccountId: uuid,
+                    walletAccounts: state.$walletAccounts,
+                    selectedWalletAccount: state.$selectedWalletAccount
+                )
+                if hadStash {
+                    // The promoted stash is on screen; refill the stash for the next visit.
+                    return .merge(
+                        .send(.receiveTapped),
+                        .run { send in
+                            await PrivateUAStash.refill(accounts: [account], sdkSynchronizer: sdkSynchronizer) { ua, accountId in
+                                await send(.updateNextPrivateUA(ua, accountId))
+                            }
+                        }
+                        .cancellable(id: state.CancelUAGenerationId, cancelInFlight: true)
+                    )
+                }
+                // Nothing was promoted — live-fill the displayed slot (filling from empty is
+                // fine, swapping a displayed address is not), then generate one more UA so the
+                // stash self-heals for the next visit.
                 return .merge(
                     .send(.receiveTapped),
                     .run { send in
-                        let freshUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, receivers)
-                        if hadStash {
-                            // The promoted stash is on screen; the fresh UA refills the stash
-                            // for the next visit.
-                            await send(.updateNextPrivateUA(freshUA, uuid))
-                        } else {
-                            // Nothing was promoted — live-fill the displayed slot (filling from
-                            // empty is fine, swapping a displayed address is not), then generate
-                            // one more UA so the stash self-heals for the next visit.
-                            await send(.updatePrivateUA(freshUA, uuid))
-                            let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, receivers)
-                            await send(.updateNextPrivateUA(stashUA, uuid))
-                        }
+                        let freshUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
+                        await send(.updatePrivateUA(freshUA, uuid))
+                        let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
+                        await send(.updateNextPrivateUA(stashUA, uuid))
                     }
                     .cancellable(id: state.CancelUAGenerationId, cancelInFlight: true)
                 )
 
             case let .updateNextPrivateUA(nextPrivateUA, accountId):
                 // The UA was derived for `accountId`; if the selection changed while the
-                // generation was in flight, dropping it beats stashing one account's
-                // address under another.
-                state.$selectedWalletAccount.withLock {
-                    guard $0?.id == accountId else { return }
-                    $0?.nextPrivateUA = nextPrivateUA
-                }
+                // generation was in flight, dropping it beats stashing one account's address
+                // under another (the helper itself guards `id == accountId` on every slot).
+                // Writing through the array too keeps it the source of truth an account switch
+                // reads (`WalletAccountsSheet`), not just this visit's live `selectedWalletAccount`.
+                PrivateUAStash.write(
+                    nextPrivateUA,
+                    forAccountId: accountId,
+                    walletAccounts: state.$walletAccounts,
+                    selectedWalletAccount: state.$selectedWalletAccount
+                )
                 return .none
 
             case let .updatePrivateUA(privateUA, accountId):

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -1339,9 +1339,15 @@ extension Root {
                 )
                 
             case .initialization(.loadedWalletAccounts(let walletAccounts)):
-                state.$walletAccounts.withLock { $0 = walletAccounts }
+                // MOB-1859: `walletAccounts()` no longer generates each account's rotation stash
+                // (`nextPrivateUA`) — that was a wallet-database write on every single load, which
+                // contended with the sync engine. Carry forward whatever stash the in-memory
+                // accounts already had (a foreground refresh, a Keystone disconnect/reconnect, …)
+                // before the wholesale overwrite below would otherwise silently drop it.
+                let mergedWalletAccounts = WalletAccount.mergingPrivateUAStash(from: state.walletAccounts, into: walletAccounts)
+                state.$walletAccounts.withLock { $0 = mergedWalletAccounts }
                 if state.selectedWalletAccount == nil {
-                    for account in walletAccounts {
+                    for account in mergedWalletAccounts {
                         if account.vendor == .zcash {
                             state.$selectedWalletAccount.withLock { $0 = account }
                             state.$zashiWalletAccount.withLock { $0 = account }
@@ -1349,6 +1355,19 @@ extension Root {
                         }
                     }
                 }
+                // Refill, in the background, only the accounts the merge above left without a
+                // stash — never awaited on this load path, which is the entire point of MOB-1859.
+                // A Receive/Swap tap before this lands still self-heals on its own (`PrivateUAStash`
+                // there too), so there is nothing for the UI to wait on.
+                let accountsNeedingStash = mergedWalletAccounts.filter { $0.nextPrivateUA == nil }
+                let stashRefillEffect: Effect<Root.Action> = accountsNeedingStash.isEmpty
+                    ? .none
+                    : .run { send in
+                        await PrivateUAStash.refill(accounts: accountsNeedingStash, sdkSynchronizer: sdkSynchronizer) { ua, accountId in
+                            await send(.privateUAStashRefilled(ua, accountId))
+                        }
+                    }
+                    .cancellable(id: state.privateUAStashRefillCancelId, cancelInFlight: true)
                 return .merge(
                     .send(.loadContacts),
                     .send(.loadUserMetadata),
@@ -1367,8 +1386,24 @@ extension Root {
                     // Sent unconditionally: a duplicate walk is harmless (the ladder is idempotent —
                     // it re-reads and re-seats the same occupant), while a missed one costs the whole
                     // launch, which is precisely the bug.
-                    .send(.home(.smartBanner(.evaluatePriority1)))
+                    .send(.home(.smartBanner(.evaluatePriority1))),
+                    stashRefillEffect
                 )
+
+            case let .privateUAStashRefilled(nextPrivateUA, accountId):
+                // Writes through the shared helper rather than directly, so the `walletAccounts`
+                // array entry (what an account switch installs as the new selection,
+                // `WalletAccountsSheet`) and `zashiWalletAccount` stay in sync with
+                // `selectedWalletAccount` for every account this background refill reaches, not
+                // only whichever one happens to be selected when the result lands.
+                PrivateUAStash.write(
+                    nextPrivateUA,
+                    forAccountId: accountId,
+                    walletAccounts: state.$walletAccounts,
+                    selectedWalletAccount: state.$selectedWalletAccount,
+                    zashiWalletAccount: state.$zashiWalletAccount
+                )
+                return .none
 
             case .resolveMetadataEncryptionKeys:
                 do {

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -83,6 +83,11 @@ struct Root {
         /// Audit 2026-08-03 (#7): the one-shot delayed `.retryStart` a failed `start()` schedules —
         /// cancelled at background, re-armed (the one-shot latch below resets) each foreground.
         var startFailureRetryCancelId = UUID()
+        /// MOB-1859: the background `PrivateUAStash.refill` dispatched from
+        /// `.initialization(.loadedWalletAccounts)` for accounts whose rotation stash is still
+        /// nil after merging in the previous in-memory accounts. A newer load's refill supersedes
+        /// whichever one is still running for a now-stale accounts list.
+        var privateUAStashRefillCancelId = UUID()
         /// One retry per foreground: a `start()` that keeps failing must not self-retry in a loop —
         /// the second failure waits for the next external trigger (foreground, gate emission).
         var didScheduleStartFailureRetry = false
@@ -385,6 +390,16 @@ struct Root {
         /// requires returning an `Effect` from the REDUCER, which a `.run` closure's body cannot do
         /// on its own partway through.
         case migrationTickAdvanced(MigrationStepVerdict)
+        /// MOB-1859: the result of one account's background rotation-stash refill, dispatched
+        /// from `.initialization(.loadedWalletAccounts)` for whichever accounts still had no
+        /// stash after merging in the previous in-memory accounts. A Root-owned action rather
+        /// than `.home(.updateNextPrivateUA(...))` — Home's handler only ever updates
+        /// `state.selectedWalletAccount`, so routing a multi-account refill through it would
+        /// silently discard the result for every account except whichever one happens to be
+        /// selected. The handler writes through `PrivateUAStash.write`, which keeps the
+        /// `walletAccounts` array (the source of truth an account switch installs as the new
+        /// selection, `WalletAccountsSheet`) in sync for every account, not only the selected one.
+        case privateUAStashRefilled(UnifiedAddress?, AccountUUID)
         case synchronizerStateChanged(RedactableSynchronizerState)
         case transactionDetailsOpen(String)
         case updateStateAfterConfigUpdate(WalletConfig)

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -789,9 +789,7 @@ struct SwapAndPay {
                 guard let account = state.selectedWalletAccount else {
                     return .send(.getQuote)
                 }
-                let isKeystone = account.vendor == .keystone
                 let uuid = account.id
-                let receivers: Set<ReceiverType> = isKeystone ? [.orchard] : [.sapling, .orchard]
                 // Rotate-ahead by one (MOB-1803): `getCustomUnifiedAddress` is a wallet-DB write
                 // that can stall for seconds behind the sync engine. `.getQuote` hard-requires
                 // `privateUnifiedAddress` (the refund address — its guard silently no-ops on nil),
@@ -801,13 +799,24 @@ struct SwapAndPay {
                     state.$selectedWalletAccount.withLock {
                         let stash = $0?.nextPrivateUA
                         $0?.privateUA = stash
-                        $0?.nextPrivateUA = nil
                     }
+                    // Clear the consumed stash in the `walletAccounts` array entry too, not only
+                    // the selected copy — otherwise switching away and back
+                    // (`WalletAccountsSheet` installs the ARRAY entry as the new selection) could
+                    // re-install and re-show `stash`, the address just promoted above, breaking
+                    // the MOB-1803 guarantee.
+                    PrivateUAStash.write(
+                        nil,
+                        forAccountId: uuid,
+                        walletAccounts: state.$walletAccounts,
+                        selectedWalletAccount: state.$selectedWalletAccount
+                    )
                     return .merge(
                         .send(.getQuote),
                         .run { send in
-                            let freshUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, receivers)
-                            await send(.updateNextPrivateUA(freshUA, uuid))
+                            await PrivateUAStash.refill(accounts: [account], sdkSynchronizer: sdkSynchronizer) { ua, accountId in
+                                await send(.updateNextPrivateUA(ua, accountId))
+                            }
                         }
                         .cancellable(id: state.UAGenerationCancelId, cancelInFlight: true)
                     )
@@ -816,22 +825,26 @@ struct SwapAndPay {
                 // its refund address — then generate one more UA so the stash self-heals and the
                 // next quote request promotes instantly.
                 return .run { send in
-                    let privateUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, receivers)
+                    let privateUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
                     await send(.updatePrivateUA(privateUA, uuid))
                     await send(.getQuote)
-                    let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, receivers)
+                    let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
                     await send(.updateNextPrivateUA(stashUA, uuid))
                 }
                 .cancellable(id: state.UAGenerationCancelId, cancelInFlight: true)
 
             case let .updateNextPrivateUA(nextPrivateUA, accountId):
                 // The UA was derived for `accountId`; if the selection changed while the
-                // generation was in flight, dropping it beats stashing one account's
-                // address under another.
-                state.$selectedWalletAccount.withLock {
-                    guard $0?.id == accountId else { return }
-                    $0?.nextPrivateUA = nextPrivateUA
-                }
+                // generation was in flight, dropping it beats stashing one account's address
+                // under another (the helper itself guards `id == accountId` on every slot).
+                // Writing through the array too keeps it the source of truth an account switch
+                // reads (`WalletAccountsSheet`), not just this visit's live `selectedWalletAccount`.
+                PrivateUAStash.write(
+                    nextPrivateUA,
+                    forAccountId: accountId,
+                    walletAccounts: state.$walletAccounts,
+                    selectedWalletAccount: state.$selectedWalletAccount
+                )
                 return .none
 
             case let .updatePrivateUA(privateUA, accountId):

--- a/secant/Sources/Models/WalletAccount+Stash.swift
+++ b/secant/Sources/Models/WalletAccount+Stash.swift
@@ -1,0 +1,121 @@
+//
+//  WalletAccount+Stash.swift
+//  modules
+//
+//  MOB-1859: `walletAccounts()` no longer generates the rotation stash (`nextPrivateUA`) on
+//  every load — that generation is a wallet-database write, and doing it for every account on
+//  every load contended with the sync engine during catch-up. This file holds the pieces that
+//  used to be duplicated across call sites, or missing entirely: a pure helper that carries a
+//  stash forward across a reload instead of losing it, the shared background work that
+//  (re)generates a stash address (previously copy-pasted between HomeStore and SwapAndPayStore),
+//  and the single write path that keeps every shared copy of an account's stash — the
+//  `walletAccounts` array included — in sync with each other.
+//
+
+import ComposableArchitecture
+@preconcurrency import ZcashLightClientKit
+
+extension WalletAccount {
+    /// Copies each account's pre-generated rotation stash (`nextPrivateUA`) from `current` into
+    /// the freshly loaded `loaded` list, matched by `id`. A fresh load always comes back with a
+    /// nil stash for every account (MOB-1859), so without this merge, reloading the accounts
+    /// list — a foreground refresh, a Keystone disconnect/reconnect, a newly imported account —
+    /// would silently drop whatever stash Receive/Swap had already pre-generated for the
+    /// accounts that already existed. An account with no matching entry in `current` (freshly
+    /// imported, or the very first load) simply keeps the nil stash it already has: it gets one
+    /// lazily, either from a background refill dispatched after the load or from the next
+    /// Receive/Swap visit.
+    static func mergingPrivateUAStash(from current: [WalletAccount], into loaded: [WalletAccount]) -> [WalletAccount] {
+        loaded.map { account in
+            var account = account
+            account.nextPrivateUA = current.first { $0.id == account.id }?.nextPrivateUA
+            return account
+        }
+    }
+}
+
+/// The rotate-ahead-by-one stash behind the "next private address" that Receive and Swap
+/// promote into view when the user taps in (MOB-1803): a fresh unified address is pre-generated
+/// and held in `WalletAccount.nextPrivateUA`, never shown, so a visit can promote it into the
+/// displayed `privateUA` slot synchronously instead of waiting on a wallet-database write. This
+/// namespace holds the two pieces every caller needs: which receivers a stash address is
+/// generated with, and the background work that (re)generates one and reports it back.
+///
+/// `refill` deliberately stops short of returning an `Effect<Action>`: `Root.Action` — one of
+/// this helper's three callers — does not conform to `Sendable` (it carries payloads, such as
+/// `BGProcessingTask`, that can't), so a generic `Action` parameter used inside a `send(...)`
+/// call cannot type-check under strict concurrency for every caller at once. Working only in
+/// `WalletAccount`/`UnifiedAddress?`/`AccountUUID` — all `Sendable` — sidesteps that: each caller
+/// keeps its own concretely-typed `.run { send in … }.cancellable(id:)`, which is where that
+/// wrapping already lived, and only the generation loop and the receiver rule are shared.
+enum PrivateUAStash {
+    /// The receiver set a stash address is generated with. A Keystone hardware account can only
+    /// receive shielded funds through an orchard-only address; every other account uses the full
+    /// sapling+orchard receiver set. The single source of truth for this rule — previously
+    /// inlined at each call site, including the one that used to run inside `walletAccounts()`.
+    static func receivers(for account: WalletAccount) -> Set<ReceiverType> {
+        account.vendor == .keystone ? [.orchard] : [.sapling, .orchard]
+    }
+
+    /// Generates a fresh stash address for each of `accounts`, in order, awaiting each in turn,
+    /// and reports every result back through `onGenerated` as it lands. Callers pass a single
+    /// selected account (Home's and SwapAndPay's own refill-after-promotion effect) or every
+    /// account whose stash came back nil from a load (Root's `.loadedWalletAccounts`). This is
+    /// meant to run inside a caller's own `.run { send in … }` — never awaited on a path the UI
+    /// blocks on — with the caller wrapping that in its own `.cancellable(id:)` so a newer
+    /// request supersedes a still-running one. Errors are swallowed with `try?`, matching every
+    /// other call site of this SDK method: a failed generation just leaves that account's stash
+    /// nil for the next attempt to retry.
+    static func refill(
+        accounts: [WalletAccount],
+        sdkSynchronizer: SDKSynchronizerClient,
+        onGenerated: @Sendable (UnifiedAddress?, AccountUUID) async -> Void
+    ) async {
+        for account in accounts {
+            let accountId = account.id
+            let freshUA = try? await sdkSynchronizer.getCustomUnifiedAddress(accountId, receivers(for: account))
+            await onGenerated(freshUA, accountId)
+        }
+    }
+
+    /// Writes `nextPrivateUA` for `accountId` into every shared slot that can hold a copy of that
+    /// account, so the `walletAccounts` array can never fall out of sync with the live copies
+    /// rotation actually reads and writes. Without this, only `selectedWalletAccount` (and,
+    /// where tracked, `zashiWalletAccount`) ever saw a stash — the array entry stayed nil forever,
+    /// so an account switch (`WalletAccountsSheet`, which installs the tapped ARRAY entry as the
+    /// new selection) always installed a nil stash, forcing the slow live-fill path on every
+    /// first Receive/Swap visit after a switch, not just the very first one ever.
+    ///
+    /// Every stash write goes through this one function: Root's background refill after a load,
+    /// Home's and SwapAndPay's refill after a promotion, and the promotion step itself (which
+    /// calls this with `nil` to clear the stash it just consumed). Clearing through here too
+    /// matters as much as writing: if the array entry kept a stash that was already promoted and
+    /// shown, switching away and back would re-install and re-show that same address, breaking
+    /// the MOB-1803 guarantee that a promoted address is never shown twice.
+    ///
+    /// `zashiWalletAccount` defaults to `nil` because not every feature tracks it — only
+    /// `Root.State` declares all three `@Shared` slots; `Home.State` and `SwapAndPay.State`
+    /// declare just `walletAccounts` and `selectedWalletAccount`.
+    static func write(
+        _ nextPrivateUA: UnifiedAddress?,
+        forAccountId accountId: AccountUUID,
+        walletAccounts: Shared<[WalletAccount]>,
+        selectedWalletAccount: Shared<WalletAccount?>,
+        zashiWalletAccount: Shared<WalletAccount?>? = nil
+    ) {
+        walletAccounts.withLock { accounts in
+            guard let index = accounts.firstIndex(where: { $0.id == accountId }) else { return }
+            accounts[index].nextPrivateUA = nextPrivateUA
+        }
+        selectedWalletAccount.withLock {
+            guard $0?.id == accountId else { return }
+            $0?.nextPrivateUA = nextPrivateUA
+        }
+        if let zashiWalletAccount {
+            zashiWalletAccount.withLock {
+                guard $0?.id == accountId else { return }
+                $0?.nextPrivateUA = nextPrivateUA
+            }
+        }
+    }
+}

--- a/zodlTests/HomeTests/HomeReceiveRotationTests.swift
+++ b/zodlTests/HomeTests/HomeReceiveRotationTests.swift
@@ -200,4 +200,72 @@ import ComposableArchitecture
 
         await store.finish()
     }
+
+    // d. MOB-1859 (review): the `walletAccounts` array entry is the source of truth an account
+    // switch installs as the new selection (`WalletAccountsSheet`), so both the promotion step
+    // and the background refill must keep it in sync, not only `selectedWalletAccount`'s live
+    // copy — otherwise a switch away and back from this account would either re-show an address
+    // already displayed (breaking the MOB-1803 guarantee) or find a stash that never arrived
+    // (forcing the slow live-fill path again instead of just once).
+    @MainActor @Test func promotionClearsTheArrayEntryStashAndTheRefillWritesItBack() async {
+        // Gated exactly like `tapWithStashPromotesAndNavigatesWithoutAwaitingGeneration` above:
+        // without the gate, the un-awaited refill can race ahead of the assertions checking the
+        // state right after `.receiveScreenRequested`, since this mock has no delay of its own.
+        let generationGateOpen = LockIsolated(false)
+        let generationCalls = LockIsolated(0)
+
+        let state = Home.State.initial
+        let previousAccount = state.selectedWalletAccount
+        let previousAccounts = state.walletAccounts
+        var account = testWalletAccount
+        account.privateUA = Const.previousVisitUA
+        account.nextPrivateUA = Const.stashUA
+        state.$selectedWalletAccount.withLock { $0 = account }
+        // The array entry starts with the SAME stash as the selected copy — what a merged load
+        // (`RootInitialization.swift`) or an earlier refill would already have left behind.
+        state.$walletAccounts.withLock { $0 = [account] }
+        defer {
+            state.$selectedWalletAccount.withLock { $0 = previousAccount }
+            state.$walletAccounts.withLock { $0 = previousAccounts }
+        }
+
+        let store = TestStore(initialState: state) {
+            Home()
+        } withDependencies: {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getCustomUnifiedAddress: { _, _ in
+                    generationCalls.withValue { $0 += 1 }
+                    while !generationGateOpen.value {
+                        if Task.isCancelled { return nil }
+                        try? await Task.sleep(nanoseconds: 10_000_000)
+                    }
+                    return Const.freshUA
+                }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.receiveScreenRequested)
+
+        // Promotion consumed the stash — the array entry must lose it too, not only the selected
+        // copy, or a switch away and back would re-install and re-show `Const.stashUA`. Checked
+        // while the refill mock is still gated shut, so this can only reflect the synchronous
+        // promotion step, never the background refill landing early.
+        #expect(store.state.selectedWalletAccount?.nextPrivateUA == nil)
+        #expect(store.state.walletAccounts.first { $0.id == account.id }?.nextPrivateUA == nil)
+
+        await store.receive(\.receiveTapped, timeout: .seconds(5))
+        #expect(!generationGateOpen.value)
+
+        generationGateOpen.setValue(true)
+        await store.receive(\.updateNextPrivateUA, timeout: .seconds(5))
+
+        // The refill wrote the fresh stash back into the array entry too — not only the selected
+        // copy — so the next account switch installs a real stash instead of forcing a live-fill.
+        #expect(store.state.selectedWalletAccount?.nextPrivateUA == Const.freshUA)
+        #expect(store.state.walletAccounts.first { $0.id == account.id }?.nextPrivateUA == Const.freshUA)
+        #expect(generationCalls.value == 1)
+
+        await store.finish()
+    }
 }

--- a/zodlTests/ModelsTests/WalletAccountStashTests.swift
+++ b/zodlTests/ModelsTests/WalletAccountStashTests.swift
@@ -1,0 +1,93 @@
+//
+//  WalletAccountStashTests.swift
+//  zodlTests
+//
+//  Covers the pure merge helper behind rotation-stash preservation across account reloads
+//  (MOB-1859, Models/WalletAccount+Stash.swift `WalletAccount.mergingPrivateUAStash`) and the
+//  shared receiver-set rule (`PrivateUAStash.receivers`).
+//
+
+import Testing
+import Foundation
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite struct WalletAccountStashTests {
+    private enum Const {
+        /// Sentinel UA built through the SDK's internal `init(validatedEncoding:networkType:)`
+        /// (reachable via `@testable import ZcashLightClientKit`) — the merge logic treats
+        /// addresses as opaque tokens, so no FFI validation is involved.
+        static let existingStashUA = UnifiedAddress(validatedEncoding: "u1modelstashfixture", networkType: .mainnet)
+    }
+
+    // MARK: - mergingPrivateUAStash
+
+    @Test func mergeKeepsExistingStashByMatchingAccountId() {
+        var withStash = account(idByte: 0x01, vendor: .zcash)
+        withStash.nextPrivateUA = Const.existingStashUA
+        // As `walletAccounts()` returns it post-MOB-1859: same account, nil stash.
+        let freshlyLoaded = account(idByte: 0x01, vendor: .zcash)
+
+        let merged = WalletAccount.mergingPrivateUAStash(from: [withStash], into: [freshlyLoaded])
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.nextPrivateUA == Const.existingStashUA)
+    }
+
+    @Test func mergeLeavesAnAccountWithNoPriorEntryNil() {
+        // Simulates a freshly imported account: nothing in `current` matches its id.
+        let newlyImported = account(idByte: 0x02, vendor: .keystone)
+
+        let merged = WalletAccount.mergingPrivateUAStash(from: [], into: [newlyImported])
+
+        #expect(merged.count == 1)
+        #expect(merged.first?.nextPrivateUA == nil)
+    }
+
+    @Test func mergeLeavesAnAccountNilWhenThePriorEntryHadNoStashEither() {
+        let withoutStash = account(idByte: 0x03, vendor: .zcash)
+        let freshlyLoaded = account(idByte: 0x03, vendor: .zcash)
+
+        let merged = WalletAccount.mergingPrivateUAStash(from: [withoutStash], into: [freshlyLoaded])
+
+        #expect(merged.first?.nextPrivateUA == nil)
+    }
+
+    @Test func mergeOnlyTouchesTheMatchingAccountInAMultiAccountList() {
+        var accountAWithStash = account(idByte: 0x01, vendor: .zcash)
+        accountAWithStash.nextPrivateUA = Const.existingStashUA
+        let accountBWithoutStash = account(idByte: 0x02, vendor: .keystone)
+
+        let freshlyLoaded = [account(idByte: 0x01, vendor: .zcash), account(idByte: 0x02, vendor: .keystone)]
+        let merged = WalletAccount.mergingPrivateUAStash(from: [accountAWithStash, accountBWithoutStash], into: freshlyLoaded)
+
+        #expect(merged.first { $0.id == accountAWithStash.id }?.nextPrivateUA == Const.existingStashUA)
+        #expect(merged.first { $0.id == accountBWithoutStash.id }?.nextPrivateUA == nil)
+    }
+
+    // MARK: - PrivateUAStash.receivers
+
+    @Test func receiversRuleIsOrchardOnlyForKeystoneAndSaplingOrchardForEveryoneElse() {
+        let keystoneAccount = account(idByte: 0x04, vendor: .keystone)
+        let zcashAccount = account(idByte: 0x05, vendor: .zcash)
+
+        #expect(PrivateUAStash.receivers(for: keystoneAccount) == [.orchard])
+        #expect(PrivateUAStash.receivers(for: zcashAccount) == [.sapling, .orchard])
+    }
+
+    // MARK: - Helpers
+
+    private func account(idByte: UInt8, vendor: WalletAccount.Vendor) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Test",
+                keySource: vendor == .keystone ? String(localizable: .accountsKeystone).lowercased() : "zashi",
+                seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+}

--- a/zodlTests/UtilTests/RootLoadedWalletAccountsStashTests.swift
+++ b/zodlTests/UtilTests/RootLoadedWalletAccountsStashTests.swift
@@ -1,0 +1,218 @@
+//
+//  RootLoadedWalletAccountsStashTests.swift
+//  zodlTests
+//
+//  Covers MOB-1859 at Root's `.initialization(.loadedWalletAccounts)`
+//  (Features/Root/RootInitialization.swift): `walletAccounts()` no longer generates each
+//  account's rotation stash on every load (a wallet-database write that contended with the sync
+//  engine), so the handler must merge in whatever stash the in-memory accounts already had and
+//  refill, in the background, only the accounts that still have none. The refill result must be
+//  OBSERVABLE in the `walletAccounts` array entry for every account — not only whichever one
+//  happens to be selected — because an account switch (`WalletAccountsSheet`) installs the
+//  tapped ARRAY entry as the new selection; an array entry that never receives a stash forces
+//  the slow live-fill path on every first Receive/Swap visit after a switch.
+//
+//  `extension Root.State: @retroactive Equatable` already exists, module-wide, at
+//  RootInitializeSDKHealTests.swift — this file must NOT redeclare it (duplicate-conformance
+//  compile error; see that file's header).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+// Mutates the process-global `@Shared(.inMemory(.walletAccounts))` / `.selectedWalletAccount` /
+// `.zashiWalletAccount` slots.
+@Suite(.serialized) @MainActor struct RootLoadedWalletAccountsStashTests {
+    private enum Const {
+        /// Sentinel UAs built through the SDK's internal `init(validatedEncoding:networkType:)`
+        /// (reachable via `@testable import ZcashLightClientKit`) — the rotation logic treats
+        /// addresses as opaque tokens, so no FFI validation is involved and the encodings only
+        /// need to be distinct.
+        static let existingStashUA = UnifiedAddress(validatedEncoding: "u1rootexistingstashfixture", networkType: .mainnet)
+        static let refilledStashUA = UnifiedAddress(validatedEncoding: "u1rootrefilledstashfixture", networkType: .mainnet)
+    }
+
+    // `vendor` defaults to `.keystone` but a test can ask for a `.zcash` fixture too: the
+    // Zashi-account auto-select loop in `.loadedWalletAccounts` only fires for a `.zcash`-vendor
+    // account, and only a `.zcash` account can become `selectedWalletAccount`/`zashiWalletAccount`
+    // this way — a test that needs to observe the refill land on BOTH the array entry of a
+    // non-selected account and the selected copy needs one fixture of each vendor.
+    private func account(idByte: UInt8, vendor: WalletAccount.Vendor = .keystone) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: vendor == .keystone ? "Keystone" : "Zashi",
+                keySource: vendor == .keystone ? String(localizable: .accountsKeystone).lowercased() : nil,
+                seedFingerprint: [UInt8](repeating: 0x02, count: 32),
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func freshRootState() -> Root.State {
+        Root.State(
+            destinationState: Root.DestinationState(internalDestination: .welcome),
+            exportLogsState: ExportLogs.State(),
+            onboardingState: RestoreWalletCoordFlow.State(),
+            phraseDisplayState: RecoveryPhraseDisplay.State(),
+            walletConfig: .initial,
+            welcomeState: Welcome.State()
+        )
+    }
+
+    // Covers the review finding that the original version of this test was blind to: both
+    // fixtures were Keystone, so `selectedWalletAccount`/`zashiWalletAccount` stayed nil and the
+    // test passed whether or not the refill ever reached anything other than the dispatched
+    // action itself. With one Zcash (selected) and one Keystone (not selected) account, this
+    // proves the refilled stash is observable in EVERY shared slot it should land in, and that a
+    // second load reads that stash back out of the array instead of asking the SDK again.
+    @Test func loadRefillsTheArrayAndSelectionThenAReloadWithBothStashesSkipsRefillEntirely() async {
+        let generationCalls = LockIsolated(0)
+        let generatedForAccountIds = LockIsolated<[AccountUUID]>([])
+
+        let zcashAccount = account(idByte: 0x01, vendor: .zcash)
+        let keystoneAccount = account(idByte: 0x02, vendor: .keystone)
+
+        var initialState = freshRootState()
+        let previousWalletAccounts = initialState.walletAccounts
+        let previousSelected = initialState.selectedWalletAccount
+        let previousZashi = initialState.zashiWalletAccount
+        defer {
+            initialState.$walletAccounts.withLock { $0 = previousWalletAccounts }
+            initialState.$selectedWalletAccount.withLock { $0 = previousSelected }
+            initialState.$zashiWalletAccount.withLock { $0 = previousZashi }
+        }
+
+        initialState.$walletAccounts.withLock { $0 = [] }
+        initialState.$selectedWalletAccount.withLock { $0 = nil }
+        initialState.$zashiWalletAccount.withLock { $0 = nil }
+
+        let store = TestStore(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            // A `.zcash`-vendor fixture auto-selects, which is exactly the point of this test —
+            // but that selection also (harmlessly) wakes the `.loadContacts`/`.loadUserMetadata`/
+            // smart-banner-ladder sends `.loadedWalletAccounts` always fires. None of those are
+            // what this test is about, so they get just enough to run without tripping an
+            // "unimplemented dependency" issue, mirroring RootInitializeSDKColdStartFetchTests.
+            $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
+            $0.userMetadataProvider.load = { _ in }
+            $0.readTransactionsStorage = .noOp
+            $0.userDefaults = .noOp
+            $0.walletStorage = .noOp
+            $0.mainQueue = .immediate
+            $0.continuousClock = TestClock()
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getCustomUnifiedAddress: { accountId, _ in
+                    generationCalls.withValue { $0 += 1 }
+                    generatedForAccountIds.withValue { $0.append(accountId) }
+                    return Const.refilledStashUA
+                }
+            )
+        }
+        store.exhaustivity = .off
+
+        // The freshly "loaded" list, as `walletAccounts()` returns it post-MOB-1859: every
+        // account comes back with a nil stash, and neither has been seen before, so the merge
+        // leaves both nil too.
+        await store.send(.initialization(.loadedWalletAccounts([zcashAccount, keystoneAccount])))
+
+        // No prior selection, so the Zashi-vendor account auto-selects.
+        #expect(store.state.selectedWalletAccount?.id == zcashAccount.id)
+        #expect(store.state.zashiWalletAccount?.id == zcashAccount.id)
+
+        // Both accounts have a nil stash after the merge, so both need a background refill.
+        await store.receive(
+            { action in
+                guard case .privateUAStashRefilled(_, let accountId) = action else { return false }
+                return accountId == zcashAccount.id
+            },
+            timeout: .seconds(5)
+        )
+        await store.receive(
+            { action in
+                guard case .privateUAStashRefilled(_, let accountId) = action else { return false }
+                return accountId == keystoneAccount.id
+            },
+            timeout: .seconds(5)
+        )
+        #expect(generationCalls.value == 2)
+        #expect(generatedForAccountIds.value == [zcashAccount.id, keystoneAccount.id])
+
+        // The refill must be OBSERVABLE, not merely dispatched: the array entry for the
+        // NON-selected Keystone account carries it...
+        #expect(store.state.walletAccounts.first { $0.id == keystoneAccount.id }?.nextPrivateUA == Const.refilledStashUA)
+        // ...and so does the array entry for the selected Zcash account...
+        #expect(store.state.walletAccounts.first { $0.id == zcashAccount.id }?.nextPrivateUA == Const.refilledStashUA)
+        // ...as well as BOTH of its live copies.
+        #expect(store.state.selectedWalletAccount?.nextPrivateUA == Const.refilledStashUA)
+        #expect(store.state.zashiWalletAccount?.nextPrivateUA == Const.refilledStashUA)
+
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+
+        // A second load (e.g. a foreground refresh) with the very same accounts:
+        // `walletAccounts()` still returns a nil stash for both post-MOB-1859, but the array —
+        // now holding both refilled stashes from the first load — is the merge's source of
+        // truth. Zero further SDK calls proves the merge actually reads it back, rather than the
+        // first load's refill being the only thing that ever populated it.
+        await store.send(.initialization(.loadedWalletAccounts([zcashAccount, keystoneAccount])))
+
+        #expect(store.state.walletAccounts.first { $0.id == zcashAccount.id }?.nextPrivateUA == Const.refilledStashUA)
+        #expect(store.state.walletAccounts.first { $0.id == keystoneAccount.id }?.nextPrivateUA == Const.refilledStashUA)
+
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+
+        #expect(generationCalls.value == 2)
+    }
+
+    @Test func loadSkipsTheRefillEntirelyWhenEveryAccountAlreadyHasAStash() async {
+        let generationCalls = LockIsolated(0)
+
+        let accountWithStash = account(idByte: 0x03)
+
+        var initialState = freshRootState()
+        let previousWalletAccounts = initialState.walletAccounts
+        let previousSelected = initialState.selectedWalletAccount
+        let previousZashi = initialState.zashiWalletAccount
+        defer {
+            initialState.$walletAccounts.withLock { $0 = previousWalletAccounts }
+            initialState.$selectedWalletAccount.withLock { $0 = previousSelected }
+            initialState.$zashiWalletAccount.withLock { $0 = previousZashi }
+        }
+
+        var seededWithStash = accountWithStash
+        seededWithStash.nextPrivateUA = Const.existingStashUA
+        initialState.$walletAccounts.withLock { $0 = [seededWithStash] }
+        initialState.$selectedWalletAccount.withLock { $0 = nil }
+        initialState.$zashiWalletAccount.withLock { $0 = nil }
+
+        let store = TestStore(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getCustomUnifiedAddress: { _, _ in
+                    generationCalls.withValue { $0 += 1 }
+                    return Const.refilledStashUA
+                }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.initialization(.loadedWalletAccounts([accountWithStash])))
+
+        #expect(store.state.walletAccounts.first?.nextPrivateUA == Const.existingStashUA)
+
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+
+        // No account needed a refill, so `getCustomUnifiedAddress` must never have been called.
+        #expect(generationCalls.value == 0)
+    }
+}


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1859.

**What:** loading the wallet's accounts no longer derives a "next private address" for every account. The live synchronizer dependency returns accounts with an empty address stash, and the three places that replace the shared account list merge each account's existing stash back by id. The shared account list is now the source of truth for that stash: one helper writes a stash value into the list entry and mirrors it into the selected-account copies, and it is used by the Root load path, by the Receive and Swap screens' refills, and by the promotion step that consumes a stash (which now also clears it in the list, so an account switch can never re-show an address already displayed). After a load, Root refills only the accounts whose stash is still empty, in the background, cancellable, never awaited on the load path. The transaction-existence check is unchanged because the SDK offers no single-transaction lookup.

**Why:** deriving the next address persists the diversifier index, which is a wallet-database write. It ran for every account on every load, including twice on cold start, while the sync engine was writing the same database, behind a 15 s busy timeout. That made opening the wallet slow during catch-up and added contention that the Receive screen fix (MOB-1803) had already identified. Keeping the stash in the shared list means the writes happen once per account and their results are never discarded.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `WalletAccountStashTests` (pure merge helper, 5 tests) and `RootLoadedWalletAccountsStashTests` (2 tests): the load path calls address generation only for accounts without a stash, the refilled address is observable in the list entry and in the selected-account copies, and a second load with both stashes present makes zero generation calls.
- `HomeReceiveRotationTests` gains a test that promotion clears the list entry's stash and the refill writes it back.
- `SwapAndPayQuoteRotationTests`, `AddKeystoneHWWalletTests`, `RootTransactionsAccountSwitchTests`, `RootInitializeSDKColdStartFetchTests`, `SmartBannerLadderReadinessTests` still pass; 41 tests across the 8 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)