### PR TITLE
[MOB-1860] Cancel an abandoned voting proof instead of letting it run boosted in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 
 ### Fixed
+- [MOB-1860] Leaving a voting screen while a proof is being prepared stops that work instead of letting it run in the background.
 - [MOB-1859] Opening the wallet no longer generates a fresh receive address for every account on each load, so loading is faster during sync.
 - [MOB-1857] Sending with insufficient funds shows the proper message again, and a failed payment request always shows an error instead of doing nothing.
 - [MOB-1856] The app stays responsive while it catches up on a long transaction history.

--- a/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
+++ b/secant/Sources/Dependencies/VotingCryptoClient/VotingCryptoClientLiveKey.swift
@@ -300,54 +300,48 @@ extension VotingCryptoClient: DependencyKey {
             },
             // swiftlint:disable:next line_length
             buildAndProveDelegation: { roundId, bundleIndex, bundleNotes, senderSeed, hotkeyStoredSecret, networkId, accountIndex, roundName, pirEndpoints, expectedSnapshotHeight, pirDepth, tier0Layers, tier1Layers, polyLen in
-                AsyncThrowingStream<ProofEvent, Error> { continuation in
-                    Task.detached {
-                        do {
-                            let backend = try await dbActor.backend()
-                            let inputs = try VotingRustBackend.generateDelegationInputs(
-                                senderSeed: senderSeed,
-                                hotkeyStoredSecret: hotkeyStoredSecret,
-                                networkId: networkId,
-                                accountIndex: accountIndex
-                            )
-                            let sdkNotes = bundleNotes.map { $0.toSDK() }
-                            let keys = VotingDelegationKeyInputs(
-                                fvk: inputs.fvkBytes,
-                                hotkeyStoredSecret: hotkeyStoredSecret,
-                                seedFingerprint: inputs.seedFingerprint,
-                                accountIndex: accountIndex,
-                                roundName: roundName
-                            )
-                            let params = VotingDelegationProofParams(
-                                roundId: roundId,
-                                bundleIndex: bundleIndex,
-                                notes: sdkNotes,
-                                keys: keys
-                            )
-                            let result = try await backend.buildAndProveDelegation(
-                                params,
-                                pirEndpoints: pirEndpoints,
-                                expectedSnapshotHeight: expectedSnapshotHeight,
-                                pirLayout: VotingPirLayout(
-                                    pirDepth: pirDepth,
-                                    tier0Layers: tier0Layers,
-                                    tier1Layers: tier1Layers,
-                                    polyLen: polyLen
-                                ),
-                                progress: { progress in
-                                    continuation.yield(.progress(progress))
-                                }
-                            )
-                            // Don't call publishState here — the Rust FFI may still hold
-                            // a brief RefCell borrow on the DB connection, and publishState
-                            // borrows it again. Let the store call refreshState after
-                            // receiving .completed to avoid the concurrent borrow panic.
-                            continuation.yield(.completed(Data(result.proof)))
-                            continuation.finish()
-                        } catch {
-                            continuation.finish(throwing: error)
-                        }
-                    }
+                VotingCryptoClient.makeDelegationProofStream { progress in
+                    let backend = try await dbActor.backend()
+                    let inputs = try VotingRustBackend.generateDelegationInputs(
+                        senderSeed: senderSeed,
+                        hotkeyStoredSecret: hotkeyStoredSecret,
+                        networkId: networkId,
+                        accountIndex: accountIndex
+                    )
+                    let sdkNotes = bundleNotes.map { $0.toSDK() }
+                    let keys = VotingDelegationKeyInputs(
+                        fvk: inputs.fvkBytes,
+                        hotkeyStoredSecret: hotkeyStoredSecret,
+                        seedFingerprint: inputs.seedFingerprint,
+                        accountIndex: accountIndex,
+                        roundName: roundName
+                    )
+                    let params = VotingDelegationProofParams(
+                        roundId: roundId,
+                        bundleIndex: bundleIndex,
+                        notes: sdkNotes,
+                        keys: keys
+                    )
+                    // Re-check cancellation after the awaits above — the FFI call below cannot be
+                    // interrupted once entered, so an abandoned proof must not cross into it.
+                    try Task.checkCancellation()
+                    let result = try await backend.buildAndProveDelegation(
+                        params,
+                        pirEndpoints: pirEndpoints,
+                        expectedSnapshotHeight: expectedSnapshotHeight,
+                        pirLayout: VotingPirLayout(
+                            pirDepth: pirDepth,
+                            tier0Layers: tier0Layers,
+                            tier1Layers: tier1Layers,
+                            polyLen: polyLen
+                        ),
+                        progress: progress
+                    )
+                    // Don't call publishState here — the Rust FFI may still hold
+                    // a brief RefCell borrow on the DB connection, and publishState
+                    // borrows it again. Let the store call refreshState after
+                    // receiving .completed to avoid the concurrent borrow panic.
+                    return Data(result.proof)
                 }
             },
             extractOrchardFvkFromUfvk: { ufvkStr, networkId in
@@ -636,6 +630,44 @@ extension VotingCryptoClient: DependencyKey {
                 )
             }
         )
+    }
+}
+
+// MARK: - Delegation proof stream
+
+extension VotingCryptoClient {
+    /// Builds the `AsyncThrowingStream` of `ProofEvent`s that `buildAndProveDelegation` returns,
+    /// running `prove` on a detached task so the long proving FFI call never blocks the caller's
+    /// executor. `onTermination` cancels that task when the stream's consumer goes away — e.g. a
+    /// coordinator effect torn down by `.cancellable(cancelInFlight: true)` when the next proof
+    /// starts — and the task checks `Task.isCancelled` before calling `prove` so an abandoned proof
+    /// that has not reached the FFI yet is skipped outright instead of running to completion at
+    /// proving priority in the background. A proof already inside the FFI cannot be interrupted
+    /// mid-call; cancelling at that point only stops it from yielding further progress or a
+    /// completed proof to a stream nobody is consuming anymore.
+    /// Factored out of `liveValue` so a test can substitute a spy `prove` and drive the stream's
+    /// cancellation behavior directly.
+    static func makeDelegationProofStream(
+        prove: @escaping @Sendable (_ progress: @escaping @Sendable (Double) -> Void) async throws -> Data
+    ) -> AsyncThrowingStream<ProofEvent, Error> {
+        AsyncThrowingStream<ProofEvent, Error> { continuation in
+            let task = Task.detached {
+                guard !Task.isCancelled else {
+                    continuation.finish()
+                    return
+                }
+                do {
+                    let proof = try await prove { progress in
+                        continuation.yield(.progress(progress))
+                    }
+                    continuation.yield(.completed(proof))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
     }
 }
 

--- a/zodlTests/VotingTests/VotingCryptoClientLiveKeyTests.swift
+++ b/zodlTests/VotingTests/VotingCryptoClientLiveKeyTests.swift
@@ -1,0 +1,159 @@
+//
+//  VotingCryptoClientLiveKeyTests.swift
+//  zodlTests
+//
+
+#if VOTING_ENABLED
+import Foundation
+import Testing
+import os
+@testable import zodl_internal
+
+/// Covers the cancellation wiring inside `VotingCryptoClient.makeDelegationProofStream`, the seam
+/// `VotingCryptoClientLiveKey`'s `buildAndProveDelegation` closure delegates to. Before this, the
+/// detached task backing the stream had no `onTermination` and no cancellation check, so leaving a
+/// voting screen mid-proof left that proof running at proving priority in the background while the
+/// next one started. These tests exercise the seam directly with a spy `prove`, standing in for the
+/// real backend call, instead of driving the whole coordinator + Rust FFI.
+@Suite struct VotingCryptoClientLiveKeyTests {
+    @Test func uncancelledRunYieldsProgressThenCompletedInOrder() async throws {
+        let spy = DelegationProofSpy(behavior: .succeedsImmediately(progress: [0.25, 0.75], proof: Data([1, 2, 3])))
+
+        var received: [ProofEvent] = []
+        for try await event in VotingCryptoClient.makeDelegationProofStream(prove: spy.prove) {
+            received.append(event)
+        }
+
+        #expect(received == [.progress(0.25), .progress(0.75), .completed(Data([1, 2, 3]))])
+    }
+
+    @Test func cancellingWhileProveIsRunningIsObservedQuickly() async throws {
+        let spy = DelegationProofSpy(behavior: .parksUntilCancelled)
+        let stream = VotingCryptoClient.makeDelegationProofStream(prove: spy.prove)
+        let consumer = Task<Void, Error> {
+            for try await _ in stream { }
+        }
+
+        // Only cancel once `prove` has actually started, so this exercises cancellation reaching
+        // code already past the seam's guard — the "abandoned proof already inside the FFI" case.
+        await spy.invoked.wait()
+        consumer.cancel()
+        _ = try? await consumer.value
+
+        let observedCancellation = await awaitSignal(spy.cancelledObserved, timeout: .milliseconds(100))
+        #expect(observedCancellation)
+    }
+
+    @Test func cancellingBeforeProducerStartsNeverLeavesProveUncancelled() async throws {
+        let spy = DelegationProofSpy(behavior: .parksUntilCancelled)
+        let events = SignalledRecords<ProofEvent>()
+        let consumer = Task<Void, Error> {
+            // The stream (and the detached task it starts) is created only once this task's body
+            // begins running, i.e. right as `cancel()` below races to mark it cancelled — so the
+            // producer's dispatch races a cancellation that may land before or after the producer's
+            // own `guard !Task.isCancelled` runs. Both orderings are legal Swift Concurrency
+            // scheduling (neither is a language guarantee), so the assertions below tolerate either
+            // outcome instead of assuming one — see the comment below for what must always hold.
+            let stream = VotingCryptoClient.makeDelegationProofStream(prove: spy.prove)
+            for try await event in stream {
+                events.record(event)
+            }
+        }
+        consumer.cancel()
+        let consumerResult = await consumer.result
+        if case .failure(let error) = consumerResult {
+            #expect(error is CancellationError)
+        }
+
+        // Whichever way the two-hop race above lands, exactly one of two outcomes is legal:
+        // `prove` is never invoked (the producer's own cancellation check won the race), or `prove`
+        // is invoked and then observes cancellation via `withTaskCancellationHandler` (the
+        // consumer's termination reached the producer before `prove` returned). What must never
+        // happen is `prove` running to completion uncancelled — that's the bug this test guards
+        // against (a producer without the `onTermination` wiring), and it still fails against that
+        // regression: the spy would be invoked and never observe cancellation.
+        let invoked = await awaitSignal(spy.invoked, timeout: .milliseconds(100))
+        var observedCancellation = false
+        if invoked {
+            observedCancellation = await awaitSignal(spy.cancelledObserved, timeout: .milliseconds(100))
+        }
+        #expect(!invoked || observedCancellation)
+        #expect(events.values.isEmpty)
+    }
+}
+
+/// Spy standing in for the delegation-proving backend call inside `makeDelegationProofStream`.
+/// `.succeedsImmediately` returns canned progress and a canned proof without ever suspending;
+/// `.parksUntilCancelled` suspends until the task running it is cancelled, so a test can observe
+/// whether that cancellation actually reaches code already inside the seam's `prove` closure.
+private final class DelegationProofSpy: @unchecked Sendable {
+    enum Behavior {
+        case succeedsImmediately(progress: [Double], proof: Data)
+        case parksUntilCancelled
+    }
+
+    /// Opens the instant `prove` starts running.
+    let invoked = ResumableGate()
+    /// Opens if and only if `prove`'s `withTaskCancellationHandler` observed cancellation.
+    let cancelledObserved = ResumableGate()
+
+    private let behavior: Behavior
+    private let parkedContinuation = OSAllocatedUnfairLock<CheckedContinuation<Data, Error>?>(initialState: nil)
+
+    init(behavior: Behavior) {
+        self.behavior = behavior
+    }
+
+    func prove(progress: @escaping @Sendable (Double) -> Void) async throws -> Data {
+        invoked.open()
+        switch behavior {
+        case .succeedsImmediately(let progressValues, let proof):
+            progressValues.forEach { progress($0) }
+            return proof
+        case .parksUntilCancelled:
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
+                    parkedContinuation.withLock { $0 = continuation }
+                }
+            } onCancel: {
+                cancelledObserved.open()
+                let pending = parkedContinuation.withLock { state -> CheckedContinuation<Data, Error>? in
+                    let value = state
+                    state = nil
+                    return value
+                }
+                pending?.resume(throwing: CancellationError())
+            }
+        }
+    }
+}
+
+/// Awaits `gate` and a `timeout` concurrently, returning `true` if the gate opened first and
+/// `false` if the timeout elapsed first. Keeps a positive wait event-driven — it resolves the
+/// instant the gate opens rather than always paying the full timeout — while still bounding how
+/// long a genuine regression (cancellation never observed, or observed when it should not be) can
+/// hang the test.
+private func awaitSignal(_ gate: ResumableGate, timeout: Duration) async -> Bool {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+        let hasResumed = OSAllocatedUnfairLock(initialState: false)
+        let resumeOnce: @Sendable (Bool) -> Void = { value in
+            let shouldResume = hasResumed.withLock { alreadyResumed -> Bool in
+                guard !alreadyResumed else { return false }
+                alreadyResumed = true
+                return true
+            }
+            if shouldResume {
+                continuation.resume(returning: value)
+            }
+        }
+        Task {
+            await gate.wait()
+            resumeOnce(true)
+        }
+        Task {
+            try? await Task.sleep(for: timeout)
+            resumeOnce(false)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1860. Voting only.

**What:** the delegation-proof stream in the voting crypto dependency now keeps the handle of the detached task that produces it, cancels that task when the stream is terminated by its consumer, checks for cancellation before starting the proving work, and checks once more right before entering the Rust FFI call. A proof that is already inside the FFI cannot be interrupted; the fix prevents the next orphan from starting and stops the abandoned producer from yielding into a stream nobody reads. The stream construction is extracted into an internal factory so the wiring is testable with a spy prover; the live value passes the real backend work into it. The QoS boost and the key-generation task are untouched.

**Why:** the coordinator consumes the stream under `cancelInFlight`, so leaving a screen or restarting a proof cancelled only the consumer. The producer kept running an all-cores proof under the interactive QoS boost while the next proof started, and each cycle added another orphan.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `VotingCryptoClientLiveKeyTests` (new, 3 tests): cancelling the consumer while the prover is parked is observed by the prover within 100 ms; cancelling before the producer starts leaves the prover either never invoked or invoked and cancelled, with no elements emitted; an uncancelled run yields the progress values and the completed proof in order. Assertions await latches, not fixed sleeps; passed in five consecutive runs.
- `VotingCoordFlowCoordinatorTests` (78 tests) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)