### PR TITLE
[MOB-1862] Balance breakdown parity, updating signal, and pending-funds spendability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 
 ### Fixed
+- [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send waits for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent.
 - [MOB-1860] Leaving a voting screen while a proof is being prepared stops that work instead of letting it run in the background.
 - [MOB-1859] Opening the wallet no longer generates a fresh receive address for every account on each load, so loading is faster during sync.
 - [MOB-1857] Sending with insufficient funds shows the proper message again, and a failed payment request always shows an error instead of doing nothing.

--- a/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
@@ -164,11 +164,33 @@ struct Balances {
                 guard let account = state.selectedWalletAccount else {
                     return .none
                 }
+                // Same read order as the home screen's balances, so the breakdown never
+                // contradicts the figure the user tapped to open it. The unmasked local snapshot
+                // comes first: the SDK's visible balances can be spendable-masked until the
+                // server reports a fresh tip, and a mask must not be shown as a real zero.
+                let cachedBalance = sdkSynchronizer.latestState().localAccountsBalances[account.id]
                 return .run { send in
-                    if let accountBalance = try? await sdkSynchronizer.getAccountsBalances()[account.id] {
-                        await send(.updateBalance(accountBalance))
-                    } else if let accountBalance = sdkSynchronizer.latestState().accountsBalances[account.id] {
-                        await send(.updateBalance(accountBalance))
+                    if let cachedBalance {
+                        await send(.updateBalance(cachedBalance))
+                    }
+
+                    if let localBalances = try? await sdkSynchronizer.getLocalAccountBalances(),
+                       let freshBalance = localBalances[account.id] {
+                        if freshBalance != cachedBalance {
+                            await send(.updateBalance(freshBalance))
+                        }
+                        return
+                    }
+
+                    // Do not let a masked visible balance replace a concrete local snapshot.
+                    // Use the established API only when no local value is available.
+                    guard cachedBalance == nil else { return }
+                    if let fallbackBalance = sdkSynchronizer.latestState().localAccountsBalances[account.id] {
+                        await send(.updateBalance(fallbackBalance))
+                    } else if let fallbackBalance = try? await sdkSynchronizer.getAccountsBalances()[account.id] {
+                        await send(.updateBalance(fallbackBalance))
+                    } else if let fallbackBalance = sdkSynchronizer.latestState().accountsBalances[account.id] {
+                        await send(.updateBalance(fallbackBalance))
                     }
                 }
 
@@ -183,13 +205,19 @@ struct Balances {
                 return .none
 
             case .synchronizerStateChanged(let latestState):
-                return .send(.updateBalances(latestState.data.accountsBalances))
+                return .send(.updateBalances(latestState.data.localAccountsBalances))
 
             case .updateBalances(let accountsBalances):
                 guard let account = state.selectedWalletAccount else {
                     return .none
                 }
-                return .send(.updateBalance(accountsBalances[account.id]))
+                // An absent entry means the synchronizer does not know the selected account yet —
+                // a replayed seed state is the common case. Publish nothing rather than zeros, or
+                // every replay would wipe the concrete balance the sheet is showing.
+                guard let accountBalance = accountsBalances[account.id] else {
+                    return .none
+                }
+                return .send(.updateBalance(accountBalance))
 
             case .updateBalance(let accountBalance):
                 // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future

--- a/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
@@ -18,7 +18,14 @@ struct Balances {
 
         var autoShieldingThreshold: Zatoshi
         var changePending: Zatoshi
+        /// The account the published balance was read for — see `hasConcreteBalance`.
+        var concreteBalanceAccountId: AccountUUID?
         var isShielding: Bool
+        /// The SDK is withholding the spendable value until it confirms a fresh chain tip. Not a
+        /// balance: it says the number is not knowable yet, which a zero balance never can.
+        var isSpendableMasked = false
+        /// A sync is running, so a balance may still be on its way.
+        var isSyncInProgress = false
         var pendingTransactions: Zatoshi
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
         var shieldedBalance: Zatoshi
@@ -71,12 +78,23 @@ struct Balances {
             isShielding || !isShieldableBalanceAvailable
         }
 
+        /// Whether a real balance for the CURRENTLY selected account has already been published.
+        /// Recorded against the account rather than as a bare flag: nothing tells this reducer
+        /// when the selection changes, so a flag would go on vouching for the previous account.
+        var hasConcreteBalance: Bool {
+            guard let concreteBalanceAccountId else { return false }
+
+            return concreteBalanceAccountId == selectedWalletAccount?.id
+        }
+
+        /// The spendable value is still being worked out — the only situation that deserves an
+        /// "updating" affordance. Deliberately not derived from the balance: a zero spendable
+        /// value is a settled answer for an empty wallet and for funds waiting on confirmations
+        /// alike, and reading it as unfinished left the indicator up forever and the Send screen
+        /// gated on value that was simply not spendable yet. Only two things are genuinely
+        /// unfinished — the SDK withholding the value, and a sync that has published nothing yet.
         var isProcessingZeroAvailableBalance: Bool {
-            if shieldedBalance.amount == 0 && ShieldingProcessorClient.isShieldable(balance: transparentBalance, threshold: autoShieldingThreshold) {
-                return false
-            }
-            
-            return totalBalance.amount != shieldedBalance.amount && shieldedBalance.amount == 0
+            isSpendableMasked || (isSyncInProgress && !hasConcreteBalance)
         }
 
         init(
@@ -121,7 +139,26 @@ struct Balances {
     @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
 
     init() { }
-    
+
+    /// The one `spendability` derivation, shared by every place that can move one of its inputs —
+    /// a fresh balance in `.updateBalance`, or the mask/sync flags mirrored in
+    /// `.synchronizerStateChanged` — so the two can never compute a different answer for the same
+    /// state.
+    private func spendability(for state: State) -> Spendability {
+        let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)
+        || (!ShieldingProcessorClient.isShieldable(balance: state.transparentBalance, threshold: zcashSDKEnvironment.shieldingThreshold())
+            && state.shieldedBalance == state.totalBalance - state.transparentBalance))
+        || state.totalBalance == .zero
+
+        if state.isProcessingZeroAvailableBalance {
+            return .nothing
+        } else if everythingCondition {
+            return .everything
+        } else {
+            return .something
+        }
+    }
+
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
@@ -205,6 +242,19 @@ struct Balances {
                 return .none
 
             case .synchronizerStateChanged(let latestState):
+                // Recorded before anything is published: the states that carry a mask are exactly
+                // the ones with no balance to publish, so waiting for a balance to arrive would
+                // leave the sheet silent while it should be saying the value is still coming.
+                state.isSpendableMasked = latestState.data.isSpendableMasked
+                state.isSyncInProgress = latestState.data.syncStatus.isSyncing
+
+                // Re-derived here too, unconditionally: `isProcessingZeroAvailableBalance` (and an
+                // account switch invalidating `hasConcreteBalance`) can change on this action alone,
+                // with no balance publish following — most visibly when `.updateBalances` below
+                // finds no entry for this account, which is exactly when a stored `spendability`
+                // would otherwise go on repeating a now-stale answer.
+                state.spendability = spendability(for: state)
+
                 return .send(.updateBalances(latestState.data.localAccountsBalances))
 
             case .updateBalances(let accountsBalances):
@@ -220,6 +270,12 @@ struct Balances {
                 return .send(.updateBalance(accountBalance))
 
             case .updateBalance(let accountBalance):
+                if accountBalance != nil {
+                    // Every path that reaches here with a value looked it up by the account
+                    // selected right now, so that is the account this figure answers for.
+                    state.concreteBalanceAccountId = state.selectedWalletAccount?.id
+                }
+
                 // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future
                 // shielded pool) instead of hand-summing individual pools.
                 state.changePending = accountBalance?.shieldedChangePendingConfirmation ?? .zero
@@ -230,18 +286,9 @@ struct Balances {
                 state.shieldedWithPendingBalance = accountBalance?.shieldedTotal() ?? .zero
                 state.totalBalance = state.shieldedWithPendingBalance + state.transparentBalance + (accountBalance?.awaitingResolution ?? .zero)
 
-                let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)
-                || (!ShieldingProcessorClient.isShieldable(balance: state.transparentBalance, threshold: zcashSDKEnvironment.shieldingThreshold()) && state.shieldedBalance == state.totalBalance - state.transparentBalance))
-                || state.totalBalance == .zero
-                
-                // spendability
-                if state.isProcessingZeroAvailableBalance {
-                    state.spendability = .nothing
-                } else if everythingCondition {
-                    state.spendability = .everything
+                state.spendability = spendability(for: state)
+                if state.spendability == .everything {
                     return .send(.everythingSpendable)
-                } else {
-                    state.spendability = .something
                 }
                 return .none
                 

--- a/secant/Sources/Features/SendForm/SendFormStore.swift
+++ b/secant/Sources/Features/SendForm/SendFormStore.swift
@@ -139,9 +139,16 @@ struct SendForm {
             && !isMaxRequestInFlight
         }
 
+        /// The SDK has not said what is spendable yet. Distinct from "nothing is spendable":
+        /// the answer is still coming, so the form waits for it instead of judging on a zero.
+        var isSpendabilityBeingDetermined: Bool {
+            walletBalancesState.isSpendableMasked
+        }
+
         var isValidForm: Bool {
             isValidAddress
             && !isInsufficientFunds
+            && !isSpendabilityBeingDetermined
             && memoState.isValid
             && isValidAmount
             && isTexSendSupported
@@ -156,6 +163,12 @@ struct SendForm {
 
         var isInsufficientFunds: Bool {
             guard isValidAmount else { return false }
+            // A masked spendable value arrives as zero, so every typed amount would exceed it and
+            // the form would accuse the user of insufficient funds over a figure the SDK has
+            // simply declined to state. Holding the error needs the matching gate in `isValidForm`
+            // to go with it: without that, Send would look enabled while the answer is unknown,
+            // and with only that, the error would still be on screen underneath it.
+            guard !isSpendabilityBeingDetermined else { return false }
 
             return amount.amount > shieldedBalance.amount
         }

--- a/secant/Sources/Features/SendForm/SendFormView.swift
+++ b/secant/Sources/Features/SendForm/SendFormView.swift
@@ -104,7 +104,7 @@ struct SendFormView: View {
                                                         title: String(localizable: .generalMax),
                                                         style: .standard,
                                                         isEnabled: store.isMaxButtonEnabled,
-                                                        isInFlight: store.isMaxRequestInFlight
+                                                        isInFlight: store.isMaxRequestInFlight || store.isSpendabilityBeingDetermined
                                                     ) {
                                                         store.send(.maxTapped)
                                                     }

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -24,6 +24,9 @@ struct WalletBalances {
         var isExchangeRateFeatureOn = false
         var isExchangeRateRefreshEnabled = false
         var isExchangeRateStale = false
+        /// The SDK is withholding the spendable value until it confirms a fresh chain tip. Not a
+        /// balance: it says the number is not knowable yet, which a zero balance never can.
+        var isSpendableMasked = false
         var migratingDatabase = false
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
         var shieldedBalance: Zatoshi
@@ -281,6 +284,12 @@ struct WalletBalances {
                 if snapshot.syncStatus != .unprepared {
                     state.migratingDatabase = false
                 }
+
+                // Recorded before either guard below. The mask is a property of the synchronizer,
+                // not of any one account's balance, and the states that carry it are precisely the
+                // ones with nothing to publish — so deferring it past the guards would leave the
+                // screen silent exactly while it should be saying it is still working this out.
+                state.isSpendableMasked = latestState.data.isSpendableMasked
 
                 guard let account = state.selectedWalletAccount else {
                     return .none

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -18,6 +18,8 @@ struct WalletBalances {
         var CancelRateId = UUID()
         var CancelMigrationSnapshotId = UUID()
         var autoShieldingThreshold: Zatoshi = .zero
+        /// The account the published balance was read for — see `hasConcreteBalance`.
+        var concreteBalanceAccountId: AccountUUID?
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion? = nil
         var fiatCurrencyResult: FiatCurrencyResult?
         var isAvailableBalanceTappable = true
@@ -27,6 +29,8 @@ struct WalletBalances {
         /// The SDK is withholding the spendable value until it confirms a fresh chain tip. Not a
         /// balance: it says the number is not knowable yet, which a zero balance never can.
         var isSpendableMasked = false
+        /// A sync is running, so a balance may still be on its way.
+        var isSyncInProgress = false
         var migratingDatabase = false
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
         var shieldedBalance: Zatoshi
@@ -43,16 +47,27 @@ struct WalletBalances {
             fiatCurrencyResult?.state == .fetching
         }
 
-        var isProcessingZeroAvailableBalance: Bool {
-            if shieldedBalance.amount == 0 && ShieldingProcessorClient.isShieldable(balance: transparentBalance, threshold: autoShieldingThreshold) {
-                return false
-            }
+        /// Whether a real balance for the CURRENTLY selected account has already been published.
+        /// Recorded against the account rather than as a bare flag: nothing tells this reducer
+        /// when the selection changes, so a flag would go on vouching for the previous account.
+        var hasConcreteBalance: Bool {
+            guard let concreteBalanceAccountId else { return false }
 
-            return totalBalance.amount != shieldedBalance.amount && shieldedBalance.amount == 0
+            return concreteBalanceAccountId == selectedWalletAccount?.id
         }
 
-        // Display-only: deliberately not folded into `transparentBalance`, which feeds
-        // `isProcessingZeroAvailableBalance`, the auto-shielding threshold comparison, and spendability.
+        /// The spendable value is still being worked out — the only situation that deserves an
+        /// "updating" affordance. Deliberately not derived from the balance: a zero spendable
+        /// value is a settled answer for an empty wallet and for funds waiting on confirmations
+        /// alike, and reading it as unfinished left the indicator up forever and the Send screen
+        /// gated on value that was simply not spendable yet. Only two things are genuinely
+        /// unfinished — the SDK withholding the value, and a sync that has published nothing yet.
+        var isProcessingZeroAvailableBalance: Bool {
+            isSpendableMasked || (isSyncInProgress && !hasConcreteBalance)
+        }
+
+        // Display-only: deliberately not folded into `transparentBalance`, which feeds the
+        // auto-shielding threshold comparison and spendability.
         var transparentPoolBalance: Zatoshi {
             transparentBalance + awaitingResolutionBalance
         }
@@ -115,6 +130,25 @@ struct WalletBalances {
     @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
 
     init() { }
+
+    /// The one `spendability` derivation, shared by every place that can move one of its inputs —
+    /// a fresh balance in `.balanceUpdated`, or the mask/sync flags mirrored in
+    /// `.synchronizerStateChanged` — so the two can never compute a different answer for the same
+    /// state.
+    private func spendability(for state: State) -> Spendability {
+        let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)
+        || (!ShieldingProcessorClient.isShieldable(balance: state.transparentBalance, threshold: zcashSDKEnvironment.shieldingThreshold())
+            && state.shieldedBalance == state.totalBalance - state.transparentBalance))
+        || state.totalBalance == .zero
+
+        if state.isProcessingZeroAvailableBalance {
+            return .nothing
+        } else if everythingCondition {
+            return .everything
+        } else {
+            return .something
+        }
+    }
 
     var body: some Reducer<State, Action> {
         Reduce { state, action in
@@ -249,6 +283,10 @@ struct WalletBalances {
                 }
                 
             case .balanceUpdated(let accountBalance):
+                // Every path that reaches here looked the balance up by the account selected right
+                // now, so that is the account this figure answers for.
+                state.concreteBalanceAccountId = state.selectedWalletAccount?.id
+
                 // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future
                 // shielded pool) instead of hand-summing individual pools.
                 state.shieldedBalance = accountBalance.shieldedSpendableValue
@@ -264,18 +302,7 @@ struct WalletBalances {
                 state.ironwoodPoolBalance = accountBalance.ironwoodBalance.total()
                 state.awaitingResolutionBalance = accountBalance.awaitingResolution
 
-                let everythingCondition = state.shieldedBalance.amount > 0 && ((state.shieldedBalance == state.totalBalance)
-                || (!ShieldingProcessorClient.isShieldable(balance: state.transparentBalance, threshold: zcashSDKEnvironment.shieldingThreshold()) && state.shieldedBalance == state.totalBalance - state.transparentBalance))
-                || state.totalBalance == .zero
-
-                // spendability
-                if state.isProcessingZeroAvailableBalance {
-                    state.spendability = .nothing
-                } else if everythingCondition {
-                    state.spendability = .everything
-                } else {
-                    state.spendability = .something
-                }
+                state.spendability = spendability(for: state)
                 return .none
 
             case .synchronizerStateChanged(let latestState):
@@ -290,6 +317,14 @@ struct WalletBalances {
                 // ones with nothing to publish — so deferring it past the guards would leave the
                 // screen silent exactly while it should be saying it is still working this out.
                 state.isSpendableMasked = latestState.data.isSpendableMasked
+                state.isSyncInProgress = latestState.data.syncStatus.isSyncing
+
+                // Re-derived here too, unconditionally: `isProcessingZeroAvailableBalance` (and an
+                // account switch invalidating `hasConcreteBalance`) can change on this action alone,
+                // with no balance publish following — most visibly when the guards below return
+                // because there is nothing to publish for this account, which is exactly when a
+                // stored `spendability` would otherwise go on repeating a now-stale answer.
+                state.spendability = spendability(for: state)
 
                 guard let account = state.selectedWalletAccount else {
                     return .none

--- a/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesView.swift
@@ -57,7 +57,7 @@ struct WalletBalancesView: View {
                     } label: {
                         AvailableBalanceView(
                             balance: store.shieldedBalance,
-                            showIndicator: store.isProcessingZeroAvailableBalance
+                            showIndicator: store.isProcessingZeroAvailableBalance || store.isSpendableMasked
                         )
                         .padding(.top, 12)
                         .padding(.bottom, 30)

--- a/secant/Sources/Utils/SensitiveData.swift
+++ b/secant/Sources/Utils/SensitiveData.swift
@@ -109,6 +109,10 @@ struct RedactableSynchronizerState: Equatable, Redactable {
         var syncStatus: SyncStatus
         var latestBlockHeight: BlockHeight
         var fullyScannedHeight: BlockHeight
+        /// True while the SDK is withholding every pool's spendable value because it has not
+        /// confirmed a fresh chain tip. Mirrored here because a zero spendable balance cannot be
+        /// told apart from an empty wallet or funds still confirming without it.
+        var isSpendableMasked: Bool
     }
 
     let data: SynchronizerStateWrapper
@@ -120,7 +124,8 @@ struct RedactableSynchronizerState: Equatable, Redactable {
             localAccountsBalances: data.localAccountsBalances,
             syncStatus: data.syncStatus,
             latestBlockHeight: data.latestBlockHeight,
-            fullyScannedHeight: data.fullyScannedHeight
+            fullyScannedHeight: data.fullyScannedHeight,
+            isSpendableMasked: data.isSpendableMasked
         )
     }
 }

--- a/zodlTests/BalancesTests/BalancesTests.swift
+++ b/zodlTests/BalancesTests/BalancesTests.swift
@@ -210,6 +210,132 @@ import ComposableArchitecture
         #expect(shieldCalled.value)
     }
 
+
+    // MARK: - The breakdown reads the same unmasked local balances as the home screen
+
+    /// A replayed `.zero` synchronizer state carries no entry for the selected account. The
+    /// breakdown must publish nothing from it — anything else would replace the concrete
+    /// balance on screen with zeros the moment the stream replays its seed value.
+    @MainActor @Test func replayedZeroSynchronizerStatePublishesNoBalance() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = state(shieldedBalance: Zatoshi(600), transparentBalance: Zatoshi(5))
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            initialState.totalBalance = Zatoshi(816)
+            let store = TestStore(initialState: initialState) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+
+            await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted))
+            // The relay hop still runs; what must NOT follow is an `.updateBalance`. The store is
+            // exhaustive here, so one would be reported as an unhandled action.
+            await store.receive(\.updateBalances)
+            await store.finish()
+
+            #expect(store.state.shieldedBalance == Zatoshi(600))
+            #expect(store.state.totalBalance == Zatoshi(816))
+        }
+    }
+
+    /// The state stream carries both a possibly masked visible balance and the unmasked local
+    /// snapshot. The breakdown must read the local one, so it agrees with the home screen
+    /// instead of showing zeros while the engine withholds the spendable value.
+    @MainActor @Test func synchronizerStateUsesUnmaskedLocalBalance() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let localBalance = fullPoolAccountBalance()
+            let maskedBalance = AccountBalance(
+                saplingBalance: .zero,
+                orchardBalance: .zero,
+                ironwoodBalance: .zero,
+                unshielded: .zero,
+                awaitingResolution: .zero
+            )
+            var snapshot = SynchronizerState.zero
+            snapshot.accountsBalances = [testWalletAccount.id: maskedBalance]
+            snapshot.localAccountsBalances = [testWalletAccount.id: localBalance]
+
+            var initialState = state()
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: initialState) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.synchronizerStateChanged(snapshot.redacted))
+            await store.receive(\.updateBalances)
+            await store.receive(\.updateBalance)
+
+            #expect(store.state.shieldedBalance == localBalance.shieldedSpendableValue)
+            #expect(store.state.shieldedBalance != .zero)
+        }
+    }
+
+    /// The instant read on appear prefers the unmasked local balances too, so opening the sheet
+    /// during a server switch does not momentarily show a masked zero.
+    @MainActor @Test func updateBalancesOnAppearPrefersLocalAccountBalances() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let localBalance = fullPoolAccountBalance()
+            let maskedBalance = AccountBalance(
+                saplingBalance: .zero,
+                orchardBalance: .zero,
+                ironwoodBalance: .zero,
+                unshielded: .zero,
+                awaitingResolution: .zero
+            )
+            let accountUUID = testWalletAccount.id
+            var initialState = state()
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: initialState) {
+                Balances()
+            } withDependencies: {
+                $0.sdkSynchronizer = .mocked(
+                    getAccountsBalances: { [accountUUID: maskedBalance] },
+                    getLocalAccountBalances: { [accountUUID: localBalance] }
+                )
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.updateBalancesOnAppear)
+            await store.receive(\.updateBalance)
+
+            #expect(store.state.shieldedBalance == localBalance.shieldedSpendableValue)
+        }
+    }
+
+    private var testWalletAccount: WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 9, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func fullPoolAccountBalance() -> AccountBalance {
+        AccountBalance(
+            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
+            unshielded: Zatoshi(5),
+            awaitingResolution: Zatoshi(1)
+        )
+    }
+
     private func state(
         autoShieldingThreshold: Zatoshi = Zatoshi(1_000_000),
         changePending: Zatoshi = .zero,

--- a/zodlTests/BalancesTests/BalancesTests.swift
+++ b/zodlTests/BalancesTests/BalancesTests.swift
@@ -78,15 +78,33 @@ import ComposableArchitecture
         #expect(shielding.isShieldingButtonDisabled) // disabled while shielding even if available
     }
 
+    /// "Processing with zero available" means the spendable value is still being worked out, and
+    /// no shape of the balance says that. A zero spendable balance is a settled answer — nothing
+    /// to spend right now — whether the rest of the wallet is confirming or transparent.
     @Test func isProcessingZeroAvailableBalance() {
-        var processing = state(shieldedBalance: .zero, transparentBalance: Zatoshi(10))
-        processing.autoShieldingThreshold = Zatoshi(50)
-        processing.totalBalance = Zatoshi(10)
-        #expect(processing.isProcessingZeroAvailableBalance)
+        withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var confirming = state(shieldedBalance: .zero, transparentBalance: Zatoshi(10))
+            confirming.autoShieldingThreshold = Zatoshi(50)
+            confirming.totalBalance = Zatoshi(10)
+            #expect(!confirming.isProcessingZeroAvailableBalance)
 
-        var hasTransparentAboveThreshold = state(shieldedBalance: .zero, transparentBalance: Zatoshi(100))
-        hasTransparentAboveThreshold.autoShieldingThreshold = Zatoshi(50)
-        #expect(!hasTransparentAboveThreshold.isProcessingZeroAvailableBalance)
+            var hasTransparentAboveThreshold = state(shieldedBalance: .zero, transparentBalance: Zatoshi(100))
+            hasTransparentAboveThreshold.autoShieldingThreshold = Zatoshi(50)
+            #expect(!hasTransparentAboveThreshold.isProcessingZeroAvailableBalance)
+
+            // The SDK declining to state the spendable value is the case that IS unresolved.
+            var masked = confirming
+            masked.isSpendableMasked = true
+            #expect(masked.isProcessingZeroAvailableBalance)
+
+            // So is a running sync that has not published a balance for this account yet.
+            var syncingBeforeFirstBalance = state()
+            syncingBeforeFirstBalance.isSyncInProgress = true
+            #expect(!syncingBeforeFirstBalance.hasConcreteBalance)
+            #expect(syncingBeforeFirstBalance.isProcessingZeroAvailableBalance)
+        }
     }
 
     @Test func isPendingTransactionReflectsSharedTransactions() {
@@ -210,7 +228,6 @@ import ComposableArchitecture
         #expect(shieldCalled.value)
     }
 
-
     // MARK: - The breakdown reads the same unmasked local balances as the home screen
 
     /// A replayed `.zero` synchronizer state carries no entry for the selected account. The
@@ -229,7 +246,12 @@ import ComposableArchitecture
                 $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
             }
 
-            await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted))
+            await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted)) {
+                // `spendability` is re-derived on every `.synchronizerStateChanged`, from the
+                // concrete balance already on screen — unrelated to, and not proof against, the
+                // "no `.updateBalance` follows" assertion below.
+                $0.spendability = .something
+            }
             // The relay hop still runs; what must NOT follow is an `.updateBalance`. The store is
             // exhaustive here, so one would be reported as an unhandled action.
             await store.receive(\.updateBalances)
@@ -312,6 +334,127 @@ import ComposableArchitecture
         }
     }
 
+    // MARK: - Funds pending confirmation are something to spend later, not nothing at all
+
+    /// A self-shield waiting for confirmations: the shielded total exceeds the spendable value and
+    /// there is no transparent balance left. That is a complete answer — nothing spendable right
+    /// now, something spendable soon — so the breakdown must not report it as unresolved.
+    @MainActor @Test func fundsPendingConfirmationAreSomethingRatherThanNothing() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = state()
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: initialState) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.updateBalance(pendingSelfShieldBalance()))
+
+            #expect(store.state.shieldedBalance == .zero)
+            #expect(store.state.transparentBalance == .zero)
+            #expect(store.state.shieldedWithPendingBalance == Zatoshi(500))
+            #expect(!store.state.isProcessingZeroAvailableBalance)
+            #expect(store.state.spendability == .something)
+        }
+    }
+
+    /// The same wallet while the SDK withholds the spendable value: now it IS unresolved, and the
+    /// sheet must say so rather than presenting the withheld zero as a real figure.
+    @MainActor @Test func aMaskedSpendableValueIsReportedAsStillBeingDetermined() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var masked = SynchronizerState.zero
+            masked.isSpendableMasked = true
+            masked.localAccountsBalances = [testWalletAccount.id: pendingSelfShieldBalance()]
+
+            var initialState = state()
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: initialState) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.synchronizerStateChanged(masked.redacted))
+            await store.receive(\.updateBalances)
+            await store.receive(\.updateBalance)
+
+            #expect(store.state.isSpendableMasked)
+            #expect(store.state.isProcessingZeroAvailableBalance)
+            #expect(store.state.spendability == .nothing)
+        }
+    }
+
+    // MARK: - `spendability` must not go on repeating a stale answer once the flags it depends on move
+
+    /// A masked state with no local entry for the account never reaches `.updateBalance`, where
+    /// `spendability` is otherwise recomputed. Without a re-derivation here the stored answer is
+    /// simply whatever it was before the mask arrived — `.everything` for a sheet that has not
+    /// published a balance yet — which is exactly wrong while the SDK is still working it out.
+    @MainActor @Test func aMaskWithNoLocalSnapshotLeavesSpendabilityAsStillBeingDetermined() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var initialState = state()
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: initialState) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            var masked = SynchronizerState.zero
+            masked.isSpendableMasked = true
+            await store.send(.synchronizerStateChanged(masked.redacted))
+
+            #expect(store.state.isProcessingZeroAvailableBalance)
+            #expect(store.state.spendability == .nothing)
+        }
+    }
+
+    /// The published balance vouches for the account it was read for. Switching account while a
+    /// sync is running, before anything is published for the new account, must stop `spendability`
+    /// from going on answering for the account that is no longer selected.
+    @MainActor @Test func spendabilityStopsAnsweringForThePreviousAccountAfterASwitch() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var syncing = SynchronizerState.zero
+            syncing.syncStatus = .syncing(0.5, false)
+
+            var initialState = state()
+            initialState.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: initialState) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.synchronizerStateChanged(syncing.redacted))
+            await store.send(.updateBalance(pendingSelfShieldBalance()))
+            #expect(store.state.hasConcreteBalance)
+            #expect(store.state.spendability == .something)
+
+            store.state.$selectedWalletAccount.withLock { $0 = otherWalletAccount }
+            #expect(!store.state.hasConcreteBalance)
+            #expect(store.state.isProcessingZeroAvailableBalance)
+
+            // No balance has been published for the new account yet, but the next state-stream
+            // tick must still stop `spendability` from going on answering for the OLD one.
+            await store.send(.synchronizerStateChanged(syncing.redacted))
+            #expect(store.state.isProcessingZeroAvailableBalance)
+            #expect(store.state.spendability == .nothing)
+        }
+    }
+
     private var testWalletAccount: WalletAccount {
         WalletAccount(
             Account(
@@ -323,6 +466,30 @@ import ComposableArchitecture
                 ufvk: nil,
                 uivk: nil
             )
+        )
+    }
+
+    private var otherWalletAccount: WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 10, count: 16)),
+                name: "Keystone",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func pendingSelfShieldBalance() -> AccountBalance {
+        AccountBalance(
+            saplingBalance: .zero,
+            orchardBalance: PoolBalance(spendableValue: .zero, changePendingConfirmation: .zero, valuePendingSpendability: Zatoshi(500)),
+            ironwoodBalance: .zero,
+            unshielded: .zero,
+            awaitingResolution: .zero
         )
     }
 

--- a/zodlTests/ShieldingTests/ShieldingEligibilityTests.swift
+++ b/zodlTests/ShieldingTests/ShieldingEligibilityTests.swift
@@ -55,9 +55,11 @@ import ComposableArchitecture
 // the plain `ShieldingEligibilityTests` suite above. A dedicated `.serialized` suite with pinned
 // storage keeps this test isolated from concurrently running suites that also touch that storage.
 @Suite(.serialized) struct WalletBalancesEligibilityTests {
-    /// WalletBalances and Balances compute "processing with zero available" from the same wallet
-    /// and must agree at exactly the shielding threshold (the SDK's rule is inclusive).
-    @Test func walletBalancesProcessingRuleIsInclusiveAtTheThreshold() {
+    /// "Processing with zero available" means the spendable value is still being worked out, so it
+    /// no longer reads the balance at all. A wallet holding exactly the shielding threshold in
+    /// transparent funds is a settled answer and must never read as unresolved — the regression
+    /// guarded here is any return of a balance-shaped rule to that property.
+    @Test func walletBalancesAtTheShieldingThresholdIsNotStillBeingDetermined() {
         withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {

--- a/zodlTests/WalletBalancesTests/WalletBalancesMaskedSpendableTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesMaskedSpendableTests.swift
@@ -1,0 +1,158 @@
+//
+//  WalletBalancesMaskedSpendableTests.swift
+//  zodlTests
+//
+//  Covers the SDK's "the spendable value is masked" signal as it reaches the app: the mirror on
+//  RedactableSynchronizerState, the WalletBalances state flag, and the Send form's gates
+//  (Utils/SensitiveData.swift, Features/WalletBalances/WalletBalancesStore.swift,
+//  Features/SendForm/SendFormStore.swift).
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct WalletBalancesMaskedSpendableTests {
+    private var testWalletAccount: WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 7, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    // MARK: - The redacted wrapper carries the signal at all
+
+    @Test func redactableSynchronizerStateMirrorsIsSpendableMasked() {
+        var masked = SynchronizerState.zero
+        masked.isSpendableMasked = true
+        #expect(masked.redacted.data.isSpendableMasked)
+
+        #expect(!SynchronizerState.zero.redacted.data.isSpendableMasked)
+    }
+
+    // MARK: - WalletBalances mirrors it, even with nothing to publish
+
+    @MainActor @Test func synchronizerStateChangedMirrorsMaskWithoutALocalSnapshot() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            // `.zero` has no entry for the selected account, so nothing is published from it —
+            // the mask must still be recorded, or the screen would never say it is working.
+            var masked = SynchronizerState.zero
+            masked.isSpendableMasked = true
+            await store.send(.synchronizerStateChanged(masked.redacted))
+            #expect(store.state.isSpendableMasked)
+
+            await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted))
+            #expect(!store.state.isSpendableMasked)
+        }
+    }
+
+    @MainActor @Test func synchronizerStateChangedMirrorsMaskAlongsideAPublishedBalance() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var masked = SynchronizerState.zero
+            masked.isSpendableMasked = true
+            masked.localAccountsBalances = [testWalletAccount.id: fullPoolAccountBalance()]
+
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.synchronizerStateChanged(masked.redacted))
+            await store.receive(\.balanceUpdated)
+
+            #expect(store.state.isSpendableMasked)
+            #expect(store.state.shieldedBalance == fullPoolAccountBalance().shieldedSpendableValue)
+        }
+    }
+
+    // MARK: - The Send form waits for the value instead of calling it insufficient
+
+    @Test func sendFormHoldsTheFormWhileTheSpendableValueIsMasked() {
+        withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = SendForm.State.initial
+            let previousAccount = state.selectedWalletAccount
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            defer { state.$selectedWalletAccount.withLock { $0 = previousAccount } }
+
+            state.isValidAddress = true
+            // `SendForm.State.amount` is hard-wired to zero under the test build, so the only way
+            // to drive `amount > shieldedBalance` true here is a spendable balance below zero.
+            // The production case this stands for is the opposite shape and the same comparison:
+            // a masked spendable value reads as zero, so any typed amount exceeds it.
+            state.shieldedBalance = Zatoshi(-1)
+            state.walletBalancesState.isSpendableMasked = false
+            #expect(state.isInsufficientFunds)
+
+            state.walletBalancesState.isSpendableMasked = true
+
+            #expect(state.isSpendabilityBeingDetermined)
+            // Without the gate the form would tell the user the funds are insufficient for an
+            // amount the wallet may well be able to send once the value stops being masked.
+            #expect(!state.isInsufficientFunds)
+            // A held error is not enough on its own — Send must stay disabled too, or tapping it
+            // would submit an amount nothing has checked against a real spendable balance.
+            #expect(!state.isValidForm)
+
+            state.walletBalancesState.isSpendableMasked = false
+            #expect(!state.isSpendabilityBeingDetermined)
+            #expect(state.isInsufficientFunds)
+        }
+    }
+
+    @Test func sendFormUnmaskedKeepsTheOrdinaryInsufficientFundsAnswer() {
+        withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = SendForm.State.initial
+            let previousAccount = state.selectedWalletAccount
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            defer { state.$selectedWalletAccount.withLock { $0 = previousAccount } }
+
+            state.isValidAddress = true
+            state.shieldedBalance = Zatoshi(100_000)
+            state.walletBalancesState.isSpendableMasked = false
+
+            #expect(!state.isSpendabilityBeingDetermined)
+            #expect(!state.isInsufficientFunds)
+            #expect(state.isValidForm)
+        }
+    }
+
+    private func fullPoolAccountBalance() -> AccountBalance {
+        AccountBalance(
+            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
+            unshielded: Zatoshi(5),
+            awaitingResolution: Zatoshi(1)
+        )
+    }
+}

--- a/zodlTests/WalletBalancesTests/WalletBalancesMaskedSpendableTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesMaskedSpendableTests.swift
@@ -29,6 +29,20 @@ import ComposableArchitecture
         )
     }
 
+    private var otherWalletAccount: WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 8, count: 16)),
+                name: "Keystone",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
     // MARK: - The redacted wrapper carries the signal at all
 
     @Test func redactableSynchronizerStateMirrorsIsSpendableMasked() {
@@ -63,6 +77,34 @@ import ComposableArchitecture
 
             await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted))
             #expect(!store.state.isSpendableMasked)
+        }
+    }
+
+    // MARK: - `spendability` must not go on repeating a stale answer once the flags it depends on move
+
+    /// A masked state with no local entry for the account never reaches `.balanceUpdated`, where
+    /// `spendability` is otherwise recomputed. Without a re-derivation here the stored answer is
+    /// simply whatever it was before the mask arrived — `.everything` for a wallet that has not
+    /// published a balance yet — which hides the "still updating" row exactly when it should show.
+    @MainActor @Test func aMaskWithNoLocalSnapshotLeavesSpendabilityAsStillBeingDetermined() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            var masked = SynchronizerState.zero
+            masked.isSpendableMasked = true
+            await store.send(.synchronizerStateChanged(masked.redacted))
+
+            #expect(store.state.isProcessingZeroAvailableBalance)
+            #expect(store.state.spendability == .nothing)
         }
     }
 
@@ -144,6 +186,111 @@ import ComposableArchitecture
             #expect(!state.isInsufficientFunds)
             #expect(state.isValidForm)
         }
+    }
+
+    // MARK: - Funds pending confirmation are something to spend later, not nothing at all
+
+    /// A self-shield waiting for confirmations: the shielded total exceeds the spendable value and
+    /// no transparent balance is left. Nothing is spendable this minute, but that is the complete
+    /// answer — the home screen must not spin over it as though the figure were still coming.
+    @MainActor @Test func fundsPendingConfirmationAreSomethingRatherThanNothing() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.balanceUpdated(pendingSelfShieldBalance()))
+
+            #expect(store.state.shieldedBalance == .zero)
+            #expect(store.state.transparentBalance == .zero)
+            #expect(store.state.shieldedWithPendingBalance == Zatoshi(500))
+            #expect(!store.state.isProcessingZeroAvailableBalance)
+            #expect(store.state.spendability == .something)
+        }
+    }
+
+    /// A running sync that has not published anything yet genuinely has no answer, so it reads as
+    /// unresolved — until the first balance for the selected account arrives.
+    @MainActor @Test func aRunningSyncIsUnresolvedOnlyUntilTheFirstBalanceArrives() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var syncing = SynchronizerState.zero
+            syncing.syncStatus = .syncing(0.5, false)
+
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.synchronizerStateChanged(syncing.redacted))
+            #expect(store.state.isSyncInProgress)
+            #expect(!store.state.hasConcreteBalance)
+            #expect(store.state.isProcessingZeroAvailableBalance)
+
+            await store.send(.balanceUpdated(pendingSelfShieldBalance()))
+            #expect(store.state.hasConcreteBalance)
+            #expect(!store.state.isProcessingZeroAvailableBalance)
+        }
+    }
+
+    /// The published balance vouches for the account it was read for. Switching account must not
+    /// let the previous account's figure keep answering for the new one — nothing tells this
+    /// reducer that the selection changed, so the record has to carry the account with it. Nor may
+    /// `spendability` — a stored snapshot, unlike `hasConcreteBalance` — keep repeating the old
+    /// account's answer once the next state-stream tick has a chance to revisit it.
+    @MainActor @Test func aBalanceStopsVouchingWhenTheSelectedAccountChanges() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var syncing = SynchronizerState.zero
+            syncing.syncStatus = .syncing(0.5, false)
+
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = testWalletAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.synchronizerStateChanged(syncing.redacted))
+            await store.send(.balanceUpdated(pendingSelfShieldBalance()))
+            #expect(store.state.hasConcreteBalance)
+            #expect(store.state.spendability == .something)
+
+            store.state.$selectedWalletAccount.withLock { $0 = otherWalletAccount }
+            #expect(!store.state.hasConcreteBalance)
+            #expect(store.state.isProcessingZeroAvailableBalance)
+
+            // No balance has been published for the new account yet, but the next state-stream
+            // tick must still stop `spendability` from going on answering for the OLD one.
+            await store.send(.synchronizerStateChanged(syncing.redacted))
+            #expect(store.state.isProcessingZeroAvailableBalance)
+            #expect(store.state.spendability == .nothing)
+        }
+    }
+
+    private func pendingSelfShieldBalance() -> AccountBalance {
+        AccountBalance(
+            saplingBalance: .zero,
+            orchardBalance: PoolBalance(spendableValue: .zero, changePendingConfirmation: .zero, valuePendingSpendability: Zatoshi(500)),
+            ironwoodBalance: .zero,
+            unshielded: .zero,
+            awaitingResolution: .zero
+        )
     }
 
     private func fullPoolAccountBalance() -> AccountBalance {

--- a/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
@@ -16,6 +16,9 @@ import ComposableArchitecture
 @Suite(.serialized) struct WalletBalancesTests {
     // MARK: - Computed props
 
+    /// "Processing with zero available" means the spendable value is still being worked out. No
+    /// shape of the balance says that: a zero spendable balance is a settled answer, so none of
+    /// these wallets is unresolved, however their value is distributed.
     @Test func isProcessingZeroAvailableBalance() {
         var transparentAboveThreshold = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(100), transparentBalance: Zatoshi(100))
         transparentAboveThreshold.autoShieldingThreshold = Zatoshi(50)
@@ -23,10 +26,20 @@ import ComposableArchitecture
 
         var shieldedZeroPending = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(10), transparentBalance: Zatoshi(10))
         shieldedZeroPending.autoShieldingThreshold = Zatoshi(50)
-        #expect(shieldedZeroPending.isProcessingZeroAvailableBalance)
+        #expect(!shieldedZeroPending.isProcessingZeroAvailableBalance)
 
         let hasShielded = WalletBalances.State(shieldedBalance: Zatoshi(100), totalBalance: Zatoshi(200), transparentBalance: Zatoshi(100))
         #expect(!hasShielded.isProcessingZeroAvailableBalance)
+
+        // The two states that really are unresolved.
+        var masked = shieldedZeroPending
+        masked.isSpendableMasked = true
+        #expect(masked.isProcessingZeroAvailableBalance)
+
+        var syncingBeforeFirstBalance = WalletBalances.State()
+        syncingBeforeFirstBalance.isSyncInProgress = true
+        #expect(!syncingBeforeFirstBalance.hasConcreteBalance)
+        #expect(syncingBeforeFirstBalance.isProcessingZeroAvailableBalance)
     }
 
     @Test func currencyValueIsEmptyWithoutConversionAndFormattedWithIt() {


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1862. Three commits.

**What**
1. The balance breakdown sheet publishes from the same unmasked local balance snapshots the home balance already uses, and its instant read prefers the local read with the same fallback order. A replayed empty synchronizer state no longer publishes a zero balance into the breakdown.
2. The SDK's "spendable value is masked" flag is mirrored into the wallet-balances state. While it is set, the available-balance row shows its updating indicator, the Send form is not valid, "insufficient funds" is not shown, and the Max chip shows its in-flight state. No new component, string or asset.
3. "Processing zero available balance" is redefined in both balance stores as "the spendable value is still being determined": the flag is masked, or a sync is running and no concrete balance has been published yet for the selected account. Funds that are merely pending confirmation therefore count as something to spend, with a spendable amount of zero and no spinner. The spendability value is re-derived whenever those inputs change, not only when a balance is published, so the indicator and the Send gates cannot lag behind the flag. The shielding-threshold early return is removed because no shielding path read this predicate.

**Why:** after the home balance moved to unmasked local snapshots, the breakdown sheet still read the masked visible balances and mapped a missing entry to zero, which reached "everything spendable" on a replayed empty snapshot. The old "shielded spendable zero while total non-zero" rule drove a spinner that never cleared for funds pending confirmation and blocked the Send form. The SDK now says explicitly when the spendable value is masked, so the UI can show "updating" only while that is true.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **` after each commit.
- `BalancesTests` (extended) and new `WalletBalancesMaskedSpendableTests`: replayed zero state publishes nothing; masked state mirrors the flag, turns the indicator on, makes the Send form invalid and not "insufficient"; unmasked returns to normal; a pending self-shield yields "something to spend" with no spinner; a masked state with no local entry and an account switch mid-sync both re-derive spendability.
- Full `zodlTests` target: 1644 tests passed, 2 pre-existing known issues.

**Notes for reviewers:** `WalletBalances.State.autoShieldingThreshold` is now write-only; it is left in place because removing it would delete an existing eligibility test, and is flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)