### PR TITLE
[MOB-1863] Show sent transactions as awaiting confirmation once a server accepted them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ### Changed
 - [MOB-1858] Sending no longer waits behind unrelated network work. Preparing a payment now runs alongside other activity instead of blocking it, and if the wallet really is busy with something else, the send reports a failure you can retry instead of appearing to hang.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
+- [MOB-1863] A sent transaction now shows "Sent · awaiting confirmation" once a server has accepted it, instead of "Sending" until the wallet catches up.
 
 ### Fixed
 - [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send waits for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent.

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -23457,6 +23457,23 @@
         }
       }
     },
+    "transaction.sentAwaitingConfirmation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sent · awaiting confirmation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviado · esperando confirmación"
+          }
+        }
+      }
+    },
     "transaction.shieldedFunds" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -784,6 +784,15 @@ extension SDKSynchronizerClient {
                 currentChainTip: currentChainTip
             )
 
+            // MOB-1863: a `.sending` row can already be accepted by a server for broadcast even
+            // though this device's own scan hasn't caught up yet. Only look this up for rows
+            // that need it, so mined/received rows don't pay for an extra query.
+            if transaction.status == .sending {
+                if case .accepted = await synchronizer.transactionSubmissionStatus(for: clearedTransaction.rawID) {
+                    transaction.isAcceptedBySubmitter = true
+                }
+            }
+
             // MOB-1856: the SDK's `getRecipients(for:)` is itself just
             // `getTransactionOutputs(for:).map { $0.recipient }` -- reuse the `outputs` already read
             // above instead of a second call that re-reads the exact same rows from the database.

--- a/secant/Sources/Models/TransactionState.swift
+++ b/secant/Sources/Models/TransactionState.swift
@@ -47,6 +47,10 @@ struct TransactionState: Equatable, Identifiable {
     var zecAmount: Zatoshi
     var isMarkedAsRead = false
     var isInAddressBook = false
+    /// A sent, unmined transaction that a server has already accepted for broadcast (SDK
+    /// `TransactionSubmissionStatus.accepted`). Lets a `.sending` row read "awaiting
+    /// confirmation" instead of "Sending" once the network has it, not just this device.
+    var isAcceptedBySubmitter = false
     var hasTransparentOutputs = false
     var totalSpent: Zatoshi?
     var totalReceived: Zatoshi?
@@ -185,7 +189,9 @@ struct TransactionState: Equatable, Identifiable {
             case .receiving:
                 return String(localizable: .transactionReceiving)
             case .sending:
-                return String(localizable: .transactionSending)
+                return isAcceptedBySubmitter
+                ? String(localizable: .transactionSentAwaitingConfirmation)
+                : String(localizable: .transactionSending)
             case .shielding:
                 return String(localizable: .transactionShieldingFunds)
             case .shielded:

--- a/zodlTests/ModelsTests/TransactionStateTests.swift
+++ b/zodlTests/ModelsTests/TransactionStateTests.swift
@@ -348,4 +348,30 @@ import Foundation
         state.status = .failed
         #expect(state.daysAgo.isEmpty)
     }
+
+    // MARK: - Submission acceptance (MOB-1863)
+
+    /// Once a server has accepted a sent, unmined transaction for broadcast, the row must read
+    /// "Sent · awaiting confirmation" rather than the generic "Sending" - the wallet's own scan
+    /// catching up is not the same as the network not having the transaction yet.
+    @Test func sendingTransactionAcceptedBySubmitterShowsAwaitingConfirmation() {
+        var state = TransactionState(fee: Zatoshi(10), id: "s", status: .sending, zecAmount: Zatoshi(-10))
+        state.isAcceptedBySubmitter = true
+        #expect(state.title() == String(localizable: .transactionSentAwaitingConfirmation))
+    }
+
+    /// Without server acceptance, a sending transaction keeps today's generic "Sending" label.
+    @Test func sendingTransactionNotYetAcceptedShowsSending() {
+        var state = TransactionState(fee: Zatoshi(10), id: "s", status: .sending, zecAmount: Zatoshi(-10))
+        state.isAcceptedBySubmitter = false
+        #expect(state.title() == String(localizable: .transactionSending))
+    }
+
+    /// The flag only matters while a transaction is still `.sending` - a mined (`.paid`)
+    /// transaction ignores it and keeps its regular label.
+    @Test func minedTransactionIgnoresTheAcceptedFlag() {
+        var state = TransactionState(fee: Zatoshi(10), id: "m", status: .paid, zecAmount: Zatoshi(-10))
+        state.isAcceptedBySubmitter = true
+        #expect(state.title() == String(localizable: .transactionSent))
+    }
 }


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Linear: MOB-1863.

**What:** `TransactionState` gains an `isAcceptedBySubmitter` flag. When the live synchronizer dependency maps a transaction whose computed status is "sending", it asks the SDK for the transaction's submission status and sets the flag when a server has accepted the broadcast. The status label shows "Sent · awaiting confirmation" (en) / "Enviado · esperando confirmación" (es) for such rows instead of "Sending". Rows in any other status are untouched and make no extra query.

**Why:** the app derives "sending" from a sent transaction having no mined height, and the mined height is only learned by scanning the block the transaction landed in. Submission does not ride the sync wire, so after a successful broadcast the row said "Sending" for as long as the scan was stalled, even though the chain very likely already had the transaction. The SDK now records which server accepted a submission, so the label can say so.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- `TransactionStateTests` (3 new, 22 total): sending and accepted shows the new label; sending and not accepted still shows "Sending"; a mined transaction ignores the flag.
- The suites under `RootTransactionsTests` still pass (37 tests), covering the `Equatable` change on the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)