### PR TITLE
[MOB-1848] Whole-branch review follow-ups for the sync contention series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1863] A sent transaction now shows "Sent · awaiting confirmation" once a server has accepted it, instead of "Sending" until the wallet catches up.
 
 ### Fixed
-- [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send waits for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent.
+- [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send and Swap wait for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent.
 - [MOB-1860] Leaving a voting screen while a proof is being prepared stops that work instead of letting it run in the background.
 - [MOB-1859] Opening the wallet no longer generates a fresh receive address for every account on each load, so loading is faster during sync.
 - [MOB-1857] Sending with insufficient funds shows the proper message again, and a failed payment request always shows an error instead of doing nothing.

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -320,6 +320,7 @@ extension SDKSynchronizerClient: DependencyKey {
                 return try await Self.createThenSubmitUnderGuard(
                     transactionGuard: transactionGuard,
                     timeout: submissionGuardTimeout,
+                    logPrefix: "[MultiSubmit]",
                     prove: {
                         try await synchronizer.broadcaster.createProposedTransactions(
                             proposal: proposal,
@@ -412,6 +413,7 @@ extension SDKSynchronizerClient: DependencyKey {
                 return try await Self.createThenSubmitUnderGuard(
                     transactionGuard: transactionGuard,
                     timeout: submissionGuardTimeout,
+                    logPrefix: "[MultiSubmit/PCZT]",
                     prove: {
                         try await synchronizer.broadcaster.createTransactionFromPCZT(
                             pcztWithProofs: pcztWithProofs,
@@ -532,6 +534,7 @@ extension SDKSynchronizerClient {
     static func createThenSubmitUnderGuard(
         transactionGuard: TransactionGuardClient,
         timeout: Duration,
+        logPrefix: String,
         prove: () async throws -> [CreatedTransaction],
         submit: ([CreatedTransaction]) async -> CreateProposedTransactionsResult
     ) async throws -> CreateProposedTransactionsResult {
@@ -542,7 +545,7 @@ extension SDKSynchronizerClient {
                 await submit(transactions)
             }
         } catch is TransactionGuardBusyError {
-            LoggerProxy.error("[MultiSubmit] Gave up waiting \(timeout) for exclusive access; nothing was broadcast.")
+            LoggerProxy.error("\(logPrefix) Gave up waiting \(timeout) for exclusive access; nothing was broadcast.")
 
             return CreateProposedTransactionsResult.failure(
                 txIds: [],

--- a/secant/Sources/Dependencies/TransactionGuard/TransactionGuard.swift
+++ b/secant/Sources/Dependencies/TransactionGuard/TransactionGuard.swift
@@ -145,6 +145,14 @@ let serverSwitchTimeout: Duration = .seconds(60)
 /// already owns the guard is never cut short. Long enough to queue behind a normal broadcast, short
 /// enough that a wedged holder surfaces as a failed send the user can retry instead of a screen that
 /// appears to have frozen. Nothing has been broadcast when it expires, so retrying is always safe.
+///
+/// The trade-off this creates is deliberate, not just a hedge against a wedged holder: a
+/// *legitimate* holder can also run past 30s — a server switch bounded by `serverSwitchTimeout`
+/// (60s) or a migration broadcast can both hold the guard longer than a send is willing to wait.
+/// A send queued behind either one reports "busy" rather than waiting the holder out, and the user
+/// retries once it clears. That is preferred over letting a send queue indefinitely behind
+/// unrelated work; the 30s figure itself is a product choice, not a value derived from any
+/// protocol or server-side limit.
 let submissionGuardTimeout: Duration = .seconds(30)
 
 /// Race `operation` against a `duration` timer; whichever finishes first wins and the loser is

--- a/secant/Sources/Features/Home/HomeStore.swift
+++ b/secant/Sources/Features/Home/HomeStore.swift
@@ -219,8 +219,12 @@ struct Home {
                     .run { send in
                         let freshUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
                         await send(.updatePrivateUA(freshUA, uuid))
-                        let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
-                        await send(.updateNextPrivateUA(stashUA, uuid))
+                        // A failed generation must not be reported as nil: `.updateNextPrivateUA`
+                        // writes through unconditionally and would clear a stash another path wrote
+                        // while this call was resolving (the same rule `PrivateUAStash.refill` follows).
+                        if let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account)) {
+                            await send(.updateNextPrivateUA(stashUA, uuid))
+                        }
                     }
                     .cancellable(id: state.CancelUAGenerationId, cancelInFlight: true)
                 )

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -255,9 +255,12 @@ extension Root {
                     // `.retryStart`, restarting the sync this boundary just stopped). The next
                     // foreground's `.registerForSynchronizersUpdate` respawns it.
                     .cancel(id: state.migrationSyncGateCancelId),
-                    // MOB-1853: a benchmark/apply-switch run still in flight when the app
-                    // backgrounds must not land later against the synchronizer `stop()` above just
-                    // tore down.
+                    // MOB-1853: cancels only the benchmark (`.refreshAutomaticServer`'s effect,
+                    // the one thing this id covers). An apply already in flight (`applySwitch`,
+                    // `RootStore.swift`) carries no cancel id of its own and keeps running to
+                    // completion regardless, under `switchIfIdle`/`withTimeout(serverSwitchTimeout)`
+                    // — cancelling a switch mid-apply is a behaviour change left for a follow-up,
+                    // not something this background-teardown path attempts.
                     .cancel(id: state.automaticServerRefreshCancelId)
                 )
 

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -643,8 +643,9 @@ struct Root {
     }
     
     /// The `onChange` wrapper must observe every reducer that can mutate an input of
-    /// `canApplyAutoServerSwitch` (path, bindings, bgTask, settings path) — keep ALL
-    /// composed reducers inside `combinedCore`; never add a sibling reducer here in `body`.
+    /// `canApplyAutoServerSwitch` (path, bindings, bgTask, settings path, and — via
+    /// `isSynchronizerIdleForSwitch` — `lastKnownSyncStatus` / `isSyncStalledSinceLastProgress`)
+    /// — keep ALL composed reducers inside `combinedCore`; never add a sibling reducer here in `body`.
     var body: some Reducer<State, Action> {
         combinedCore
             .onChange(of: \.canApplyAutoServerSwitch) { _, state in

--- a/secant/Sources/Features/SwapAndPayForm/CrossPayForm.swift
+++ b/secant/Sources/Features/SwapAndPayForm/CrossPayForm.swift
@@ -49,7 +49,7 @@ extension SwapAndPayForm {
                                         title: String(localizable: .generalMax),
                                         style: .standard,
                                         isEnabled: store.isPayMaxButtonEnabled,
-                                        isInFlight: store.isMaxRequestInFlight
+                                        isInFlight: store.isMaxRequestInFlight || store.isSpendabilityBeingDetermined
                                     ) {
                                         store.send(.maxTapped)
                                     }

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -848,8 +848,12 @@ struct SwapAndPay {
                     let privateUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
                     await send(.updatePrivateUA(privateUA, uuid))
                     await send(.getQuote)
-                    let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account))
-                    await send(.updateNextPrivateUA(stashUA, uuid))
+                    // A failed generation must not be reported as nil: `.updateNextPrivateUA`
+                    // writes through unconditionally and would clear a stash another path wrote
+                    // while this call was resolving (the same rule `PrivateUAStash.refill` follows).
+                    if let stashUA = try? await sdkSynchronizer.getCustomUnifiedAddress(uuid, PrivateUAStash.receivers(for: account)) {
+                        await send(.updateNextPrivateUA(stashUA, uuid))
+                    }
                 }
                 .cancellable(id: state.UAGenerationCancelId, cancelInFlight: true)
 

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -99,27 +99,41 @@ struct SwapAndPay {
             "\(address)-\(selectedAsset?.chain ?? "zcash")"
         }
         
+        /// The SDK has not said what is spendable yet. Distinct from "nothing is spendable":
+        /// the answer is still coming, so the form waits for it instead of judging on a zero.
+        var isSpendabilityBeingDetermined: Bool {
+            walletBalancesState.isSpendableMasked
+        }
+
         var isValidForm: Bool {
             selectedAsset != nil
             && !address.isEmpty
             && amount > 0
             && !isInsufficientFunds
+            && !isSpendabilityBeingDetermined
         }
-        
+
         var isInsufficientFunds: Bool {
             guard !isSwapToZecExperienceEnabled else { return false }
 
             guard !amountText.isEmpty else {
                 return false
             }
-            
+
             guard let selectedAsset else {
                 return false
             }
-            
+
             guard let zecAsset else {
                 return false
             }
+
+            // A masked spendable value arrives as zero, so every typed amount would exceed it and
+            // the form would accuse the user of insufficient funds over a figure the SDK has
+            // simply declined to state. Holding the error needs the matching gate in `isValidForm`
+            // to go with it: without that, Swap/Pay would look enabled while the answer is
+            // unknown, and with only that, the error would still be on screen underneath it.
+            guard !isSpendabilityBeingDetermined else { return false }
 
             let spendableZec = walletBalancesState.shieldedBalance.decimalValue.decimalValue
             

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -162,9 +162,15 @@ struct SwapAndPay {
                 return false
             }
 
+            // Same gate as `isInsufficientFunds` above: a masked spendable value reads as zero,
+            // and the Pay screen renders this verdict directly (red field border, "You'll pay"
+            // label), so it must wait for the value instead of judging on a figure the SDK has
+            // declined to state.
+            guard !isSpendabilityBeingDetermined else { return false }
+
             let spendableZec = walletBalancesState.shieldedBalance.decimalValue.decimalValue
             let amountInToken = (assetAmount * selectedAsset.usdPrice) / zecAsset.usdPrice
-            
+
             return amountInToken >= spendableZec
         }
 

--- a/secant/Sources/Features/SwapAndPayForm/SwapForm.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapForm.swift
@@ -368,7 +368,7 @@ extension SwapAndPayForm {
                             title: String(localizable: .generalMax),
                             style: .swap,
                             isEnabled: store.isSwapMaxButtonEnabled,
-                            isInFlight: store.isMaxRequestInFlight
+                            isInFlight: store.isMaxRequestInFlight || store.isSpendabilityBeingDetermined
                         ) {
                             store.send(.maxTapped)
                         }

--- a/secant/Sources/Models/WalletAccount+Stash.swift
+++ b/secant/Sources/Models/WalletAccount+Stash.swift
@@ -58,14 +58,20 @@ enum PrivateUAStash {
     }
 
     /// Generates a fresh stash address for each of `accounts`, in order, awaiting each in turn,
-    /// and reports every result back through `onGenerated` as it lands. Callers pass a single
+    /// and reports every success back through `onGenerated` as it lands. Callers pass a single
     /// selected account (Home's and SwapAndPay's own refill-after-promotion effect) or every
     /// account whose stash came back nil from a load (Root's `.loadedWalletAccounts`). This is
     /// meant to run inside a caller's own `.run { send in … }` — never awaited on a path the UI
     /// blocks on — with the caller wrapping that in its own `.cancellable(id:)` so a newer
-    /// request supersedes a still-running one. Errors are swallowed with `try?`, matching every
-    /// other call site of this SDK method: a failed generation just leaves that account's stash
-    /// nil for the next attempt to retry.
+    /// request supersedes a still-running one.
+    ///
+    /// Errors are swallowed with `try?` and the account is simply skipped: every caller writes
+    /// whatever it receives through `PrivateUAStash.write`, which is unconditional, so reporting a
+    /// failed generation as `nil` would clear a stash a different, faster path had already written
+    /// for the same account while this call was still resolving (typical right after
+    /// backgrounding, when the synchronizer has already stopped and this call is the one that
+    /// fails). A failure therefore leaves the account's existing stash — nil or not — untouched
+    /// for the next attempt to retry.
     static func refill(
         accounts: [WalletAccount],
         sdkSynchronizer: SDKSynchronizerClient,
@@ -73,7 +79,11 @@ enum PrivateUAStash {
     ) async {
         for account in accounts {
             let accountId = account.id
-            let freshUA = try? await sdkSynchronizer.getCustomUnifiedAddress(accountId, receivers(for: account))
+            // A nil result means generation failed, not that the address should be cleared —
+            // skip the callback so a failure can never overwrite a stash a different path wrote.
+            guard let freshUA = try? await sdkSynchronizer.getCustomUnifiedAddress(accountId, receivers(for: account)) else {
+                continue
+            }
             await onGenerated(freshUA, accountId)
         }
     }

--- a/zodlTests/HomeTests/HomeReceiveRotationTests.swift
+++ b/zodlTests/HomeTests/HomeReceiveRotationTests.swift
@@ -312,4 +312,45 @@ import ComposableArchitecture
         // The failed refill must not have overwritten the stash the other path wrote.
         #expect(store.state.walletAccounts.first { $0.id == account.id }?.nextPrivateUA == Const.secondFreshUA)
     }
+
+    @MainActor @Test func failedLiveFillLeavesAConcurrentlyWrittenStashUntouched() async {
+        let state = Home.State.initial
+        let previousAccount = state.selectedWalletAccount
+        let previousAccounts = state.walletAccounts
+        var account = testWalletAccount
+        account.privateUA = nil
+        account.nextPrivateUA = nil
+        state.$selectedWalletAccount.withLock { $0 = account }
+        state.$walletAccounts.withLock { $0 = [account] }
+        defer {
+            state.$selectedWalletAccount.withLock { $0 = previousAccount }
+            state.$walletAccounts.withLock { $0 = previousAccounts }
+        }
+
+        let store = TestStore(initialState: state) {
+            Home()
+        } withDependencies: {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getCustomUnifiedAddress: { accountId, _ in
+                    // No stash, so the tap takes the live-fill path. Simulate a different, faster
+                    // path writing a real stash for this account while the live-fill's own
+                    // generations are still resolving, then have every generation here fail.
+                    @Shared(.inMemory(.walletAccounts)) var sharedWalletAccounts: [WalletAccount] = []
+                    $sharedWalletAccounts.withLock { accounts in
+                        guard let index = accounts.firstIndex(where: { $0.id == accountId }) else { return }
+                        accounts[index].nextPrivateUA = Const.secondFreshUA
+                    }
+                    return nil
+                }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.receiveScreenRequested)
+        await store.receive(\.receiveTapped, timeout: .seconds(5))
+        await store.finish()
+
+        // The failed self-heal must not have reported nil and cleared the stash the other path wrote.
+        #expect(store.state.walletAccounts.first { $0.id == account.id }?.nextPrivateUA == Const.secondFreshUA)
+    }
 }

--- a/zodlTests/HomeTests/HomeReceiveRotationTests.swift
+++ b/zodlTests/HomeTests/HomeReceiveRotationTests.swift
@@ -268,4 +268,48 @@ import ComposableArchitecture
 
         await store.finish()
     }
+
+    // e. Review follow-up (MOB-1859): a failed refill must not clobber a stash a different,
+    // faster path already wrote for the same account while this one was still in flight —
+    // typical right after backgrounding, when the synchronizer has already stopped and this
+    // slower call is the one that ends up failing.
+    @MainActor @Test func failedRefillLeavesAConcurrentlyWrittenStashUntouched() async {
+        let state = Home.State.initial
+        let previousAccount = state.selectedWalletAccount
+        let previousAccounts = state.walletAccounts
+        var account = testWalletAccount
+        account.privateUA = Const.previousVisitUA
+        account.nextPrivateUA = Const.stashUA
+        state.$selectedWalletAccount.withLock { $0 = account }
+        state.$walletAccounts.withLock { $0 = [account] }
+        defer {
+            state.$selectedWalletAccount.withLock { $0 = previousAccount }
+            state.$walletAccounts.withLock { $0 = previousAccounts }
+        }
+
+        let store = TestStore(initialState: state) {
+            Home()
+        } withDependencies: {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getCustomUnifiedAddress: { accountId, _ in
+                    // Simulate a different, faster path writing a real stash for this same
+                    // account while this attempt is still resolving, then have THIS attempt fail.
+                    @Shared(.inMemory(.walletAccounts)) var sharedWalletAccounts: [WalletAccount] = []
+                    $sharedWalletAccounts.withLock { accounts in
+                        guard let index = accounts.firstIndex(where: { $0.id == accountId }) else { return }
+                        accounts[index].nextPrivateUA = Const.secondFreshUA
+                    }
+                    return nil
+                }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.receiveScreenRequested)
+        await store.receive(\.receiveTapped, timeout: .seconds(5))
+        await store.finish()
+
+        // The failed refill must not have overwritten the stash the other path wrote.
+        #expect(store.state.walletAccounts.first { $0.id == account.id }?.nextPrivateUA == Const.secondFreshUA)
+    }
 }

--- a/zodlTests/SwapAndPayTests/SwapAndPayMaxButtonTests.swift
+++ b/zodlTests/SwapAndPayTests/SwapAndPayMaxButtonTests.swift
@@ -522,4 +522,22 @@ private enum SwapMaxButtonTestError: Error {
         #expect(!state.isSpendabilityBeingDetermined)
         #expect(!state.isInsufficientFunds)
     }
+
+    @Test func crossPayInsufficientFundsIsHeldWhileTheSpendableValueIsMasked() {
+        var state = swapState()
+        state.amountText = "1.5"
+        // `assetAmount` reads as zero under the test build (see this file's header note), so a
+        // spendable balance below zero is the only way to drive the unmasked `>=` verdict true.
+        state.walletBalancesState.shieldedBalance = Zatoshi(-1)
+        state.walletBalancesState.isSpendableMasked = false
+        #expect(state.isCrossPayInsufficientFunds)
+
+        state.walletBalancesState.isSpendableMasked = true
+        // The Pay screen's red field border and "You'll pay" label read this verdict directly,
+        // so it has to wait for the value exactly like `isInsufficientFunds` does.
+        #expect(!state.isCrossPayInsufficientFunds)
+
+        state.walletBalancesState.isSpendableMasked = false
+        #expect(state.isCrossPayInsufficientFunds)
+    }
 }

--- a/zodlTests/SwapAndPayTests/SwapAndPayMaxButtonTests.swift
+++ b/zodlTests/SwapAndPayTests/SwapAndPayMaxButtonTests.swift
@@ -480,4 +480,46 @@ private enum SwapMaxButtonTestError: Error {
         state.walletBalancesState.spendability = .nothing
         #expect(!state.isPayMaxButtonEnabled)
     }
+
+    // MARK: - Masked spendability (MOB-1862 parity: the Swap/Pay form waits for the value
+    // instead of calling it insufficient, exactly like Send — SendFormStore.swift, covered by
+    // WalletBalancesMaskedSpendableTests.swift's own `sendFormHoldsTheFormWhileTheSpendableValueIsMasked`).
+
+    @Test func swapFormHoldsInsufficientFundsWhileTheSpendableValueIsMasked() {
+        var state = swapState()
+        state.amountText = "1.5"
+        // `SwapAndPay.State.amount` is hard-wired to zero under the test build (see this file's
+        // header note), so the only way to drive `amount > shieldedBalance` true here is a
+        // spendable balance below zero, exactly like the Send-form equivalent test. The
+        // production case this stands for is the opposite shape: a masked spendable value reads
+        // as zero, so any typed amount exceeds it.
+        state.walletBalancesState.shieldedBalance = Zatoshi(-1)
+        state.walletBalancesState.isSpendableMasked = false
+        #expect(state.isInsufficientFunds)
+        // `isValidForm` also requires `amount > 0`, which the test build always reads as zero,
+        // so it is always false in this harness regardless of masking. Asserted below for parity
+        // with the production expression, not as proof of the branch where amount > 0.
+        #expect(!state.isValidForm)
+
+        state.walletBalancesState.isSpendableMasked = true
+        #expect(state.isSpendabilityBeingDetermined)
+        // Without the gate the form would tell the user the funds are insufficient for an amount
+        // the wallet may well be able to send once the value stops being masked.
+        #expect(!state.isInsufficientFunds)
+        #expect(!state.isValidForm)
+
+        state.walletBalancesState.isSpendableMasked = false
+        #expect(!state.isSpendabilityBeingDetermined)
+        #expect(state.isInsufficientFunds)
+    }
+
+    @Test func swapFormUnmaskedKeepsTheOrdinaryInsufficientFundsAnswer() {
+        var state = swapState()
+        state.amountText = "1.5"
+        state.walletBalancesState.shieldedBalance = Zatoshi(500_000_000)
+        state.walletBalancesState.isSpendableMasked = false
+
+        #expect(!state.isSpendabilityBeingDetermined)
+        #expect(!state.isInsufficientFunds)
+    }
 }

--- a/zodlTests/SwapAndPayTests/SwapAndPayQuoteRotationTests.swift
+++ b/zodlTests/SwapAndPayTests/SwapAndPayQuoteRotationTests.swift
@@ -135,4 +135,45 @@ import ComposableArchitecture
 
         await store.finish()
     }
+
+    @MainActor @Test func failedLiveFillLeavesAConcurrentlyWrittenStashUntouched() async {
+        let state = SwapAndPay.State.initial
+        let previousAccount = state.selectedWalletAccount
+        let previousAccounts = state.walletAccounts
+        var account = testWalletAccount
+        account.nextPrivateUA = nil
+        state.$selectedWalletAccount.withLock { $0 = account }
+        state.$walletAccounts.withLock { $0 = [account] }
+        defer {
+            state.$selectedWalletAccount.withLock { $0 = previousAccount }
+            state.$walletAccounts.withLock { $0 = previousAccounts }
+        }
+
+        let store = TestStore(initialState: state) {
+            SwapAndPay()
+        } withDependencies: {
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getCustomUnifiedAddress: { accountId, _ in
+                    // No stash, so the quote takes the live-fill path. Simulate a different, faster
+                    // path writing a real stash for this account while the live-fill's own
+                    // generations are still resolving, then have every generation here fail.
+                    @Shared(.inMemory(.walletAccounts)) var sharedWalletAccounts: [WalletAccount] = []
+                    $sharedWalletAccounts.withLock { accounts in
+                        guard let index = accounts.firstIndex(where: { $0.id == accountId }) else { return }
+                        accounts[index].nextPrivateUA = Const.secondFreshUA
+                    }
+                    return nil
+                }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped)
+        await store.receive(\.updatePrivateUA, timeout: .seconds(5))
+        await store.receive(\.getQuote, timeout: .seconds(5))
+        await store.finish()
+
+        // The failed self-heal must not have reported nil and cleared the stash the other path wrote.
+        #expect(store.state.walletAccounts.first { $0.id == account.id }?.nextPrivateUA == Const.secondFreshUA)
+    }
 }

--- a/zodlTests/UtilTests/RootLoadedWalletAccountsStashTests.swift
+++ b/zodlTests/UtilTests/RootLoadedWalletAccountsStashTests.swift
@@ -172,6 +172,66 @@ import ComposableArchitecture
         #expect(generationCalls.value == 2)
     }
 
+    // Review follow-up (MOB-1859): the shared refill loop (`PrivateUAStash.refill`) used to call
+    // its `onGenerated` callback even when generation failed (`try?` produced nil), and every
+    // handler writes whatever it receives straight through `PrivateUAStash.write`, which is
+    // unconditional — so a failed background refill would clear a stash a different, faster path
+    // had already written for the very same account while this call was still resolving. This is
+    // exactly what happens right after backgrounding: the synchronizer stops, this call fails,
+    // but another path may already have succeeded in the meantime.
+    @Test func aFailedRefillLeavesAStashWrittenByAnotherPathDuringItUntouched() async {
+        let zcashAccount = account(idByte: 0x05, vendor: .zcash)
+
+        var initialState = freshRootState()
+        let previousWalletAccounts = initialState.walletAccounts
+        let previousSelected = initialState.selectedWalletAccount
+        let previousZashi = initialState.zashiWalletAccount
+        defer {
+            initialState.$walletAccounts.withLock { $0 = previousWalletAccounts }
+            initialState.$selectedWalletAccount.withLock { $0 = previousSelected }
+            initialState.$zashiWalletAccount.withLock { $0 = previousZashi }
+        }
+
+        initialState.$walletAccounts.withLock { $0 = [] }
+        initialState.$selectedWalletAccount.withLock { $0 = nil }
+        initialState.$zashiWalletAccount.withLock { $0 = nil }
+
+        let store = TestStore(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
+            $0.userMetadataProvider.load = { _ in }
+            $0.readTransactionsStorage = .noOp
+            $0.userDefaults = .noOp
+            $0.walletStorage = .noOp
+            $0.mainQueue = .immediate
+            $0.continuousClock = TestClock()
+            $0.sdkSynchronizer = SDKSynchronizerClient.mocked(
+                getCustomUnifiedAddress: { accountId, _ in
+                    // Simulate a different, faster path (e.g. a Receive visit's own refill)
+                    // writing a real stash for this same account while this slower background
+                    // call is still resolving, then have THIS call fail — the exact ordering the
+                    // bug depended on.
+                    @Shared(.inMemory(.walletAccounts)) var sharedWalletAccounts: [WalletAccount] = []
+                    $sharedWalletAccounts.withLock { accounts in
+                        guard let index = accounts.firstIndex(where: { $0.id == accountId }) else { return }
+                        accounts[index].nextPrivateUA = Const.existingStashUA
+                    }
+                    return nil
+                }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.initialization(.loadedWalletAccounts([zcashAccount])))
+
+        await store.skipReceivedActions(strict: false)
+        await store.skipInFlightEffects(strict: false)
+
+        // The failed refill must not have overwritten the stash the other path wrote.
+        #expect(store.state.walletAccounts.first { $0.id == zcashAccount.id }?.nextPrivateUA == Const.existingStashUA)
+    }
+
     @Test func loadSkipsTheRefillEntirelyWhenEveryAccountAlreadyHasAStash() async {
         let generationCalls = LockIsolated(0)
 

--- a/zodlTests/UtilTests/TransactionGuardTests.swift
+++ b/zodlTests/UtilTests/TransactionGuardTests.swift
@@ -199,7 +199,6 @@ import Testing
         }
         await holderAcquired.wait()
 
-        let start = ContinuousClock.now
         var caught: Error?
         do {
             try await client.withSubmission(timeout: .milliseconds(100)) {
@@ -208,11 +207,9 @@ import Testing
         } catch {
             caught = error
         }
-        let elapsed = ContinuousClock.now - start
 
         #expect(caught is TransactionGuardBusyError, "A busy guard must surface TransactionGuardBusyError, got \(String(describing: caught))")
         #expect(!bodyRan.value, "The submission body must not run when the guard could not be acquired")
-        #expect(elapsed < .milliseconds(300), "The acquisition must give up near its deadline; it took \(elapsed)")
 
         // The timed-out acquirer must not have taken ownership it then dropped.
         await releaseHolder.signal()
@@ -299,6 +296,7 @@ import Testing
         let result = try await SDKSynchronizerClient.createThenSubmitUnderGuard(
             transactionGuard: client,
             timeout: .seconds(30),
+            logPrefix: "[MultiSubmit]",
             prove: {
                 await log.record("prove-start")
                 try await Task.sleep(for: .milliseconds(20))
@@ -314,7 +312,7 @@ import Testing
         #expect(result == SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: ["abc"]))
         let recorded = await log.values
         #expect(
-            recorded == ["prove-start", "prove-end", "acquire", "submit", "release"],
+            recorded == ["prove-start", "prove-end", "acquire-timed", "submit", "release"],
             "Proving must finish before the guard is taken and the guard released after the broadcast; got \(recorded)"
         )
     }
@@ -331,6 +329,7 @@ import Testing
         let result = try await SDKSynchronizerClient.createThenSubmitUnderGuard(
             transactionGuard: client,
             timeout: .milliseconds(10),
+            logPrefix: "[MultiSubmit]",
             prove: {
                 await log.record("prove")
                 return []
@@ -360,6 +359,7 @@ import Testing
         let result = try? await SDKSynchronizerClient.createThenSubmitUnderGuard(
             transactionGuard: client,
             timeout: .seconds(30),
+            logPrefix: "[MultiSubmit]",
             prove: { throw TestFailure() },
             submit: { _ in
                 await log.record("submit")
@@ -373,11 +373,19 @@ import Testing
     }
 
     /// A pass-through client that logs every guard interaction, so a test can assert *when* the
-    /// guard is taken relative to the work around it.
+    /// guard is taken relative to the work around it. `acquire` and `acquireWithTimeout` record
+    /// distinct labels so a test can tell which one the seam actually called — without that, a
+    /// seam that regressed to the unbounded `withSubmission(_:)` (and so the plain `acquire`)
+    /// would still satisfy an ordering assertion written against a single shared "acquire" label.
+    /// The submission seam must never call the unbounded `acquire`, so that closure also records
+    /// an `Issue` — a belt-and-braces signal alongside the ordering mismatch it also causes.
     private static func recordingClient(into log: OrderRecorder) -> TransactionGuardClient {
         TransactionGuardClient(
-            acquire: { await log.record("acquire") },
-            acquireWithTimeout: { _ in await log.record("acquire") },
+            acquire: {
+                Issue.record("The submission seam must acquire the guard with a timeout, never the unbounded acquire.")
+                await log.record("acquire")
+            },
+            acquireWithTimeout: { _ in await log.record("acquire-timed") },
             tryAcquire: { true },
             release: { await log.record("release") }
         )


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Six small commits from the whole-branch review of the integration branch, each tagged with the ticket it belongs to.

**What**
- `[MOB-1862]` The Swap and Pay form gains the same masked-spendability gates as the Send form: while the SDK masks the spendable value the form is not valid, "insufficient funds" is not shown (including the cross-pay variant that drives the red field border and the "You'll pay" label), and the Max chip shows its in-flight state.
- `[MOB-1858]` The send seam's busy log carries the caller's prefix (the PCZT path was logged under the software-send prefix); the seam tests now distinguish bounded from unbounded acquisition so a regression to the unbounded guard fails a test; a wall-clock assertion is removed; the 30 s send acquisition timeout is kept and its trade-off against the 60 s server-switch bound and unbounded migration broadcasts is documented.
- `[MOB-1859]` A failed background address generation no longer clears an address stash another path wrote: the shared refill helper skips the callback on failure, and the Receive/Swap live-fill paths skip the stash update when their second generation fails.
- `[MOB-1853]` Two comments corrected: backgrounding cancels only the server benchmark (an in-flight apply runs to completion under its own timeout), and the automatic-switch gate documentation lists its synchronizer-idle inputs.

**Why:** these are the cross-task findings of the final review: the two forms disagreed during the mask, the guard's diagnostics and tests had gaps, the new stash source of truth could be clobbered by a failed generation, and two comments overstated what the code does.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **` after each commit.
- Touched suites green: `TransactionGuardTests`, `RootLoadedWalletAccountsStashTests`, `HomeReceiveRotationTests`, `SwapAndPayQuoteRotationTests`, `SwapAndPayMaxButtonTests`, `WalletBalancesMaskedSpendableTests`, `SendFormMaxButtonTests`. New tests were written first and failed for the intended reason before each fix.
- The full `zodlTests` target is re-run on the integration tip after this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)