### PR TITLE
[MOB-1848] Repin the SDK to the merged contention-fixes tip

### DIFF
--- a/.sdk-pin
+++ b/.sdk-pin
@@ -1,1 +1,1 @@
-eb43a7ed44bc7673256ede2166afc2906b3c2a7c
+1acce49dda3b4fbd1e719d3101f5aee1e8bbb2a2


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes).

**What:** `.sdk-pin` moves from `eb43a7ed` to `1acce49d`, the SDK integration branch after it absorbed the current SDK `main` (the voting restore FFI from zodl-inc/zodl-swift-wallet-sdk#40). No code change.

**Why:** the pin records the SDK commit this branch was verified against.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build against the merged SDK checkout → `** BUILD SUCCEEDED **` (the build phase wrote the new pin).
- SDK offline tests on the merged tip: 1030 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)