### PR TITLE
[MOB-1862] Remove the write-only shielding threshold from the wallet-balances state

### DIFF
--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -17,7 +17,6 @@ struct WalletBalances {
         var CancelStateId = UUID()
         var CancelRateId = UUID()
         var CancelMigrationSnapshotId = UUID()
-        var autoShieldingThreshold: Zatoshi = .zero
         /// The account the published balance was read for — see `hasConcreteBalance`.
         var concreteBalanceAccountId: AccountUUID?
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion? = nil
@@ -154,8 +153,6 @@ struct WalletBalances {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                // __LD TESTED
-                 state.autoShieldingThreshold = zcashSDKEnvironment.shieldingThreshold()
                 if let exchangeRate = userStoredPreferences.exchangeRate(), exchangeRate.automatic {
                     state.isExchangeRateFeatureOn = true
                 } else {

--- a/zodlTests/ShieldingTests/ShieldingEligibilityTests.swift
+++ b/zodlTests/ShieldingTests/ShieldingEligibilityTests.swift
@@ -48,28 +48,3 @@ import ComposableArchitecture
         #expect(transactions.isAnyShieldingPending())
     }
 }
-
-// `WalletBalances.State` carries `@Shared(.inMemory(...))` properties (`currencyConversion`,
-// `selectedWalletAccount`), so constructing it touches process-global in-memory storage — the same
-// reason `WalletBalancesTests` (WalletBalancesTests.swift) is `.serialized` rather than living in
-// the plain `ShieldingEligibilityTests` suite above. A dedicated `.serialized` suite with pinned
-// storage keeps this test isolated from concurrently running suites that also touch that storage.
-@Suite(.serialized) struct WalletBalancesEligibilityTests {
-    /// "Processing with zero available" means the spendable value is still being worked out, so it
-    /// no longer reads the balance at all. A wallet holding exactly the shielding threshold in
-    /// transparent funds is a settled answer and must never read as unresolved — the regression
-    /// guarded here is any return of a balance-shaped rule to that property.
-    @Test func walletBalancesAtTheShieldingThresholdIsNotStillBeingDetermined() {
-        withDependencies {
-            $0.defaultInMemoryStorage = InMemoryStorage()
-        } operation: {
-            var state = WalletBalances.State()
-            state.shieldedBalance = .zero
-            state.totalBalance = Zatoshi(100_000)
-            state.transparentBalance = Zatoshi(100_000)
-            state.autoShieldingThreshold = Zatoshi(100_000)
-
-            #expect(!state.isProcessingZeroAvailableBalance)
-        }
-    }
-}

--- a/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
@@ -20,12 +20,10 @@ import ComposableArchitecture
     /// shape of the balance says that: a zero spendable balance is a settled answer, so none of
     /// these wallets is unresolved, however their value is distributed.
     @Test func isProcessingZeroAvailableBalance() {
-        var transparentAboveThreshold = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(100), transparentBalance: Zatoshi(100))
-        transparentAboveThreshold.autoShieldingThreshold = Zatoshi(50)
-        #expect(!transparentAboveThreshold.isProcessingZeroAvailableBalance)
+        let transparentOnly = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(100), transparentBalance: Zatoshi(100))
+        #expect(!transparentOnly.isProcessingZeroAvailableBalance)
 
-        var shieldedZeroPending = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(10), transparentBalance: Zatoshi(10))
-        shieldedZeroPending.autoShieldingThreshold = Zatoshi(50)
+        let shieldedZeroPending = WalletBalances.State(shieldedBalance: .zero, totalBalance: Zatoshi(10), transparentBalance: Zatoshi(10))
         #expect(!shieldedZeroPending.isProcessingZeroAvailableBalance)
 
         let hasShielded = WalletBalances.State(shieldedBalance: Zatoshi(100), totalBalance: Zatoshi(200), transparentBalance: Zatoshi(100))


### PR DESCRIPTION
Part of MOB-1848 (Slipstream sync contention fixes). Follow-up to the whole-branch review; no user-visible change, so no CHANGELOG entry.

**What:** `WalletBalances.State.autoShieldingThreshold` and its assignment on appear are removed. After MOB-1862 redefined `isProcessingZeroAvailableBalance` as "the spendable value is still being determined", nothing read the property; the spendability derivation takes the threshold from the SDK environment directly. The breakdown sheet's `Balances.State.autoShieldingThreshold` is untouched because `isShieldableBalanceAvailable` still uses it.

**Tests:** the processing test in `WalletBalancesTests` no longer sets a threshold on its two states. The `WalletBalancesEligibilityTests` suite (one test) is deleted: it existed only to pin the removed shielding-threshold rule, and once the property is gone its case is the transparent-only shape that `WalletBalancesTests.isProcessingZeroAvailableBalance` already asserts, alongside the two genuinely unresolved states. The sibling `ShieldingEligibilityTests` suite in the same file stays.

**Verification**
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.
- Full `zodlTests` target → 1653 tests in 225 suites passed, 2 pre-existing known issues (one test and one suite fewer than before, as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)