### PR TITLE
[MOB-1848] Repin the SDK to the audit-fixes tip

### DIFF
--- a/.sdk-pin
+++ b/.sdk-pin
@@ -1,1 +1,1 @@
-1acce49dda3b4fbd1e719d3101f5aee1e8bbb2a2
+d39e2a445ebfaa0d1bf199a16e9e067804ee8e7b


### PR DESCRIPTION
Part of MOB-1848.

**What:** `.sdk-pin` moves from `1acce49d` to `d39e2a44`, the SDK integration branch after the audit fixes (zodl-inc/zodl-swift-wallet-sdk#48 to #54). No code change.

**Why:** the app changes that follow use the new SDK APIs (`restartSync(at:)`, `releaseForResubmission(transactions:to:)`) and rely on the SDK's lifecycle and mask-metadata fixes; the pin records the commit this branch is verified against.

**Test plan**
- `xcodebuild … -scheme zodl-internal` build against the SDK checkout at `d39e2a44` → `** BUILD SUCCEEDED **`.
- SDK gates on that tip: `make test-offline` → 1066 tests, 0 failures; `make lint` → no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)