### PR TITLE
[MOB-1858] Release created transactions to background resubmission when the broadcast is missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1501] Swap and Pay now offer DASH, Bitcoin Cash, and ZEC on Solana and NEAR as assets you can swap to or pay with, and Dash and Bitcoin Cash can be chosen as the chain when saving a swap address in the Address Book.
 
 ### Changed
-- [MOB-1858] Sending no longer waits behind unrelated network work. Preparing a payment now runs alongside other activity instead of blocking it, and if the wallet really is busy with something else, the send reports a failure you can retry instead of appearing to hang.
+- [MOB-1858] Sending no longer waits behind unrelated network work. Preparing a payment now runs alongside other activity instead of blocking it, and if the wallet is still busy with something else by the time it's ready to broadcast, the transaction is shown as pending and submitted automatically in the background instead of being reported as a failure.
 - [MOB-1831] Automatic server selection no longer switches servers for marginal gains. The app switches only when the benchmark shows the new server is meaningfully faster than the current one — at least 200 ms and at least 25% faster — or when the current server fails its health checks. Practically equal servers no longer cause needless sync restarts.
 - [MOB-1863] A sent transaction now shows "Sent · awaiting confirmation" once a server has accepted it, instead of "Sending" until the wallet catches up.
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -17051,6 +17051,23 @@
         }
       }
     },
+    "send.pendingGuardBusyInfo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your transaction was created and will be handed to a server as soon as the wallet finishes its current network work."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu transacción se ha creado y se enviará a un servidor en cuanto la billetera termine su trabajo de red actual."
+          }
+        }
+      }
+    },
     "send.pendingInfo" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerInterface.swift
@@ -23,6 +23,11 @@ struct SDKSynchronizerClient: Sendable {
     enum CreateProposedTransactionsResult: Equatable, Sendable {
         enum GrpcFailureReason: Equatable, Sendable {
             case timeout
+            // A submission guard still busy after its acquisition timeout, or a send cancelled
+            // while waiting for it. Either way nothing was broadcast, but the transactions were
+            // already created and are released to the SDK's background resubmission — the UI
+            // treats this exactly like `.timeout`, just with its own copy.
+            case guardBusy
         }
 
         case failure(txIds: [String], code: Int, description: String)
@@ -303,7 +308,7 @@ struct SDKSynchronizerClient: Sendable {
     var sendMaxAmount: @Sendable (AccountUUID, Recipient, Memo?) async throws -> Zatoshi
     /// Creates the proposal's transactions via the SDK `Broadcaster` and submits them to the
     /// endpoints chosen by the user's connection mode (Automatic -> all known servers,
-    /// Manual -> the selected server). See `selectedSubmissionEndpoints`.
+    /// Manual -> the selected server). See `intendedEndpoints`.
     var createAndSubmitProposedTransactions: @Sendable (Proposal, UnifiedSpendingKey) async throws -> CreateProposedTransactionsResult
     var proposeShielding: @Sendable (AccountUUID, Zatoshi, Memo, TransparentAddress?) async throws -> Proposal?
     

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -321,6 +321,10 @@ extension SDKSynchronizerClient: DependencyKey {
                     transactionGuard: transactionGuard,
                     timeout: submissionGuardTimeout,
                     logPrefix: "[MultiSubmit]",
+                    intendedEndpoints: Self.intendedEndpoints(
+                        userStoredPreferences: userStoredPreferences,
+                        zcashSDKEnvironment: zcashSDKEnvironment
+                    ),
                     prove: {
                         try await synchronizer.broadcaster.createProposedTransactions(
                             proposal: proposal,
@@ -339,6 +343,9 @@ extension SDKSynchronizerClient: DependencyKey {
                                 }
                             }
                         )
+                    },
+                    release: { transactions, endpoints in
+                        await synchronizer.broadcaster.releaseForResubmission(transactions: transactions, to: endpoints)
                     }
                 )
             },
@@ -414,6 +421,10 @@ extension SDKSynchronizerClient: DependencyKey {
                     transactionGuard: transactionGuard,
                     timeout: submissionGuardTimeout,
                     logPrefix: "[MultiSubmit/PCZT]",
+                    intendedEndpoints: Self.intendedEndpoints(
+                        userStoredPreferences: userStoredPreferences,
+                        zcashSDKEnvironment: zcashSDKEnvironment
+                    ),
                     prove: {
                         try await synchronizer.broadcaster.createTransactionFromPCZT(
                             pcztWithProofs: pcztWithProofs,
@@ -432,6 +443,9 @@ extension SDKSynchronizerClient: DependencyKey {
                                 }
                             }
                         )
+                    },
+                    release: { transactions, endpoints in
+                        await synchronizer.broadcaster.releaseForResubmission(transactions: transactions, to: endpoints)
                     }
                 )
             },
@@ -528,15 +542,20 @@ extension SDKSynchronizerClient {
     /// it made a send wait out every unrelated guarded operation — and made them wait out a
     /// multi-second proof — for no protection at all. Only `submit` races a server switch.
     ///
-    /// A guard still busy after `timeout` fails the send definitively rather than hanging: nothing
-    /// was created on-chain, so the user can simply try again. A proving failure is untouched and
-    /// keeps propagating to the caller.
+    /// A guard still busy after `timeout`, or a send cancelled while it waited, must not report a
+    /// plain failure: proving already created the transactions and reserved their inputs in the
+    /// wallet database, so telling the user "nothing happened, try again" risks a double payment.
+    /// Instead the transactions are released to the SDK's background resubmission (`intendedEndpoints`,
+    /// the same ones a normal submission would have used) and reported as pending. A proving
+    /// failure is untouched and keeps propagating to the caller — nothing was created yet.
     static func createThenSubmitUnderGuard(
         transactionGuard: TransactionGuardClient,
         timeout: Duration,
         logPrefix: String,
+        intendedEndpoints: [LightWalletEndpoint],
         prove: () async throws -> [CreatedTransaction],
-        submit: ([CreatedTransaction]) async -> CreateProposedTransactionsResult
+        submit: ([CreatedTransaction]) async -> CreateProposedTransactionsResult,
+        release: ([CreatedTransaction], [LightWalletEndpoint]) async -> Void
     ) async throws -> CreateProposedTransactionsResult {
         let transactions = try await prove()
 
@@ -545,14 +564,57 @@ extension SDKSynchronizerClient {
                 await submit(transactions)
             }
         } catch is TransactionGuardBusyError {
-            LoggerProxy.error("\(logPrefix) Gave up waiting \(timeout) for exclusive access; nothing was broadcast.")
+            return await releaseAfterMissedBroadcast(
+                transactions,
+                to: intendedEndpoints,
+                logPrefix: logPrefix,
+                reason: "gave up waiting \(timeout) for exclusive access",
+                release: release
+            )
+        } catch is CancellationError {
+            // The effect that would have `send`-ed this result is itself cancelled, so nothing
+            // downstream reads the return value — but `release` still runs to completion (Swift's
+            // cooperative cancellation does not abort it), and that's the side effect that
+            // matters: the plan gets recorded before this call returns.
+            return await releaseAfterMissedBroadcast(
+                transactions,
+                to: intendedEndpoints,
+                logPrefix: logPrefix,
+                reason: "the send was cancelled before the broadcast",
+                release: release
+            )
+        }
+    }
 
+    /// Shared tail for `createThenSubmitUnderGuard`'s two missed-broadcast paths (guard busy,
+    /// cancelled before broadcast). With nothing proved there is nothing to release; otherwise the
+    /// transactions already exist in the wallet database with their inputs reserved, so handing
+    /// them to the SDK's background resubmission keeps the same transaction ids (no duplicate
+    /// payment) and the endpoints the user intended, and lets the confirmation screen show them as
+    /// pending instead of a plain failure that would leave them stranded.
+    private static func releaseAfterMissedBroadcast(
+        _ transactions: [CreatedTransaction],
+        to endpoints: [LightWalletEndpoint],
+        logPrefix: String,
+        reason: String,
+        release: ([CreatedTransaction], [LightWalletEndpoint]) async -> Void
+    ) async -> CreateProposedTransactionsResult {
+        guard !transactions.isEmpty else {
+            LoggerProxy.error("\(logPrefix) \(reason); nothing was created or broadcast.")
             return CreateProposedTransactionsResult.failure(
                 txIds: [],
                 code: MultiServerSubmission.guardBusyCode,
                 description: String(localizable: .transactionGuardBusy)
             )
         }
+
+        await release(transactions, endpoints)
+        LoggerProxy.error("\(logPrefix) \(reason); \(transactions.count) created transaction(s) released to background resubmission.")
+
+        return CreateProposedTransactionsResult.grpcFailure(
+            txIds: transactions.map { $0.txId.toHexStringTxId() },
+            reason: .guardBusy
+        )
     }
 
     /// Submits one transaction at a time so every one of them gets its retry plan recorded by the
@@ -595,7 +657,7 @@ extension SDKSynchronizerClient {
         }
 
         let txIds = transactions.map { $0.txId.toHexStringTxId() }
-        let endpoints = selectedSubmissionEndpoints(
+        let endpoints = intendedEndpoints(
             userStoredPreferences: userStoredPreferences,
             zcashSDKEnvironment: zcashSDKEnvironment
         )
@@ -644,7 +706,12 @@ extension SDKSynchronizerClient {
     /// Endpoint selection policy for multi-server submission:
     /// - Automatic connection mode -> all known endpoints for the current network
     /// - Manual connection mode (or mode not yet initialized) -> the currently selected endpoint
-    static func selectedSubmissionEndpoints(
+    ///
+    /// Also the endpoint list `createThenSubmitUnderGuard` releases created transactions to when
+    /// the broadcast itself never ran (guard busy, or cancelled first): those are the servers the
+    /// user's connection mode intended the transaction to reach, so background resubmission should
+    /// still target them.
+    static func intendedEndpoints(
         userStoredPreferences: UserPreferencesStorageClient,
         zcashSDKEnvironment: ZcashSDKEnvironment
     ) -> [LightWalletEndpoint] {

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowCoordinator.swift
@@ -375,9 +375,13 @@ extension SwapAndPayCoordFlow {
 
                         switch result {
                         case let .grpcFailure(txIds, reason):
-                            await send(.updatePendingDescription(
-                                reason == .timeout ? String(localizable: .sendPendingTimeoutInfo) : nil
-                            ))
+                            let pendingDescription: String?
+                            switch reason {
+                            case .timeout: pendingDescription = String(localizable: .sendPendingTimeoutInfo)
+                            case .guardBusy: pendingDescription = String(localizable: .sendPendingGuardBusyInfo)
+                            case nil: pendingDescription = nil
+                            }
+                            await send(.updatePendingDescription(pendingDescription))
                             await send(.updateTxIdToExpand(txIds.last))
                             let isTxIdPresentInTheDB = try await sdkSynchronizer.txIdExists(txIds.last)
                             await send(.sendFailed("sdkSynchronizer.createAndSubmitProposedTransactions-grpcFailure".toZcashError(), isTxIdPresentInTheDB))

--- a/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
+++ b/secant/Sources/Features/SendConfirmation/SendConfirmationStore.swift
@@ -348,9 +348,13 @@ struct SendConfirmation {
 
                         switch result {
                         case let .grpcFailure(txIds, reason):
-                            await send(.updatePendingDescription(
-                                reason == .timeout ? String(localizable: .sendPendingTimeoutInfo) : nil
-                            ))
+                            let pendingDescription: String?
+                            switch reason {
+                            case .timeout: pendingDescription = String(localizable: .sendPendingTimeoutInfo)
+                            case .guardBusy: pendingDescription = String(localizable: .sendPendingGuardBusyInfo)
+                            case nil: pendingDescription = nil
+                            }
+                            await send(.updatePendingDescription(pendingDescription))
                             await send(.updateTxIdToExpand(txIds.last))
                             let isTxIdPresentInTheDB = try await sdkSynchronizer.txIdExists(txIds.last)
                             await send(.sendFailed("sdkSynchronizer.createAndSubmitProposedTransactions-grpcFailure".toZcashError(), isTxIdPresentInTheDB))
@@ -662,9 +666,13 @@ struct SendConfirmation {
 
                         switch result {
                         case let .grpcFailure(txIds, reason):
-                            await send(.updatePendingDescription(
-                                reason == .timeout ? String(localizable: .sendPendingTimeoutInfo) : nil
-                            ))
+                            let pendingDescription: String?
+                            switch reason {
+                            case .timeout: pendingDescription = String(localizable: .sendPendingTimeoutInfo)
+                            case .guardBusy: pendingDescription = String(localizable: .sendPendingGuardBusyInfo)
+                            case nil: pendingDescription = nil
+                            }
+                            await send(.updatePendingDescription(pendingDescription))
                             await send(.updateFailedData(-999, "grpcFailure", pcztMessage))
                             await send(.updateTxIdToExpand(txIds.last))
                             let isTxIdPresentInTheDB = try await sdkSynchronizer.txIdExists(txIds.last)

--- a/zodlTests/SendTests/MultiServerSubmissionTests.swift
+++ b/zodlTests/SendTests/MultiServerSubmissionTests.swift
@@ -28,7 +28,7 @@ import ComposableArchitecture
     }
 
     @Test func automaticModeUsesAllKnownMainnetServers() {
-        let endpoints = SDKSynchronizerClient.selectedSubmissionEndpoints(
+        let endpoints = SDKSynchronizerClient.intendedEndpoints(
             userStoredPreferences: preferences(automaticServerSelection: true),
             zcashSDKEnvironment: environment(networkType: .mainnet, endpointHost: "fallback.server")
         )
@@ -50,7 +50,7 @@ import ComposableArchitecture
     }
 
     @Test func manualModeUsesSelectedServerOnly() {
-        let endpoints = SDKSynchronizerClient.selectedSubmissionEndpoints(
+        let endpoints = SDKSynchronizerClient.intendedEndpoints(
             userStoredPreferences: preferences(automaticServerSelection: false),
             zcashSDKEnvironment: environment(networkType: .mainnet, endpointHost: "manual.server")
         )
@@ -59,7 +59,7 @@ import ComposableArchitecture
     }
 
     @Test func uninitializedModeFallsBackToCurrentEnvironmentEndpoint() {
-        let endpoints = SDKSynchronizerClient.selectedSubmissionEndpoints(
+        let endpoints = SDKSynchronizerClient.intendedEndpoints(
             userStoredPreferences: preferences(automaticServerSelection: nil),
             zcashSDKEnvironment: environment(networkType: .mainnet, endpointHost: "fallback.server")
         )

--- a/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
+++ b/zodlTests/SendTests/MultiServerSubmitRoutingTests.swift
@@ -108,6 +108,26 @@ import ComposableArchitecture
         #expect(store.state.pendingInfo == String(localizable: .sendPendingTimeoutInfo))
     }
 
+    @Test func guardBusyRoutesToPendingWithGuardBusyCopy() async {
+        // A submission guard still busy after its timeout (or a send cancelled while waiting for
+        // it) means the transaction was created but never handed to a server itself — the SDK's
+        // background resubmission takes over instead, so this must land on "pending" with its own
+        // copy, not the generic timeout copy or a plain failure.
+        let txId = Data([0xAA]).toHexStringTxId()
+        let store = makeStore(
+            result: .grpcFailure(txIds: [txId], reason: .guardBusy),
+            txIdExists: true
+        )
+
+        await store.send(.sendTriggered)
+        await store.finish()
+        await store.skipReceivedActions(strict: false)
+
+        #expect(store.state.result == .pending)
+        #expect(store.state.txIdToExpand == txId)
+        #expect(store.state.pendingDescription == String(localizable: .sendPendingGuardBusyInfo))
+    }
+
     @Test func onAppearResetsMultiServerSubmissionState() async {
         var initialState = SendConfirmation.State(
             address: "ztestaddr",
@@ -266,6 +286,41 @@ import ComposableArchitecture
         #expect(store.state.txIdToExpand == txId)
         #expect(store.state.pendingDescription == String(localizable: .sendPendingTimeoutInfo))
     }
+
+    @Test func pcztGuardBusyRoutesToPendingWithGuardBusyCopy() async {
+        let txId = Data([0xAA]).toHexStringTxId()
+
+        var initialState = SendConfirmation.State(
+            address: "ztestaddr",
+            amount: Zatoshi(100_000),
+            feeRequired: Zatoshi(10_000),
+            message: "",
+            proposal: .testOnlyFakeProposal(totalFee: 10_000)
+        )
+        initialState.pcztWithProofs = Pczt([0x10, 0x11])
+        initialState.pcztWithSigs = Pczt([0x20, 0x21])
+
+        let store = TestStore(initialState: initialState) {
+            SendConfirmation()
+        }
+        store.exhaustivity = .off
+
+        store.dependencies.audioServices = AudioServicesClient(systemSoundVibrate: { })
+        store.dependencies.mainQueue = .immediate
+        store.dependencies.zcashSDKEnvironment = .testnet
+        store.dependencies.sdkSynchronizer.createAndSubmitTransactionFromPCZT = { _, _ in
+            .grpcFailure(txIds: [txId], reason: .guardBusy)
+        }
+        store.dependencies.sdkSynchronizer.txIdExists = { _ in true }
+
+        await store.send(.createTransactionFromPCZT)
+        await store.finish()
+        await store.skipReceivedActions(strict: false)
+
+        #expect(store.state.result == .pending)
+        #expect(store.state.txIdToExpand == txId)
+        #expect(store.state.pendingDescription == String(localizable: .sendPendingGuardBusyInfo))
+    }
 }
 // MARK: - Swap & Pay routing
 
@@ -401,6 +456,35 @@ import ComposableArchitecture
             #expect(store.state.pendingDescription == String(localizable: .sendPendingTimeoutInfo))
             #expect(resultState.txIdToExpand == txId)
             #expect(resultState.pendingDescription == String(localizable: .sendPendingTimeoutInfo))
+        }
+    }
+
+    @Test func guardBusySubmissionRoutesToPendingWithGuardBusyCopy() async throws {
+        // Isolate shared account storage (see partialSubmissionRoutesToFailureSupportState).
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let txId = Data([0xAA]).toHexStringTxId()
+            let store = makeStore(
+                result: .grpcFailure(txIds: [txId], reason: .guardBusy),
+                txIdExists: true
+            )
+
+            store.send(.swapRequested)
+            await waitForStore {
+                if case .sendResultPending = store.state.path.last { return true }
+                return false
+            }
+
+            guard case let .sendResultPending(resultState) = store.state.path.last else {
+                Issue.record("Expected Swap/Pay guard-busy submission to route to pending")
+                return
+            }
+
+            #expect(store.state.txIdToExpand == txId)
+            #expect(store.state.pendingDescription == String(localizable: .sendPendingGuardBusyInfo))
+            #expect(resultState.txIdToExpand == txId)
+            #expect(resultState.pendingDescription == String(localizable: .sendPendingGuardBusyInfo))
         }
     }
 

--- a/zodlTests/UtilTests/TransactionGuardTests.swift
+++ b/zodlTests/UtilTests/TransactionGuardTests.swift
@@ -1,10 +1,15 @@
+import ComposableArchitecture
+import Foundation
 import Testing
+@testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
 // Several tests drive the shared `TransactionGuardClient.liveValue`, which is backed by a single
 // process-global mutex actor. They must not run concurrently or they would contend on that guard,
 // so the suite is serialized (matching XCTest's previous serial execution).
 @Suite(.serialized) struct TransactionGuardTests {
+    private var endpointA: LightWalletEndpoint { LightWalletEndpoint(address: "endpoint-a.test", port: 9067) }
+
     @Test func tryAcquireFailsWhileHeld() async {
         let guardActor = TransactionGuard()
         try? await guardActor.acquire()
@@ -297,6 +302,7 @@ import Testing
             transactionGuard: client,
             timeout: .seconds(30),
             logPrefix: "[MultiSubmit]",
+            intendedEndpoints: [],
             prove: {
                 await log.record("prove-start")
                 try await Task.sleep(for: .milliseconds(20))
@@ -306,7 +312,8 @@ import Testing
             submit: { _ in
                 await log.record("submit")
                 return SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: ["abc"])
-            }
+            },
+            release: { _, _ in await log.record("released") }
         )
 
         #expect(result == SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: ["abc"]))
@@ -330,6 +337,7 @@ import Testing
             transactionGuard: client,
             timeout: .milliseconds(10),
             logPrefix: "[MultiSubmit]",
+            intendedEndpoints: [],
             prove: {
                 await log.record("prove")
                 return []
@@ -337,7 +345,8 @@ import Testing
             submit: { _ in
                 await log.record("submit")
                 return SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: [])
-            }
+            },
+            release: { _, _ in await log.record("released") }
         )
 
         #expect(
@@ -360,16 +369,121 @@ import Testing
             transactionGuard: client,
             timeout: .seconds(30),
             logPrefix: "[MultiSubmit]",
+            intendedEndpoints: [],
             prove: { throw TestFailure() },
             submit: { _ in
                 await log.record("submit")
                 return SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: [])
-            }
+            },
+            release: { _, _ in await log.record("released") }
         )
 
         #expect(result == nil, "A proving failure must keep propagating to the caller")
         let recorded = await log.values
         #expect(recorded.isEmpty, "A send that never got past proving must not touch the guard; got \(recorded)")
+    }
+
+    // MARK: - Missed broadcast: release to background resubmission
+
+    @Test func busyGuardAfterProvingReleasesTheCreatedTransactionsAndReportsThemPending() async throws {
+        let created = [CreatedTransaction.fixture(0xAB), CreatedTransaction.fixture(0xCD)]
+        let released = LockIsolated<[(txIds: [Data], endpoints: [LightWalletEndpoint])]>([])
+        let submits = LockIsolated(0)
+
+        let result = try await SDKSynchronizerClient.createThenSubmitUnderGuard(
+            transactionGuard: Self.busyGuardClient(),
+            timeout: .milliseconds(50),
+            logPrefix: "[Test]",
+            intendedEndpoints: [endpointA],
+            prove: { created },
+            submit: { _ in
+                submits.withValue { $0 += 1 }
+                return SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: [])
+            },
+            release: { transactions, endpoints in
+                released.withValue { $0.append((transactions.map(\.txId), endpoints)) }
+            }
+        )
+
+        #expect(submits.value == 0, "A guard that never granted access must not run the broadcast")
+        #expect(released.value.count == 1)
+        #expect(released.value.first?.txIds == created.map(\.txId))
+        #expect(released.value.first?.endpoints == [endpointA])
+        #expect(
+            result == SDKSynchronizerClient.CreateProposedTransactionsResult.grpcFailure(
+                txIds: created.map { $0.txId.toHexStringTxId() },
+                reason: .guardBusy
+            ),
+            "A missed broadcast must report the created transactions as pending, not a plain failure; got \(result)"
+        )
+    }
+
+    @Test func cancellationAfterProvingReleasesTheCreatedTransactions() async throws {
+        // `CreatedTransaction` carries no Sendable guarantee across the module boundary, so it is
+        // constructed fresh inside the unstructured `Task` below rather than captured from an
+        // outer `let` — a value crossing into `Task.init`'s `@Sendable` closure must not alias a
+        // non-Sendable capture. The expected txId (`Data([0xEF])`) mirrors `.fixture(0xEF)`.
+        let released = LockIsolated<[[Data]]>([])
+        let parked = AsyncBox()
+
+        // `acquireWithTimeout` never returns on its own; only cancelling the surrounding Task can
+        // unblock it, via `Task.sleep`'s own cancellation handling.
+        let client = TransactionGuardClient(
+            acquire: {
+                Issue.record("The submission seam must acquire the guard with a timeout, never the unbounded acquire.")
+            },
+            acquireWithTimeout: { _ in
+                await parked.signal()
+                try await Task.sleep(for: .seconds(999))
+            },
+            tryAcquire: { true },
+            release: { }
+        )
+
+        let task = Task {
+            try await SDKSynchronizerClient.createThenSubmitUnderGuard(
+                transactionGuard: client,
+                timeout: .seconds(30),
+                logPrefix: "[Test]",
+                intendedEndpoints: [],
+                prove: { [CreatedTransaction.fixture(0xEF)] },
+                submit: { _ in SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: []) },
+                release: { transactions, _ in released.withValue { $0.append(transactions.map(\.txId)) } }
+            )
+        }
+
+        await parked.wait()
+        task.cancel()
+        _ = try? await task.value
+
+        #expect(
+            released.value == [[Data([0xEF])]],
+            "A send cancelled while parked on the guard must still hand its created transactions to background resubmission"
+        )
+    }
+
+    @Test func emptyProveResultKeepsTheFailureShape() async throws {
+        let releaseCallCount = LockIsolated(0)
+
+        let result = try await SDKSynchronizerClient.createThenSubmitUnderGuard(
+            transactionGuard: Self.busyGuardClient(),
+            timeout: .milliseconds(50),
+            logPrefix: "[Test]",
+            intendedEndpoints: [endpointA],
+            prove: { [] },
+            submit: { _ in SDKSynchronizerClient.CreateProposedTransactionsResult.success(txIds: []) },
+            release: { _, _ in releaseCallCount.withValue { $0 += 1 } }
+        )
+
+        #expect(
+            result == SDKSynchronizerClient.CreateProposedTransactionsResult.failure(
+                txIds: [],
+                code: SDKSynchronizerClient.MultiServerSubmission.guardBusyCode,
+                description: String(localizable: .transactionGuardBusy)
+            ),
+            "With nothing created there is nothing to release, so the definitive failure shape is unchanged; got \(result)"
+        )
+        #expect(releaseCallCount.value == 0, "An empty prove result must never call release")
     }
 
     /// A pass-through client that logs every guard interaction, so a test can assert *when* the
@@ -401,6 +515,17 @@ import Testing
             release: { await guardActor.release() }
         )
     }
+
+    /// A client whose timed acquire always reports the guard as busy without ever taking it —
+    /// matches what a real `TransactionGuard` does once `acquire(timeout:)`'s deadline passes.
+    private static func busyGuardClient() -> TransactionGuardClient {
+        TransactionGuardClient(
+            acquire: { throw TransactionGuardBusyError() },
+            acquireWithTimeout: { _ in throw TransactionGuardBusyError() },
+            tryAcquire: { false },
+            release: { }
+        )
+    }
 }
 
 /// Minimal async one-shot signal for ordering test steps.
@@ -428,4 +553,12 @@ private struct TestFailure: Error {}
 private actor OrderRecorder {
     private(set) var values: [String] = []
     func record(_ value: String) { values.append(value) }
+}
+
+private extension CreatedTransaction {
+    /// A minimal, distinguishable transaction for seam tests: `txId` and `raw` both derive from
+    /// `byte` so a test can tell fixtures apart without caring about real transaction encoding.
+    static func fixture(_ byte: UInt8) -> CreatedTransaction {
+        CreatedTransaction(txId: Data([byte]), raw: Data([byte, byte]), expiryHeight: nil)
+    }
 }


### PR DESCRIPTION
Part of MOB-1848. Fixes the audit finding that a send which created and proved its transaction but could not hand it to a server was reported as a plain failure and left stranded.

**What:** when the submission guard stays busy past its timeout, or the send is cancelled after proving, the app now releases the exact created transactions to the SDK's background resubmission with the endpoints the user chose, and reports them as created but not yet confirmed. The confirmation screen takes its existing pending route with new copy explaining that the transaction will be handed to a server as soon as the wallet finishes its current network work; the same copy is used on the software send, the Keystone (PCZT) send and the Swap and Pay flow. An empty proving result keeps the old failure. The comment that promised a clean retry is rewritten; the endpoint selection used for submission is shared with the release path.

**Why:** proving stores the transaction in the wallet database and reserves its inputs. The SDK's background resubmission deliberately skips transactions the app never released, so a busy timeout after proving left a transaction that would neither be broadcast nor retried while a fresh attempt could find its inputs unavailable. Releasing the same transaction id cannot produce a duplicate payment.

**Test plan**
- `TransactionGuardTests` (seam): busy guard after a non-empty prove → release called once with the created transactions and intended endpoints, zero submits, result carries the created ids with the busy reason; cancellation while waiting for the guard → release; empty prove keeps the failure shape.
- `MultiServerSubmitRoutingTests` (new): the busy reason routes to the new pending copy on the software, Keystone and Swap and Pay paths; timeout and nil reasons unchanged.
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`; 73 tests in 10 suites passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)