### PR TITLE
[MOB-1855] Clear the previous account's rows on switch and keep failed fetches truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1859] Opening the wallet no longer generates a fresh receive address for every account on each load, so loading is faster during sync.
 - [MOB-1857] Sending with insufficient funds shows the proper message again, and a failed payment request always shows an error instead of doing nothing.
 - [MOB-1856] The app stays responsive while it catches up on a long transaction history.
-- [MOB-1855] The transaction list no longer empties or stays stuck on placeholders while the wallet is still catching up on sync.
+- [MOB-1855] The transaction list no longer empties or stays stuck on placeholders while the wallet is still catching up on sync, and after switching accounts, a failed refresh can no longer show the previous account's transactions as the new account's history.
 - [MOB-1853] Automatic server switching no longer restarts a sync that is actively in progress; if syncing stalls, the app now looks for a healthier server by itself. When the wallet's own reconnection attempts give up, the app now rebuilds the connection (to a better server when one is available, otherwise the current one) instead of waiting; after two rebuilds in one session it shows the error state.
 - [MOB-1831] Opening Send immediately after launching ZODL now shows the saved spendable balance while automatic server selection completes.
 - The Keystone hardware wallet connection screen now refers to Zodl instead of Zashi in the note that a previously connected wallet needs to sync to find its transaction history.

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -729,6 +729,15 @@ extension Root {
         // actually starting -- parking the newly-selected account's fetch forever.
         state.isTransactionsFetchInFlight = false
         state.isTransactionsFetchDirty = false
+        // MOB-1855: the rows still sitting in the shared `transactions` array belong to the account just
+        // LEFT -- both lists above are now invalidated and show their loading placeholder, so
+        // nothing renderable may remain for a failed fetch to leave on screen as if it were the new
+        // account's history. `transactionsAccountId` drops to `nil` alongside it, so neither the
+        // empty-fetch keep-guard nor the failure path in `RootTransactions.swift` can mistake the
+        // (now empty) array for a confirmed answer about the newly-selected account until ITS OWN
+        // fetch actually lands.
+        state.$transactions.withLock { $0 = [] }
+        state.transactionsAccountId = nil
         return .merge(
             .send(.home(.smartBanner(.walletAccountChanged))),
             .send(.home(.walletBalances(.updateBalances))),

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -186,6 +186,15 @@ struct Root {
         /// completion, which folds every dispatch coalesced during its run into exactly one
         /// follow-up fetch for whichever account is selected at that point.
         var isTransactionsFetchDirty = false
+        /// Which account the shared `transactions` array currently holds rows for. Set by
+        /// `.fetchedTransactions` (`RootTransactions.swift`) the moment it writes `$transactions`, so
+        /// it always names the account whose fetch actually produced the array's current contents --
+        /// never the account merely selected right now. `nil` after `accountSwitchedEffect`
+        /// (`RootCoordinator.swift`) clears both together on every switch, and stays `nil` until the
+        /// newly-selected account's own fetch lands. Read by the empty-fetch keep-guard and the
+        /// failure path in `RootTransactions.swift` so neither can ever treat a foreign account's
+        /// leftover rows as belonging to the account a fetch just completed (or failed) for.
+        var transactionsAccountId: AccountUUID?
         @Shared(.appStorage(.lastAuthenticationTimestamp)) var lastAuthenticationTimestamp: Int = 0
         /// The most recent `.syncing` progress value seen via `.synchronizerStateChanged`, kept
         /// solely so that handler can detect a NEW tick's progress advancing past this one and

--- a/secant/Sources/Features/Root/RootTransactions.swift
+++ b/secant/Sources/Features/Root/RootTransactions.swift
@@ -251,9 +251,22 @@ extension Root {
                 // Both lists still get `transactionsUpdated` so one that WAS mid-load can clear its
                 // placeholder, and the poller is armed from the KEPT `state.transactions`, never
                 // from this fetch's result, so a still-pending kept row keeps its 30 s reconciler.
+                //
+                // MOB-1855: `state.transactionsAccountId == accountUUID` on top of the pre-existing
+                // conditions -- the array being "kept" here must actually belong to the account THIS
+                // fetch just answered for, or the guard would protect a foreign account's leftover
+                // rows the same way it protects a legitimate stale-empty-during-sync race. In normal
+                // operation `accountSwitchedEffect` already empties `state.transactions` on every
+                // switch, so `!state.transactions.isEmpty` above would already be false for a
+                // just-switched-to account -- this clause is defense in depth for that guarantee, not
+                // the only thing enforcing it.
                 let listsAreInvalidated = state.homeState.transactionListState.isInvalidated
                     || state.transactionsCoordFlowState.transactionsManagerState.isInvalidated
-                if transactions.isEmpty && !state.transactions.isEmpty && !listsAreInvalidated && !isUpToDate(state.lastKnownSyncStatus) {
+                if transactions.isEmpty
+                    && !state.transactions.isEmpty
+                    && !listsAreInvalidated
+                    && !isUpToDate(state.lastKnownSyncStatus)
+                    && state.transactionsAccountId == accountUUID {
                     LoggerProxy.event("[RootTransactions] ignored an empty fetch while sync is not up to date; kept \(state.transactions.count) rows")
                     return .merge(
                         reconciliationPoller(for: state.transactions, state: state),
@@ -294,6 +307,10 @@ extension Root {
                     state.$transactions.withLock {
                         $0 = identifiedArray
                     }
+                    // MOB-1855: this write is the one place the array's contents actually change to
+                    // reflect `accountUUID`'s fetch, so this is where provenance is recorded too --
+                    // see `transactionsAccountId`'s doc comment (`RootStore.swift`).
+                    state.transactionsAccountId = accountUUID
                     return .merge(
                         pendingTransactionsPoller,
                         .send(.home(.smartBanner(.evaluatePriority6))),
@@ -346,6 +363,21 @@ extension Root {
                 // wrong rows are still on screen.
                 guard accountUUID == state.selectedWalletAccount?.id else {
                     return coalescedFollowUp
+                }
+                // MOB-1855: a failure carries no rows of its own to apply, so it must never be the path
+                // that VALIDATES rows left behind by a different account. `accountSwitchedEffect`
+                // (`RootCoordinator.swift`) already empties `state.transactions` on every switch, so
+                // reaching this with a non-empty array whose `transactionsAccountId` disagrees with
+                // `accountUUID` should not occur -- but "should not occur" is exactly the case a
+                // failure path must still cover defensively, since there is no fresh fetch result
+                // here to overwrite the wrong rows with. Log it: if this ever fires, that gap is
+                // worth investigating on its own.
+                if state.transactionsAccountId != accountUUID, !state.transactions.isEmpty {
+                    let clearedRowCount = state.transactions.count
+                    state.$transactions.withLock { $0 = [] }
+                    LoggerProxy.event(
+                        "[RootTransactions] transactionsFetchFailed found \(clearedRowCount) foreign-account rows still in state; cleared them"
+                    )
                 }
                 // The list keeps its previous contents (nothing to overwrite here at all), but
                 // either list may already be showing its loading placeholder -- clear it exactly

--- a/zodlTests/RootTransactionsTests/RootTransactionsAccountProvenanceTests.swift
+++ b/zodlTests/RootTransactionsTests/RootTransactionsAccountProvenanceTests.swift
@@ -1,0 +1,290 @@
+//
+//  RootTransactionsAccountProvenanceTests.swift
+//  zodlTests
+//
+//  The shared `transactions` array used to carry no record of which account's fetch actually
+//  produced it. `accountSwitchedEffect` (`RootCoordinator.swift`) invalidated both transaction
+//  lists on a switch but left the array itself untouched, so if the NEWLY selected account's first
+//  fetch then FAILED, the failure path's own guard (`accountUUID == state.selectedWalletAccount?.id`)
+//  passed -- correctly, the failure genuinely is for the current account -- and went on to notify
+//  both lists and re-arm the reconciliation poller from whatever was still sitting in
+//  `state.transactions`: the PREVIOUS account's rows. Both lists cleared their loading placeholder
+//  and rendered the old account's history as if it were the new account's, with no error surfaced
+//  anywhere.
+//
+//  The fix is two-layered: `accountSwitchedEffect` now empties the shared array (and the new
+//  `transactionsAccountId` alongside it) the moment it invalidates both lists, so nothing
+//  renderable survives a switch until the new account's own fetch actually lands; and
+//  `transactionsAccountId` (`RootStore.swift`) records which account's rows are CURRENTLY in the
+//  array, read by both the pre-existing empty-fetch keep-guard and a new defensive check on the
+//  failure path, so neither can ever treat a foreign account's leftover rows as a confirmed answer
+//  for the account a fetch just completed -- or failed -- for.
+//
+//  Mirrors `RootTransactionsAccountSwitchTests.swift`'s established pattern: a plain `Store` (not
+//  `TestStore`) driven with a file-scoped `baseNoOpDependencies` baseline (copied from that file,
+//  since these tests drive the SAME real switch action, `.home(.walletAccountTapped)`, and need the
+//  same dependency shape for `loadContacts`/`resolveMetadataEncryptionKeys`/`loadUserMetadata` to
+//  settle). Every account's rows are seeded via a REAL `.fetchedTransactions` completion rather than
+//  a hand-built `$transactions`/`transactionsAccountId` fixture, so `transactionsAccountId` ends up
+//  set exactly the way production sets it. The one late-arriving completion each test needs (a
+//  stale failure, or a still-parked fetch for the newly-selected account) is driven with
+//  `TestSupport/TestSignals.swift`'s `ResumableGate` -- the same event-driven, no-clock primitive
+//  `RootTransactionsCoalescingTests.swift` uses to hold a mocked dependency open on a gate.
+//
+//  `.serialized`: constructing/driving `Root.State` touches the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` / `.inMemory(.transactions)` /
+//  `.inMemory(.walletAccounts)` keys, same precedent as every other Root-level suite in this
+//  directory.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized, .timeLimit(.minutes(2))) @MainActor struct RootTransactionsAccountProvenanceTests {
+    private static func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    private func tx(id: String, status: TransactionState.Status = .received) -> TransactionState {
+        TransactionState(fee: Zatoshi(10), id: id, status: status, zecAmount: Zatoshi(100_000))
+    }
+
+    private struct FetchStubError: Error { }
+
+    // MARK: - (1) A failed fetch for the NEW account must never leave the OLD account's rows on screen
+
+    /// The exact regression: A has rows, the user switches to B, and B's very first fetch fails.
+    /// Before the fix, the failure path's provenance guard alone let this through -- the failure IS
+    /// for the currently-selected account -- and re-validated whatever was left in
+    /// `state.transactions`, which was still A's rows because nothing had cleared them on the
+    /// switch. Both lists then cleared their placeholder over A's stale history.
+    @Test func failedFetchForTheNewAccountNeverRevealsThePreviousAccountsRows() async {
+        let accountA = Self.walletAccount(idByte: 120)
+        let accountB = Self.walletAccount(idByte: 121)
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = accountA }
+        initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { accountUUID in
+                if accountUUID == accountB.id {
+                    throw FetchStubError()
+                }
+                return []
+            }
+        }
+
+        // Seed A's rows via a REAL `.fetchedTransactions` completion, establishing
+        // `transactionsAccountId == accountA.id` exactly the way `accountSwitchedEffect`'s own
+        // fetch would have.
+        let aRows = IdentifiedArrayOf<TransactionState>(uniqueElements: [tx(id: "a-tx-1"), tx(id: "a-tx-2")])
+        store.send(.fetchedTransactions(accountA.id, aRows))
+        #expect(store.state.transactions == aRows, "setup must land A's rows before the switch")
+
+        // The real switch action -- reaches `accountSwitchedEffect`, which must clear the shared
+        // array up front, then immediately fires a fresh fetch for B, which the mock above fails.
+        // `finish()` awaits that whole chain, including B's own `.transactionsFetchFailed`.
+        await store.send(.home(.walletAccountTapped(accountB))).finish()
+
+        #expect(
+            store.state.transactions.isEmpty,
+            "B's failed fetch must never leave A's rows in the shared array as if they were B's history"
+        )
+        #expect(store.state.homeState.transactionListState.isInvalidated == false, "Home must still clear its placeholder")
+        #expect(
+            store.state.transactionsCoordFlowState.transactionsManagerState.isInvalidated == false,
+            "See All must still clear its placeholder"
+        )
+        #expect(store.state.selectedWalletAccount == accountB)
+    }
+
+    // MARK: - (2) An empty result for the NEW account while syncing must leave it empty, not resurrect the old rows
+
+    /// The non-failure sibling of the test above: B's fetch does not throw, it legitimately answers
+    /// empty while still syncing. The array must stay empty -- both because the switch already
+    /// cleared it, and because the empty-fetch keep-guard's own account check
+    /// (`state.transactionsAccountId == accountUUID`) would refuse to treat A's old rows as B's
+    /// answer even if something else had left them behind.
+    @Test func emptyResultForTheNewAccountWhileSyncingLeavesItEmpty() async {
+        let accountA = Self.walletAccount(idByte: 122)
+        let accountB = Self.walletAccount(idByte: 123)
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = accountA }
+        initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+        initialState.lastKnownSyncStatus = .syncing(0.4, false)
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { _ in [] }
+        }
+
+        let aRows = IdentifiedArrayOf<TransactionState>(uniqueElements: [tx(id: "a-tx-1")])
+        store.send(.fetchedTransactions(accountA.id, aRows))
+        #expect(store.state.transactions == aRows, "setup must land A's rows before the switch")
+
+        // B's own post-switch fetch (mocked above) answers empty while still mid-sync.
+        await store.send(.home(.walletAccountTapped(accountB))).finish()
+
+        #expect(
+            store.state.transactions.isEmpty,
+            "a legitimate empty result for the new account must never resurrect the previous account's rows"
+        )
+        #expect(store.state.selectedWalletAccount == accountB)
+    }
+
+    // MARK: - (3) A stale failure for the account just LEFT must change nothing after the switch
+
+    /// Mirrors `RootTransactionsEmptyFetchTests.swift`'s `fetchFailureForANonSelectedAccountChangesNothing`,
+    /// but reaches the post-switch shape via the REAL switch action instead of a hand-built fixture.
+    /// B's own fetch is deliberately held open on a gate for the whole test -- its eventual
+    /// resolution (either way) is not what this test is about, and letting it complete would let
+    /// its OWN legitimate `transactionsUpdated` clear the invalidation flags this test checks,
+    /// masking whether the STALE failure wrongly did so instead.
+    @Test func staleFailureForThePreviousAccountChangesNothingAfterTheSwitch() async {
+        let accountA = Self.walletAccount(idByte: 124)
+        let accountB = Self.walletAccount(idByte: 125)
+        let gate = ResumableGate()
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = accountA }
+        initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { _ in
+                await gate.wait()
+                return []
+            }
+        }
+
+        let aRows = IdentifiedArrayOf<TransactionState>(uniqueElements: [tx(id: "a-tx-1")])
+        store.send(.fetchedTransactions(accountA.id, aRows))
+        #expect(store.state.transactions == aRows, "setup must land A's rows before the switch")
+
+        // The switch's own state mutations (clearing the array, invalidating both lists) happen
+        // synchronously in the reducer, before the fresh fetch it dispatches for B has any chance
+        // to run -- true regardless of the gate above, which only matters once that fetch actually
+        // starts.
+        store.send(.home(.walletAccountTapped(accountB)))
+
+        #expect(store.state.selectedWalletAccount == accountB)
+        #expect(store.state.transactions.isEmpty, "the switch must clear A's rows up front")
+        #expect(store.state.homeState.transactionListState.isInvalidated)
+        #expect(store.state.transactionsCoordFlowState.transactionsManagerState.isInvalidated)
+
+        // A stale failure for A, arriving after the switch -- the provenance guard
+        // (`accountUUID == state.selectedWalletAccount?.id`) must drop it before it can touch B's
+        // still-loading lists, regardless of what `transactionsAccountId` says.
+        store.send(.transactionsFetchFailed(accountUUID: accountA.id))
+
+        #expect(store.state.transactions.isEmpty, "a stale failure for the previous account must not resurrect its rows")
+        #expect(
+            store.state.homeState.transactionListState.isInvalidated,
+            "a stale failure must not clear the CURRENTLY selected account's Home invalidation"
+        )
+        #expect(
+            store.state.transactionsCoordFlowState.transactionsManagerState.isInvalidated,
+            "a stale failure must not clear the CURRENTLY selected account's See All invalidation"
+        )
+
+        gate.open()
+    }
+
+    // MARK: - (4) A same-account failure must still keep its own rows and re-arm the poller
+
+    /// The non-regression guard alongside the three above: a failure for the account that is ALREADY
+    /// selected -- no switch involved at all -- must never trip the new defensive foreign-rows
+    /// check. `transactionsAccountId` already matches, so the rows are kept exactly as before this
+    /// change, and the reconciliation poller still re-arms from them.
+    @Test func sameAccountFailureKeepsRowsAndPoller() async {
+        let account = Self.walletAccount(idByte: 126)
+        let scheduler = DispatchQueue.test
+        let fetchCalls = LockIsolated<Int>(0)
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = account }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.mainQueue = scheduler.eraseToAnyScheduler()
+            $0.sdkSynchronizer.getAllTransactions = { _ in
+                fetchCalls.withValue { $0 += 1 }
+                throw FetchStubError()
+            }
+        }
+
+        // Seed the account's own rows via a REAL `.fetchedTransactions` completion -- a pending row
+        // so the reconciliation poller below has something to arm on -- establishing
+        // `transactionsAccountId == account.id` exactly the way production does.
+        let ownRows = IdentifiedArrayOf<TransactionState>(uniqueElements: [tx(id: "own-pending-tx", status: .sending)])
+        store.send(.fetchedTransactions(account.id, ownRows))
+        #expect(store.state.transactions == ownRows, "setup must land the account's own rows")
+
+        // The SAME account's own fetch fails -- `transactionsAccountId` already matches, so the
+        // defensive foreign-rows check must not fire.
+        store.send(.transactionsFetchFailed(accountUUID: account.id))
+
+        #expect(store.state.transactions == ownRows, "a same-account failure must never clear its own kept rows")
+
+        while fetchCalls.value < 1 {
+            await scheduler.advance(by: .seconds(1))
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(fetchCalls.value >= 1, "the reconciliation poller was not armed from the kept rows after a same-account failure")
+    }
+}
+
+/// Shared no-op dependency baseline for every test in this file. Copied from
+/// `RootTransactionsAccountSwitchTests.swift` rather than the Empty/PendingRefresh files' baseline:
+/// every test here drives the REAL `.home(.walletAccountTapped)` action at least once (to reach
+/// `accountSwitchedEffect`), which also merges in `.loadContacts`/`.resolveMetadataEncryptionKeys`/
+/// `.loadUserMetadata` -- that baseline is already proven to carry those to completion. Kept as its
+/// own private, file-scoped copy per this directory's established convention of not sharing test
+/// helpers across files.
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}

--- a/zodlTests/RootTransactionsTests/RootTransactionsEmptyFetchTests.swift
+++ b/zodlTests/RootTransactionsTests/RootTransactionsEmptyFetchTests.swift
@@ -36,7 +36,11 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 @testable import zodl_internal
 
-@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor struct RootTransactionsEmptyFetchTests {
+// Three minutes, not one -- CI has clocked a healthy run of
+// `emptyFetchMidSyncWithValidListsKeepsTheListAndStillNotifiesBothLists` past the 1-minute budget
+// under load, same rationale as `RootPendingTransactionRefreshTests.swift`/
+// `RootSendCompletionRefreshTests.swift`, which size their own `.timeLimit` the same way.
+@Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootTransactionsEmptyFetchTests {
     private static func walletAccount(idByte: UInt8) -> WalletAccount {
         WalletAccount(
             Account(
@@ -75,6 +79,11 @@ import ComposableArchitecture
         var initialState = Root.State.initial
         initialState.$selectedWalletAccount.withLock { $0 = account }
         initialState.$transactions.withLock { $0 = keptTransactions }
+        // The guard now also requires the kept array to be confirmed as belonging to THIS account
+        // (see `transactionsAccountId`'s doc comment, `RootStore.swift`) -- production only ever
+        // reaches this guard with the id already set by a prior `.fetchedTransactions` for the same
+        // account, which this hand-built fixture must mirror explicitly.
+        initialState.transactionsAccountId = account.id
         initialState.homeState.transactionListState.isInvalidated = false
         initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
         initialState.lastKnownSyncStatus = .syncing(0.3, false)
@@ -97,8 +106,12 @@ import ComposableArchitecture
         #expect(store.state.transactions == keptTransactions, "a spurious empty fetch mid-sync must never blank a non-empty list")
 
         // `transactionsUpdated` reaches each list via a returned `.send` effect, not a synchronous
-        // mutation -- give it a moment to land before reading each list's own derived state.
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        // mutation -- wait on the store's own state-change publisher rather than a fixed sleep, so
+        // this resumes the moment the effect actually lands, at whatever speed the machine runs.
+        await waitForRootState(store) {
+            $0.homeState.transactionListState.latestTransactionId == "kept-pending-tx"
+                && $0.transactionsCoordFlowState.transactionsManagerState.searchedTransactionsList == keptTransactions
+        }
         #expect(
             store.state.homeState.transactionListState.latestTransactionId == "kept-pending-tx",
             "Home's transactionsUpdated was not received on the ignored-empty-fetch path"
@@ -195,6 +208,11 @@ import ComposableArchitecture
         var initialState = Root.State.initial
         initialState.$selectedWalletAccount.withLock { $0 = account }
         initialState.$transactions.withLock { $0 = keptTransactions }
+        // Mirrors the real invariant `.fetchedTransactions` maintains: rows sitting in the shared
+        // array are recorded as belonging to the account that fetched them (`RootStore.swift`'s
+        // `transactionsAccountId` doc comment) -- without this, the failure path's own defensive
+        // guard would find a mismatched id and wrongly clear this test's kept rows.
+        initialState.transactionsAccountId = account.id
         initialState.homeState.transactionListState.isInvalidated = true
         initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = true
 
@@ -214,8 +232,12 @@ import ComposableArchitecture
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
         // The failure's own completion signal reaches both lists via returned `.send` effects --
-        // give them a moment to land.
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        // wait on the store's own state-change publisher rather than a fixed sleep, so this resumes
+        // the moment both flags actually clear, at whatever speed the machine runs.
+        await waitForRootState(store) {
+            !$0.homeState.transactionListState.isInvalidated
+                && !$0.transactionsCoordFlowState.transactionsManagerState.isInvalidated
+        }
 
         #expect(store.state.transactions == keptTransactions, "a failed fetch must never clear the kept list")
         #expect(!store.state.homeState.transactionListState.isInvalidated, "a failed fetch must still clear Home's invalidation")
@@ -322,6 +344,9 @@ import ComposableArchitecture
         var initialState = Root.State.initial
         initialState.$selectedWalletAccount.withLock { $0 = account }
         initialState.$transactions.withLock { $0 = keptTransactions }
+        // See `transactionsAccountId`'s doc comment (`RootStore.swift`): the guard this test
+        // exercises now also requires the kept rows to be confirmed as this account's own.
+        initialState.transactionsAccountId = account.id
         initialState.homeState.transactionListState.isInvalidated = false
         initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
         initialState.lastKnownSyncStatus = .syncing(0.3, false)
@@ -339,6 +364,24 @@ import ComposableArchitecture
             store.state.transactions == keptTransactions,
             "an empty on-chain fetch must keep the on-chain rows even with an in-flight swap-to-ZEC synthetic row in play"
         )
+    }
+}
+
+/// Suspends until `condition` holds, resuming on the store's own state-change publisher instead of
+/// a fixed wall-clock wait -- a file-scoped copy of `RootTransactionsAccountSwitchTests.swift`'s
+/// `waitForRootState`, kept private to this file per that file's own established convention of not
+/// sharing test helpers across the suites in this directory. Still no clock of its own: the suite's
+/// `.timeLimit` is the only outer bound, and only a condition that never becomes true reaches it.
+@MainActor
+private func waitForRootState(
+    _ store: StoreOf<Root>,
+    until condition: @escaping @MainActor (Root.State) -> Bool
+) async {
+    if condition(store.state) {
+        return
+    }
+    for await state in store.publisher.values where condition(state) {
+        return
     }
 }
 


### PR DESCRIPTION
Part of MOB-1848. Fixes the audit finding that a failed refresh right after an account switch could show the previous account's transactions as the new account's history.

**What:** the shared transaction rows now record which account they belong to. Switching accounts clears the rows together with the lists' invalidation flags, so nothing renderable from the previous account survives the switch; the refreshed account's own rows set the account again when they land. A failed refresh for the selected account notifies the lists only into a truthful state (same-account rows stay; any foreign rows are cleared first, defensively), the empty-fetch keep-guard applies only to same-account rows, and the reconciliation poller is armed only from vetted rows. The empty-fetch test suite's time limit is raised to the sibling suites' three minutes and its two sleep-gated positive assertions now wait on observable state, which is what tripped the CI unit job.

**Why:** the failure path already dropped a stale failure for a previous account, but it never checked whether the rows it was about to reveal belonged to the newly selected one; both lists cleared their placeholders and rendered the old account's history, and a later legitimate empty result for the new account was then rejected by the keep-guard.

**Test plan**
- `RootTransactionsAccountProvenanceTests` (new, driving the real account-switch action): A has rows, switch to B, B's fetch fails → neither list shows A's rows; B returns an empty result while syncing → B stays empty; a stale failure for A after the switch changes nothing; a same-account failure keeps rows and the poller.
- `RootTransactionsEmptyFetchTests` passed twice in a row inside the new budget; the other `RootTransactionsTests` suites pass — 41 tests in 7 suites.
- `xcodebuild … -scheme zodl-internal` build → `** BUILD SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)