### PR TITLE
[MOB-1848] Describe the 2026-08-05 field-incident fix in plain prose

### DIFF
--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -287,7 +287,7 @@ extension Root {
                     migrationTickLoopEffect(state: state)
                 )
 
-            // G1 (field 2026-08-05): THE IN-FLOW COMMIT CURE. `flowFinished` below re-spawns the
+            // The in-flow commit cure for the 2026-08-05 field incident. `flowFinished` below re-spawns the
             // tick loop for a run committed mid-session — but only when the user LEAVES the flow,
             // and the session that commits then sits watching the progress screen never does: its
             // R0 open-lane credit is long spent (the log's "afterSync SKIPPED — already driven"),

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -1831,7 +1831,7 @@ extension Root {
             selectedAccountUUID: state.selectedWalletAccount?.id,
             walletAccounts: state.walletAccounts
         )
-        // ANY committed run spawns the loop, immediate mode included (G1 fix, field 2026-08-05 —
+        // ANY committed run spawns the loop, immediate mode included (the 2026-08-05 field-incident fix —
         // a fresh-commit session sat under "Keep Zodl open" forever): a run's note-PREPARATIONS
         // are engine-paced wallet plumbing in EVERY mode, and the tick lane is what proves and
         // delivers them between opens (AUD-3 F4 exempts preps from the tick's mode belt; D2 sends


### PR DESCRIPTION
Part of MOB-1848. Comment-only.

**What:** two comments in the Root migration flow (`RootCoordinator.swift`, `RootInitialization.swift`) labelled the fix for the 2026-08-05 field incident with an internal audit shorthand; they now describe it in plain prose. The technical content — why a committed migration run must spawn the tick loop the moment it is born, not only when the user leaves the flow — is unchanged. The migration ground rule "R0" nearby is genuine domain vocabulary (defined in `MigrationStepDriver`, used in log and trace strings) and is untouched.

**Test plan**
- No behaviour change. `RootMigrationGateRefusalTests`, `RootMigrationTickLoopTests`, `RootMigrationGateStopOnBlockTests`, `RootInitializeSDKColdStartFetchTests`, `RootAutoServerIdleGateTests`, `RootTransactionsAccountSwitchTests`: 60 tests in 6 suites passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)