### PR TITLE
[MOB-1862] Let incoming swaps request quotes while local spendability is masked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1863] A sent transaction now shows "Sent · awaiting confirmation" once a server has accepted it, instead of "Sending" until the wallet catches up.
 
 ### Fixed
-- [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send and Swap wait for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent.
+- [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send and Swap wait for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent. Swapping another asset into ZEC no longer waits for the wallet's spendable balance to be confirmed, since that swap doesn't spend it.
 - [MOB-1860] Leaving a voting screen while a proof is being prepared stops that work instead of letting it run in the background.
 - [MOB-1859] Opening the wallet no longer generates a fresh receive address for every account on each load, so loading is faster during sync.
 - [MOB-1857] Sending with insufficient funds shows the proper message again, and a failed payment request always shows an error instead of doing nothing.

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -105,12 +105,15 @@ struct SwapAndPay {
             walletBalancesState.isSpendableMasked
         }
 
+        /// Only a flow that spends local ZEC has to wait for the spendable value; an incoming swap
+        /// deposits another asset and receives ZEC, so masking must not block funding a wallet
+        /// that is still syncing. Mirrors the exemption in `isInsufficientFunds`.
         var isValidForm: Bool {
             selectedAsset != nil
             && !address.isEmpty
             && amount > 0
             && !isInsufficientFunds
-            && !isSpendabilityBeingDetermined
+            && (isSwapToZecExperienceEnabled || !isSpendabilityBeingDetermined)
         }
 
         var isInsufficientFunds: Bool {
@@ -208,10 +211,16 @@ struct SwapAndPay {
 
                 return numberFormatter.number(amountText)?.decimalValue ?? 0.0
             } else {
-                return 0.0
+                // Test builds have no live formatter; a test that needs a positive amount sets this.
+                return amountOverrideForTesting ?? 0.0
             }
         }
-        
+
+        /// Interim seam: test builds can't run `amount` through the live formatter dependency
+        /// above, so it always reads zero there unless a test opts in here. Remove once the
+        /// formatter dependency is injectable in tests (MOB-1873).
+        var amountOverrideForTesting: Decimal?
+
         var assetAmount: Decimal {
             if !_XCTIsTesting {
                 @Dependency(\.numberFormatter) var numberFormatter

--- a/zodlTests/SwapAndPayTests/SwapAndPayMaxButtonTests.swift
+++ b/zodlTests/SwapAndPayTests/SwapAndPayMaxButtonTests.swift
@@ -540,4 +540,38 @@ private enum SwapMaxButtonTestError: Error {
         state.walletBalancesState.isSpendableMasked = false
         #expect(state.isCrossPayInsufficientFunds)
     }
+
+    // MARK: - Incoming-swap exemption from the masked gate (MOB-1862 follow-on): an incoming
+    // swap deposits another asset and pays ZEC out to this wallet, so it never spends local ZEC.
+    // Masking the wallet's own spendable value must not block it the way it blocks Swap/Pay above.
+
+    @Test func incomingSwapCanRequestAQuoteWhileLocalSpendabilityIsMasked() {
+        var state = swapState()
+        state.isSwapToZecExperienceEnabled = true
+        state.address = "t1validLookingAddressForTheFixture"
+        state.amountText = "1.5"
+        state.amountOverrideForTesting = 1.5
+        state.walletBalancesState.isSpendableMasked = true
+        #expect(state.isValidForm)
+    }
+
+    @Test func outgoingSwapStaysBlockedWhileMasked() {
+        var state = swapState()
+        state.isSwapToZecExperienceEnabled = false
+        state.address = "t1validLookingAddressForTheFixture"
+        state.amountText = "1.5"
+        state.amountOverrideForTesting = 1.5
+        state.walletBalancesState.isSpendableMasked = true
+        #expect(!state.isValidForm)
+    }
+
+    @Test func incomingSwapWithEmptyAddressStaysInvalid() {
+        var state = swapState()
+        state.isSwapToZecExperienceEnabled = true
+        state.address = ""
+        state.amountText = "1.5"
+        state.amountOverrideForTesting = 1.5
+        state.walletBalancesState.isSpendableMasked = true
+        #expect(!state.isValidForm)
+    }
 }


### PR DESCRIPTION
## Summary

Swapping another asset **into** ZEC never spends the wallet's own ZEC, yet the quote form treated it like an outgoing swap and stayed disabled for as long as the SDK was still confirming local spendability (for example right after a server switch or a restore). This lets the incoming flow request a quote as soon as the destination and amount are filled in, while outgoing swaps and CrossPay keep waiting until spendability is known — the same split the insufficient-funds check already made.

- `SwapAndPay.State.isValidForm` exempts only the incoming (swap-to-ZEC) experience from the "spendability still being determined" gate.
- A test-only amount seam lets the form tests drive the parsed amount without the shared number formatter (interim; tracked under MOB-1873).

## Tests

Three new `SwapAndPayMaxButtonTests` cases: incoming + masked → valid; outgoing + masked → still invalid; incoming with an empty address → still invalid. The first fails on the previous gate.

Verified locally with the `zodl-internal` scheme: build succeeded; 33 tests in 3 suites passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
