### PR TITLE
[MOB-1862] Attribute balance responses to their account and show the breakdown as updating while masked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1863] A sent transaction now shows "Sent · awaiting confirmation" once a server has accepted it, instead of "Sending" until the wallet catches up.
 
 ### Fixed
+- [MOB-1862] After switching accounts, a balance or pending amount that was still loading for the previous account can no longer be shown as the new account's, and the balance breakdown shows that the spendable amount is still updating while the wallet confirms it.
 - [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send and Swap wait for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent. Swapping another asset into ZEC no longer waits for the wallet's spendable balance to be confirmed, since that swap doesn't spend it.
 - [MOB-1860] Leaving a voting screen while a proof is being prepared stops that work instead of letting it run in the background.
 - [MOB-1859] Opening the wallet no longer generates a fresh receive address for every account on each load, so loading is faster during sync.

--- a/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesStore.swift
@@ -20,6 +20,11 @@ struct Balances {
         var changePending: Zatoshi
         /// The account the published balance was read for — see `hasConcreteBalance`.
         var concreteBalanceAccountId: AccountUUID?
+        /// Bumped every time `.updateBalancesOnAppear` starts a new request, and carried on every
+        /// `.updateBalance` that request produces. A response whose generation no longer matches
+        /// is from a superseded request — answering for the right account is not enough on its
+        /// own, since two requests for the SAME account can still resolve out of order.
+        var balanceRequestGeneration = 0
         var isShielding: Bool
         /// The SDK is withholding the spendable value until it confirms a fresh chain tip. Not a
         /// balance: it says the number is not knowable yet, which a zero balance never can.
@@ -97,6 +102,10 @@ struct Balances {
             isSpendableMasked || (isSyncInProgress && !hasConcreteBalance)
         }
 
+        /// The breakdown shows the last unmasked spendable amount while the SDK is still masking
+        /// the value; this flag drives the row's progress indicator and the explanatory header.
+        var isSpendableValueUpdating: Bool { isSpendableMasked }
+
         init(
             autoShieldingThreshold: Zatoshi,
             changePending: Zatoshi,
@@ -124,7 +133,7 @@ struct Balances {
         case shieldFundsTapped
         case shieldingProcessorStateChanged(ShieldingProcessorClient.State)
         case synchronizerStateChanged(RedactableSynchronizerState)
-        case updateBalance(AccountBalance?)
+        case updateBalance(AccountBalance?, AccountUUID?, Int)
         case updateBalances([AccountUUID: AccountBalance])
         case updateBalancesOnAppear
     }
@@ -201,20 +210,23 @@ struct Balances {
                 guard let account = state.selectedWalletAccount else {
                     return .none
                 }
+                state.balanceRequestGeneration += 1
+                let generation = state.balanceRequestGeneration
+                let accountId = account.id
                 // Same read order as the home screen's balances, so the breakdown never
                 // contradicts the figure the user tapped to open it. The unmasked local snapshot
                 // comes first: the SDK's visible balances can be spendable-masked until the
                 // server reports a fresh tip, and a mask must not be shown as a real zero.
-                let cachedBalance = sdkSynchronizer.latestState().localAccountsBalances[account.id]
+                let cachedBalance = sdkSynchronizer.latestState().localAccountsBalances[accountId]
                 return .run { send in
                     if let cachedBalance {
-                        await send(.updateBalance(cachedBalance))
+                        await send(.updateBalance(cachedBalance, accountId, generation))
                     }
 
                     if let localBalances = try? await sdkSynchronizer.getLocalAccountBalances(),
-                       let freshBalance = localBalances[account.id] {
+                       let freshBalance = localBalances[accountId] {
                         if freshBalance != cachedBalance {
-                            await send(.updateBalance(freshBalance))
+                            await send(.updateBalance(freshBalance, accountId, generation))
                         }
                         return
                     }
@@ -222,12 +234,12 @@ struct Balances {
                     // Do not let a masked visible balance replace a concrete local snapshot.
                     // Use the established API only when no local value is available.
                     guard cachedBalance == nil else { return }
-                    if let fallbackBalance = sdkSynchronizer.latestState().localAccountsBalances[account.id] {
-                        await send(.updateBalance(fallbackBalance))
-                    } else if let fallbackBalance = try? await sdkSynchronizer.getAccountsBalances()[account.id] {
-                        await send(.updateBalance(fallbackBalance))
-                    } else if let fallbackBalance = sdkSynchronizer.latestState().accountsBalances[account.id] {
-                        await send(.updateBalance(fallbackBalance))
+                    if let fallbackBalance = sdkSynchronizer.latestState().localAccountsBalances[accountId] {
+                        await send(.updateBalance(fallbackBalance, accountId, generation))
+                    } else if let fallbackBalance = try? await sdkSynchronizer.getAccountsBalances()[accountId] {
+                        await send(.updateBalance(fallbackBalance, accountId, generation))
+                    } else if let fallbackBalance = sdkSynchronizer.latestState().accountsBalances[accountId] {
+                        await send(.updateBalance(fallbackBalance, accountId, generation))
                     }
                 }
 
@@ -267,13 +279,19 @@ struct Balances {
                 guard let accountBalance = accountsBalances[account.id] else {
                     return .none
                 }
-                return .send(.updateBalance(accountBalance))
+                return .send(.updateBalance(accountBalance, account.id, state.balanceRequestGeneration))
 
-            case .updateBalance(let accountBalance):
+            case .updateBalance(let accountBalance, let accountId, let generation):
+                // Dropped rather than applied when either no longer holds: the account it was
+                // read for (or, for a nil result, was looked up for) may no longer be selected, or
+                // a later `.updateBalancesOnAppear` dispatch may already have superseded the
+                // request this answers for.
+                guard accountId == state.selectedWalletAccount?.id, generation == state.balanceRequestGeneration else {
+                    LoggerProxy.event("[Balances] dropped a balance for a previous account or request")
+                    return .none
+                }
                 if accountBalance != nil {
-                    // Every path that reaches here with a value looked it up by the account
-                    // selected right now, so that is the account this figure answers for.
-                    state.concreteBalanceAccountId = state.selectedWalletAccount?.id
+                    state.concreteBalanceAccountId = accountId
                 }
 
                 // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future

--- a/secant/Sources/Features/BalanceBreakdown/BalancesView.swift
+++ b/secant/Sources/Features/BalanceBreakdown/BalancesView.swift
@@ -29,7 +29,7 @@ struct BalancesView: View {
                     .zFont(.semiBold, size: 24, style: Design.Text.primary)
                     .padding(.top, 40)
 
-                if store.spendability == .everything || store.isDisplayedPendingInProcess {
+                if store.spendability == .everything || store.isDisplayedPendingInProcess || store.isSpendableValueUpdating {
                     Text(
                         store.spendability == .everything
                         ? String(localizable: .balancesEverythingDone)
@@ -80,6 +80,11 @@ extension BalancesView {
                 
                 Spacer()
 
+                if store.isSpendableValueUpdating {
+                    progressViewLooping()
+                        .padding(.trailing, 10)
+                }
+
                 Asset.Assets.shield.image
                     .zImage(width: 11, height: 14, color: Asset.Colors.primary.color)
                     .padding(.trailing, 10)
@@ -87,7 +92,7 @@ extension BalancesView {
                 ZatoshiText(store.shieldedBalance, .expanded, tokenName)
                     .zFont(.medium, size: 14, style: Design.Text.primary)
             }
-            
+
             if store.isDisplayedPendingInProcess {
                 HStack(spacing: 0) {
                     Text(localizable: .balancesPending)

--- a/secant/Sources/Features/Root/RootCoordinator.swift
+++ b/secant/Sources/Features/Root/RootCoordinator.swift
@@ -738,6 +738,11 @@ extension Root {
         // fetch actually lands.
         state.$transactions.withLock { $0 = [] }
         state.transactionsAccountId = nil
+        // MOB-1862: derived from those same rows (`RootTransactions.swift`'s `.fetchedTransactions`
+        // handler) and read straight into the balance breakdown's "Pending" row, so it must not
+        // outlive the transactions it was computed from -- or the breakdown could transiently
+        // subtract the account just left's figure from the newly-selected account's pending lanes.
+        state.$unminedMigrationPendingValue.withLock { $0 = .zero }
         return .merge(
             .send(.home(.smartBanner(.walletAccountChanged))),
             .send(.home(.walletBalances(.updateBalances))),

--- a/secant/Sources/Features/Root/RootTransactions.swift
+++ b/secant/Sources/Features/Root/RootTransactions.swift
@@ -378,6 +378,11 @@ extension Root {
                     LoggerProxy.event(
                         "[RootTransactions] transactionsFetchFailed found \(clearedRowCount) foreign-account rows still in state; cleared them"
                     )
+                    // MOB-1862: derived from those same foreign rows (`.fetchedTransactions`, above)
+                    // and read straight into the balance breakdown's "Pending" row, so it must leave
+                    // together with them instead of continuing to describe an account that is no
+                    // longer on screen.
+                    state.$unminedMigrationPendingValue.withLock { $0 = .zero }
                 }
                 // The list keeps its previous contents (nothing to overwrite here at all), but
                 // either list may already be showing its loading placeholder -- clear it exactly

--- a/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
+++ b/secant/Sources/Features/WalletBalances/WalletBalancesStore.swift
@@ -19,6 +19,11 @@ struct WalletBalances {
         var CancelMigrationSnapshotId = UUID()
         /// The account the published balance was read for — see `hasConcreteBalance`.
         var concreteBalanceAccountId: AccountUUID?
+        /// Bumped every time `.updateBalances` starts a new request, and carried on every
+        /// `.balanceUpdated` that request produces. A response whose generation no longer matches
+        /// is from a superseded request — answering for the right account is not enough on its
+        /// own, since two requests for the SAME account can still resolve out of order.
+        var balanceRequestGeneration = 0
         @Shared(.inMemory(.exchangeRate)) var currencyConversion: CurrencyConversion? = nil
         var fiatCurrencyResult: FiatCurrencyResult?
         var isAvailableBalanceTappable = true
@@ -111,7 +116,7 @@ struct WalletBalances {
     enum Action: Equatable {
         case availableBalanceTapped
         case balanceTapped
-        case balanceUpdated(AccountBalance)
+        case balanceUpdated(AccountBalance, AccountUUID, Int)
         case exchangeRateRefreshTapped
         case exchangeRateEvent(ExchangeRateClient.EchangeRateEvent)
         case onAppear
@@ -251,18 +256,26 @@ struct WalletBalances {
                 guard let account = state.selectedWalletAccount else {
                     return .none
                 }
+                // The selection may have just changed; `hasConcreteBalance` already answers for
+                // the new account, so the stored spendability must follow before any balance
+                // arrives — otherwise it would go on repeating whatever the PREVIOUS account's
+                // answer was for however long this request takes to resolve.
+                state.spendability = spendability(for: state)
+                state.balanceRequestGeneration += 1
+                let generation = state.balanceRequestGeneration
+                let accountId = account.id
                 // Use the unmasked local snapshot for display continuity. The SDK's visible
                 // balances can be spendable-masked until the new server reports a fresh tip.
-                let cachedBalance = sdkSynchronizer.latestState().localAccountsBalances[account.id]
+                let cachedBalance = sdkSynchronizer.latestState().localAccountsBalances[accountId]
                 return .run { send in
                     if let cachedBalance {
-                        await send(.balanceUpdated(cachedBalance))
+                        await send(.balanceUpdated(cachedBalance, accountId, generation))
                     }
 
                     if let localBalances = try? await sdkSynchronizer.getLocalAccountBalances(),
-                       let freshBalance = localBalances[account.id] {
+                       let freshBalance = localBalances[accountId] {
                         if freshBalance != cachedBalance {
-                            await send(.balanceUpdated(freshBalance))
+                            await send(.balanceUpdated(freshBalance, accountId, generation))
                         }
                         return
                     }
@@ -270,19 +283,24 @@ struct WalletBalances {
                     // Do not let a masked visible balance replace a concrete local snapshot.
                     // Use the established API only when no local value is available.
                     guard cachedBalance == nil else { return }
-                    if let fallbackBalance = sdkSynchronizer.latestState().localAccountsBalances[account.id] {
-                        await send(.balanceUpdated(fallbackBalance))
-                    } else if let fallbackBalance = try? await sdkSynchronizer.getAccountsBalances()[account.id] {
-                        await send(.balanceUpdated(fallbackBalance))
-                    } else if let fallbackBalance = sdkSynchronizer.latestState().accountsBalances[account.id] {
-                        await send(.balanceUpdated(fallbackBalance))
+                    if let fallbackBalance = sdkSynchronizer.latestState().localAccountsBalances[accountId] {
+                        await send(.balanceUpdated(fallbackBalance, accountId, generation))
+                    } else if let fallbackBalance = try? await sdkSynchronizer.getAccountsBalances()[accountId] {
+                        await send(.balanceUpdated(fallbackBalance, accountId, generation))
+                    } else if let fallbackBalance = sdkSynchronizer.latestState().accountsBalances[accountId] {
+                        await send(.balanceUpdated(fallbackBalance, accountId, generation))
                     }
                 }
-                
-            case .balanceUpdated(let accountBalance):
-                // Every path that reaches here looked the balance up by the account selected right
-                // now, so that is the account this figure answers for.
-                state.concreteBalanceAccountId = state.selectedWalletAccount?.id
+
+            case .balanceUpdated(let accountBalance, let accountId, let generation):
+                // Dropped rather than applied when either no longer holds: the account it was
+                // read for may no longer be selected, or a later `.updateBalances` dispatch may
+                // already have superseded the request this answers for.
+                guard accountId == state.selectedWalletAccount?.id, generation == state.balanceRequestGeneration else {
+                    LoggerProxy.event("[WalletBalances] dropped a balance for a previous account or request")
+                    return .none
+                }
+                state.concreteBalanceAccountId = accountId
 
                 // Pool-agnostic accessors: sum sapling + orchard + ironwood (and any future
                 // shielded pool) instead of hand-summing individual pools.
@@ -332,7 +350,7 @@ struct WalletBalances {
                 guard let accountBalance = latestState.data.localAccountsBalances[account.id] else {
                     return .none
                 }
-                return .send(.balanceUpdated(accountBalance))
+                return .send(.balanceUpdated(accountBalance, account.id, state.balanceRequestGeneration))
             }
         }
     }

--- a/zodlTests/BalancesTests/BalancesTests.swift
+++ b/zodlTests/BalancesTests/BalancesTests.swift
@@ -107,6 +107,25 @@ import ComposableArchitecture
         }
     }
 
+    /// The breakdown must say the spendable figure is still updating while the SDK masks it, even
+    /// with nothing pending -- otherwise the one case `BalancesView`'s header goes silent for
+    /// (its condition and the spendable row's progress indicator are both keyed off this flag).
+    @Test func breakdownReportsUpdatingWhileMaskedWithNoPending() {
+        withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var masked = state(shieldedBalance: Zatoshi(1_000))
+            masked.spendability = .nothing
+            masked.isSpendableMasked = true
+
+            #expect(masked.isSpendableValueUpdating)
+            #expect(!masked.isDisplayedPendingInProcess, "nothing pending is exactly the case the header would otherwise go silent for")
+
+            masked.isSpendableMasked = false
+            #expect(!masked.isSpendableValueUpdating)
+        }
+    }
+
     @Test func isPendingTransactionReflectsSharedTransactions() {
         var state = state()
         state.$transactions.withLock { $0 = [] }
@@ -122,7 +141,7 @@ import ComposableArchitecture
             $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
         }
         store.exhaustivity = .off
-        await store.send(.updateBalance(nil))
+        await store.send(.updateBalance(nil, nil, 0))
         await store.receive(\.everythingSpendable)
         #expect(store.state.shieldedBalance == .zero)
         #expect(store.state.totalBalance == .zero)
@@ -130,59 +149,71 @@ import ComposableArchitecture
     }
 
     @MainActor @Test func updateBalanceAggregatesSaplingOrchardAndTransparent() async {
-        let store = TestStore(initialState: state(autoShieldingThreshold: Zatoshi(1_000_000))) {
-            Balances()
-        } withDependencies: {
-            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = TestStore(initialState: state(autoShieldingThreshold: Zatoshi(1_000_000))) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            let balance = AccountBalance(
+                saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+                orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+                unshielded: Zatoshi(5),
+                awaitingResolution: Zatoshi(1)
+            )
+
+            // No account is selected in this isolated storage, so `nil` is the matching account
+            // id for the provenance guard -- this test is about pool aggregation, not provenance.
+            await store.send(.updateBalance(balance, nil, 0))
+
+            #expect(store.state.changePending == Zatoshi(40))             // 10 + 30
+            #expect(store.state.pendingTransactions == Zatoshi(60))       // 20 + 40
+            #expect(store.state.shieldedBalance == Zatoshi(300))          // 100 + 200
+            #expect(store.state.transparentBalance == Zatoshi(5))         // unshielded
+            #expect(store.state.shieldedWithPendingBalance == Zatoshi(400)) // 130 + 270 totals
+            #expect(store.state.totalBalance == Zatoshi(406))            // 400 + 5 + 1 awaiting
+            #expect(store.state.spendability == .something)
         }
-        store.exhaustivity = .off
-
-        let balance = AccountBalance(
-            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
-            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
-            unshielded: Zatoshi(5),
-            awaitingResolution: Zatoshi(1)
-        )
-
-        await store.send(.updateBalance(balance))
-
-        #expect(store.state.changePending == Zatoshi(40))             // 10 + 30
-        #expect(store.state.pendingTransactions == Zatoshi(60))       // 20 + 40
-        #expect(store.state.shieldedBalance == Zatoshi(300))          // 100 + 200
-        #expect(store.state.transparentBalance == Zatoshi(5))         // unshielded
-        #expect(store.state.shieldedWithPendingBalance == Zatoshi(400)) // 130 + 270 totals
-        #expect(store.state.totalBalance == Zatoshi(406))            // 400 + 5 + 1 awaiting
-        #expect(store.state.spendability == .something)
     }
 
     // Ironwood is a third shielded pool (NU6.3 / Orchard note-version V3). The reducer must
     // pick it up through the SDK's pool-agnostic `shielded*` accessors on `AccountBalance`
     // rather than a hand-summed sapling+orchard pair, or Ironwood funds would be invisible.
     @MainActor @Test func updateBalanceAggregatesSaplingOrchardIronwoodAndTransparent() async {
-        let store = TestStore(initialState: state(autoShieldingThreshold: Zatoshi(1_000_000))) {
-            Balances()
-        } withDependencies: {
-            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = TestStore(initialState: state(autoShieldingThreshold: Zatoshi(1_000_000))) {
+                Balances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            let balance = AccountBalance(
+                saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+                orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+                ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
+                unshielded: Zatoshi(5),
+                awaitingResolution: Zatoshi(1)
+            )
+
+            // No account is selected in this isolated storage, so `nil` is the matching account
+            // id for the provenance guard -- this test is about pool aggregation, not provenance.
+            await store.send(.updateBalance(balance, nil, 0))
+
+            #expect(store.state.changePending == Zatoshi(90))              // 10 + 30 + 50
+            #expect(store.state.pendingTransactions == Zatoshi(120))       // 20 + 40 + 60
+            #expect(store.state.shieldedBalance == Zatoshi(600))           // 100 + 200 + 300
+            #expect(store.state.transparentBalance == Zatoshi(5))          // unshielded
+            #expect(store.state.shieldedWithPendingBalance == Zatoshi(810)) // 130 + 270 + 410 totals
+            #expect(store.state.totalBalance == Zatoshi(816))              // 810 + 5 + 1 awaiting
+            #expect(store.state.spendability == .something)
         }
-        store.exhaustivity = .off
-
-        let balance = AccountBalance(
-            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
-            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
-            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
-            unshielded: Zatoshi(5),
-            awaitingResolution: Zatoshi(1)
-        )
-
-        await store.send(.updateBalance(balance))
-
-        #expect(store.state.changePending == Zatoshi(90))              // 10 + 30 + 50
-        #expect(store.state.pendingTransactions == Zatoshi(120))       // 20 + 40 + 60
-        #expect(store.state.shieldedBalance == Zatoshi(600))           // 100 + 200 + 300
-        #expect(store.state.transparentBalance == Zatoshi(5))          // unshielded
-        #expect(store.state.shieldedWithPendingBalance == Zatoshi(810)) // 130 + 270 + 410 totals
-        #expect(store.state.totalBalance == Zatoshi(816))              // 810 + 5 + 1 awaiting
-        #expect(store.state.spendability == .something)
     }
 
     @MainActor @Test func shieldingProcessorRequestedMarksShielding() async {
@@ -352,7 +383,7 @@ import ComposableArchitecture
             }
             store.exhaustivity = .off
 
-            await store.send(.updateBalance(pendingSelfShieldBalance()))
+            await store.send(.updateBalance(pendingSelfShieldBalance(), testWalletAccount.id, 0))
 
             #expect(store.state.shieldedBalance == .zero)
             #expect(store.state.transparentBalance == .zero)
@@ -439,7 +470,7 @@ import ComposableArchitecture
             store.exhaustivity = .off
 
             await store.send(.synchronizerStateChanged(syncing.redacted))
-            await store.send(.updateBalance(pendingSelfShieldBalance()))
+            await store.send(.updateBalance(pendingSelfShieldBalance(), testWalletAccount.id, 0))
             #expect(store.state.hasConcreteBalance)
             #expect(store.state.spendability == .something)
 

--- a/zodlTests/RootTransactionsTests/RootAccountSwitchMigrationPendingResetTests.swift
+++ b/zodlTests/RootTransactionsTests/RootAccountSwitchMigrationPendingResetTests.swift
@@ -1,0 +1,116 @@
+//
+//  RootAccountSwitchMigrationPendingResetTests.swift
+//  zodlTests
+//
+//  MOB-1862: `accountSwitchedEffect` (`RootCoordinator.swift`) clears the shared `transactions`
+//  array and its account marker the moment the selected account changes, but left
+//  `unminedMigrationPendingValue` untouched. That figure is derived FROM those same rows
+//  (`RootTransactions.swift`'s `.fetchedTransactions` handler) and read straight into the balance
+//  breakdown's "Pending" row (`Balances.State.displayedPendingBalance`), so a switch could leave
+//  the PREVIOUS account's in-flight-migration figure subtracted from the NEWLY selected account's
+//  pending lanes for however long it takes that account's own transaction fetch to land and
+//  correct it.
+//
+//  Mirrors `RootTransactionsAccountProvenanceTests.swift`'s established pattern: a plain `Store`
+//  (not `TestStore`) driven with a file-scoped `baseNoOpDependencies` baseline. Unlike that file,
+//  the value under test is set directly rather than produced by a real `.fetchedTransactions`
+//  completion -- what is being verified here is the reset itself, not how the figure is derived in
+//  the first place (that is `RootTransactionsMigrationRowsTests.swift`'s job).
+//
+//  `.serialized`: constructing/driving `Root.State` touches the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` / `.inMemory(.walletAccounts)` /
+//  `.inMemory(.unminedMigrationPendingValue)` keys, same precedent as every other Root-level suite
+//  in this directory.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor struct RootAccountSwitchMigrationPendingResetTests {
+    private static func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    /// The exact regression: A leaves a non-zero pending-migration figure behind. B's own
+    /// transaction fetch -- which would eventually recompute the figure from scratch anyway, since
+    /// it lands on the shared `transactions` array `accountSwitchedEffect` already empties -- is
+    /// held on a gate, so this checks the window BEFORE that fetch has any chance to land: the
+    /// figure must already read zero from `accountSwitchedEffect`'s own synchronous reset, not
+    /// however long it takes B's fetch to complete and correct it as a side effect.
+    @Test func accountSwitchResetsUnminedMigrationPendingValueBeforeTheNewFetchLands() async {
+        let accountA = Self.walletAccount(idByte: 140)
+        let accountB = Self.walletAccount(idByte: 141)
+        let gate = ResumableGate()
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = accountA }
+        initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+        initialState.$unminedMigrationPendingValue.withLock { $0 = Zatoshi(12_345) }
+        initialState.homeState.transactionListState.isInvalidated = false
+        initialState.transactionsCoordFlowState.transactionsManagerState.isInvalidated = false
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+            $0.sdkSynchronizer.getAllTransactions = { _ in
+                await gate.wait()
+                return []
+            }
+        }
+
+        #expect(store.state.unminedMigrationPendingValue == Zatoshi(12_345), "setup must land A's non-zero figure before the switch")
+
+        // `Store.send` (unlike `TestStore.send`) runs the reducer's synchronous body immediately
+        // and returns once any effects it starts are merely spawned -- so by the time this call
+        // returns, `accountSwitchedEffect`'s own state mutations have already applied, while B's
+        // gated fetch has not.
+        let switchTask = store.send(.home(.walletAccountTapped(accountB)))
+
+        #expect(
+            store.state.unminedMigrationPendingValue == .zero,
+            "the previous account's figure must not survive an account switch, even before B's own fetch lands"
+        )
+
+        gate.open()
+        await switchTask.finish()
+
+        #expect(store.state.unminedMigrationPendingValue == .zero)
+        #expect(store.state.selectedWalletAccount == accountB)
+    }
+}
+
+/// Shared no-op dependency baseline for this file. Copied from
+/// `RootTransactionsAccountProvenanceTests.swift` per this directory's established convention of
+/// not sharing test helpers across files -- this test drives the same real
+/// `.home(.walletAccountTapped)` action, which also merges in `.loadContacts`/
+/// `.resolveMetadataEncryptionKeys`/`.loadUserMetadata`, and that baseline is already proven to
+/// carry those to completion.
+@MainActor
+private func baseNoOpDependencies(_ values: inout DependencyValues) {
+    values.databaseFiles = .noOp
+    values.derivationTool = .liveValue
+    values.diskSpaceChecker = .mockFullDisk
+    values.flexaHandler = .noOp
+    values.localAuthentication = .mockAuthenticationSucceeded
+    values.mainQueue = .immediate
+    values.mnemonic = .mock
+    values.readTransactionsStorage.resetZashi = { }
+    values.sdkSynchronizer = .noOp
+    values.userMetadataProvider.load = { _ in }
+    values.walletStorage = .noOp
+    values.zcashSDKEnvironment = .testnet
+}

--- a/zodlTests/RootTransactionsTests/RootTransactionsAccountProvenanceTests.swift
+++ b/zodlTests/RootTransactionsTests/RootTransactionsAccountProvenanceTests.swift
@@ -117,6 +117,47 @@ import ComposableArchitecture
         #expect(store.state.selectedWalletAccount == accountB)
     }
 
+    /// The defensive foreign-rows branch above clears `state.transactions`, but
+    /// `unminedMigrationPendingValue` (`RootStore.swift`) is derived from those same rows
+    /// (`.fetchedTransactions`, above) and read straight into the balance breakdown's "Pending"
+    /// row -- so it must be cleared alongside them, not left reading the account just left's
+    /// figure until the newly-selected account's own fetch eventually corrects it as a side
+    /// effect. Reaches the branch with a hand-built fixture rather than the real switch action --
+    /// `accountSwitchedEffect` (`RootCoordinator.swift`) already empties `transactions` on every
+    /// switch, so this defensive branch is only reachable at all with a fixture that deliberately
+    /// disagrees with that invariant, exactly as the surrounding code comment describes.
+    @Test func transactionsFetchFailedClearsUnminedMigrationPendingValueWithForeignRows() async {
+        let accountA = Self.walletAccount(idByte: 128)
+        let accountB = Self.walletAccount(idByte: 129)
+
+        var initialState = Root.State.initial
+        initialState.$selectedWalletAccount.withLock { $0 = accountB }
+        initialState.$walletAccounts.withLock { $0 = [accountA, accountB] }
+        let aRows = IdentifiedArrayOf<TransactionState>(uniqueElements: [tx(id: "a-tx-1")])
+        initialState.$transactions.withLock { $0 = aRows }
+        initialState.transactionsAccountId = accountA.id
+        let previousUnminedMigrationPendingValue = initialState.unminedMigrationPendingValue
+        initialState.$unminedMigrationPendingValue.withLock { $0 = Zatoshi(12_345) }
+        defer { initialState.$unminedMigrationPendingValue.withLock { $0 = previousUnminedMigrationPendingValue } }
+
+        let store = Store(initialState: initialState) {
+            Root()
+        } withDependencies: {
+            baseNoOpDependencies(&$0)
+        }
+
+        // `Store.send` (unlike `TestStore.send`) runs the reducer's synchronous body immediately,
+        // so both assertions below hold as soon as this call returns, with no need to await
+        // whatever effects it also spawns.
+        store.send(.transactionsFetchFailed(accountUUID: accountB.id))
+
+        #expect(store.state.transactions.isEmpty, "the foreign rows must still be cleared")
+        #expect(
+            store.state.unminedMigrationPendingValue == .zero,
+            "the pending-migration figure derived from those same foreign rows must not outlive them"
+        )
+    }
+
     // MARK: - (2) An empty result for the NEW account while syncing must leave it empty, not resurrect the old rows
 
     /// The non-failure sibling of the test above: B's fetch does not throw, it legitimately answers

--- a/zodlTests/WalletBalancesTests/WalletBalancesAccountProvenanceTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesAccountProvenanceTests.swift
@@ -1,0 +1,261 @@
+//
+//  WalletBalancesAccountProvenanceTests.swift
+//  zodlTests
+//
+//  MOB-1862: `WalletBalances.State.balanceUpdated` (a plain `AccountBalance` with no account or
+//  request identity) let a balance read for one account answer for whichever account happened to
+//  be selected by the time the read landed. A slow `getLocalAccountBalances()` call started for
+//  account A, resolving after the user had already switched to account B, would overwrite B's
+//  figures with A's -- silently, with no error surfaced anywhere. A second race lived alongside
+//  it: two `.updateBalances` dispatches for the SAME account, the earlier one answering after the
+//  later one already has, could still let the stale answer win (last-writer-wins on arrival order,
+//  not on which request was actually current).
+//
+//  The fix attributes every `.balanceUpdated` to the account it was read for AND the request that
+//  asked for it -- `WalletBalancesStore.swift`'s `.balanceUpdated(AccountBalance, AccountUUID,
+//  Int)` and `State.balanceRequestGeneration`. The handler drops anything whose account no longer
+//  matches the current selection or whose generation is not the current one. `.updateBalances`
+//  also re-derives `spendability` synchronously, before its own read has any chance to land -- a
+//  switch to an account with no published balance yet must not go on showing the PREVIOUS
+//  account's spendability for however long that read takes.
+//
+//  Mirrors `WalletBalancesMaskedSpendableTests.swift`'s established pattern for this directory:
+//  `TestStore` with `$0.defaultInMemoryStorage = InMemoryStorage()` per test, and the shared
+//  `selectedWalletAccount` slot pinned via `state.$selectedWalletAccount.withLock`. The parked-read
+//  mechanics reuse `TestSupport/TestSignals.swift`'s `ResumableGate`/`SignalledRecords`, the same
+//  event-driven, no-clock primitives `RootTransactionsCoalescingTests.swift` uses to hold a mocked
+//  dependency open on a gate and count calls.
+//
+//  `.serialized`: constructing/driving `WalletBalances.State` touches the process-global
+//  `@Shared(.inMemory(.selectedWalletAccount))` key, same precedent as
+//  `WalletBalancesMaskedSpendableTests.swift`.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+@Suite(.serialized) struct WalletBalancesAccountProvenanceTests {
+    private static func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    /// A full-value balance -- shielded equals total -- so `spendability` derives to `.everything`
+    /// once it is published for the currently selected account.
+    private static func fullyOwnedBalance(_ shielded: Zatoshi) -> AccountBalance {
+        AccountBalance(
+            saplingBalance: .zero,
+            orchardBalance: PoolBalance(spendableValue: shielded, changePendingConfirmation: .zero, valuePendingSpendability: .zero),
+            ironwoodBalance: .zero,
+            unshielded: .zero,
+            awaitingResolution: .zero
+        )
+    }
+
+    // MARK: - (1) A delayed read for the account just left must never answer for the new one
+
+    /// Account A's read is parked on a gate; the user switches to B before it resolves. Releasing
+    /// it must not let A's figures land on B's screen.
+    @MainActor @Test func aDelayedBalanceForThePreviousAccountIsRejectedAfterASwitch() async throws {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let accountA = Self.walletAccount(idByte: 40)
+            let accountB = Self.walletAccount(idByte: 41)
+            let balanceA = Self.fullyOwnedBalance(Zatoshi(500))
+            let gate = ResumableGate()
+
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = accountA }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+                $0.sdkSynchronizer = .mocked(
+                    latestState: { SynchronizerState.zero },
+                    getLocalAccountBalances: {
+                        await gate.wait()
+                        return [accountA.id: balanceA]
+                    }
+                )
+            }
+            store.exhaustivity = .off
+
+            let read = await store.send(.updateBalances)
+
+            // Switch to B while A's read is still parked on the gate.
+            store.state.$selectedWalletAccount.withLock { $0 = accountB }
+
+            gate.open()
+            // `.receive` is what actually applies a effect-sent action's resulting state to
+            // `store.state` -- `finish()` alone only waits for the effect's task to physically
+            // complete, it does not drain the action itself (`TestStore`'s `.receive`/exhaustivity
+            // machinery does that).
+            await store.receive(\.balanceUpdated)
+            await read.finish()
+
+            #expect(!store.state.hasConcreteBalance, "nothing has been published for B yet")
+            #expect(store.state.shieldedBalance == .zero, "A's amounts must not be stored for B")
+        }
+    }
+
+    // MARK: - (2) The new account's own, non-conflicting result still becomes concrete
+
+    /// The positive counterpart of the test above: B requests and receives its OWN balance, with
+    /// no switch or stale read involved. This path was never broken -- it guards against the fix
+    /// over-correcting into rejecting legitimate, matching responses too.
+    @MainActor @Test func theNewAccountsOwnResultBecomesConcrete() async throws {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let accountB = Self.walletAccount(idByte: 46)
+            let balanceB = Self.fullyOwnedBalance(Zatoshi(750))
+
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = accountB }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+                $0.sdkSynchronizer = .mocked(
+                    latestState: { SynchronizerState.zero },
+                    getLocalAccountBalances: { [accountB.id: balanceB] }
+                )
+            }
+            store.exhaustivity = .off
+
+            await store.send(.updateBalances)
+            await store.receive(\.balanceUpdated)
+
+            #expect(store.state.hasConcreteBalance)
+            #expect(store.state.shieldedBalance == balanceB.shieldedSpendableValue)
+            #expect(store.state.spendability == .everything)
+        }
+    }
+
+    // MARK: - (3) A stale request's answer must not overwrite a fresher one, even for the SAME account
+
+    /// A→B→A: the first request (generation 1, for A) is parked; two more requests land and
+    /// resolve immediately before it is released -- the second for B (which answers nothing), the
+    /// third back on A (generation 3, with a fresh figure). Releasing the first must not let its
+    /// now-superseded answer overwrite the third's, even though both answer for A.
+    @MainActor @Test func aStaleRequestGenerationIsDropped() async throws {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let accountA = Self.walletAccount(idByte: 42)
+            let accountB = Self.walletAccount(idByte: 43)
+            let staleBalance = Self.fullyOwnedBalance(Zatoshi(111))
+            let freshBalance = Self.fullyOwnedBalance(Zatoshi(999))
+            let gate = ResumableGate()
+            let fetchCalls = SignalledRecords<Void>()
+
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = accountA }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+                $0.sdkSynchronizer = .mocked(
+                    latestState: { SynchronizerState.zero },
+                    getLocalAccountBalances: {
+                        let ordinal = fetchCalls.recordCall()
+                        if ordinal == 1 {
+                            await gate.wait()
+                            return [accountA.id: staleBalance]
+                        }
+                        return [accountA.id: freshBalance]
+                    }
+                )
+            }
+            store.exhaustivity = .off
+
+            // Request #1 for A parks on the gate.
+            let firstRead = await store.send(.updateBalances)
+            await fetchCalls.countReached(1)
+
+            // Request #2, for B: resolves immediately, answers nothing (no entry for B).
+            store.state.$selectedWalletAccount.withLock { $0 = accountB }
+            await store.send(.updateBalances).finish()
+
+            // Request #3, back on A: resolves immediately with the fresh figure.
+            store.state.$selectedWalletAccount.withLock { $0 = accountA }
+            let thirdRead = await store.send(.updateBalances)
+            await store.receive(\.balanceUpdated)
+            await thirdRead.finish()
+
+            #expect(store.state.shieldedBalance == freshBalance.shieldedSpendableValue)
+
+            // Release request #1's now-stale answer.
+            gate.open()
+            await store.receive(\.balanceUpdated)
+            await firstRead.finish()
+
+            #expect(
+                store.state.shieldedBalance == freshBalance.shieldedSpendableValue,
+                "a superseded request's answer must never overwrite a newer request's own result"
+            )
+        }
+    }
+
+    // MARK: - (4) An account switch re-derives spendability from its own dispatch, not the next tick
+
+    /// A is syncing and has a concrete, fully-spendable balance. Switching to B and immediately
+    /// dispatching a fresh read must stop `spendability` from answering for A before that read has
+    /// any chance to land -- not wait for whatever synchronizer tick happens to come next.
+    @MainActor @Test func selectionChangeRederivesSpendabilityBeforeAnyTick() async throws {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let accountA = Self.walletAccount(idByte: 44)
+            let accountB = Self.walletAccount(idByte: 45)
+            let balanceA = Self.fullyOwnedBalance(Zatoshi(500))
+
+            var syncing = SynchronizerState.zero
+            syncing.syncStatus = .syncing(0.5, false)
+
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = accountA }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+                $0.sdkSynchronizer = .mocked(
+                    latestState: { SynchronizerState.zero },
+                    getLocalAccountBalances: { [accountA.id: balanceA] }
+                )
+            }
+            store.exhaustivity = .off
+
+            await store.send(.synchronizerStateChanged(syncing.redacted))
+            let firstUpdate = await store.send(.updateBalances)
+            await store.receive(\.balanceUpdated)
+            await firstUpdate.finish()
+            #expect(store.state.hasConcreteBalance)
+            #expect(store.state.spendability == .everything)
+
+            // Switch to B -- nothing has been published for it yet, and the sync is still
+            // running, so the switch alone makes B's answer unresolved.
+            store.state.$selectedWalletAccount.withLock { $0 = accountB }
+
+            let request = await store.send(.updateBalances)
+            #expect(
+                store.state.spendability == .nothing,
+                "must not go on answering with A's spendability while B's own request is still in flight"
+            )
+            await request.finish()
+        }
+    }
+}

--- a/zodlTests/WalletBalancesTests/WalletBalancesMaskedSpendableTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesMaskedSpendableTests.swift
@@ -206,7 +206,7 @@ import ComposableArchitecture
             }
             store.exhaustivity = .off
 
-            await store.send(.balanceUpdated(pendingSelfShieldBalance()))
+            await store.send(.balanceUpdated(pendingSelfShieldBalance(), testWalletAccount.id, 0))
 
             #expect(store.state.shieldedBalance == .zero)
             #expect(store.state.transparentBalance == .zero)
@@ -239,7 +239,7 @@ import ComposableArchitecture
             #expect(!store.state.hasConcreteBalance)
             #expect(store.state.isProcessingZeroAvailableBalance)
 
-            await store.send(.balanceUpdated(pendingSelfShieldBalance()))
+            await store.send(.balanceUpdated(pendingSelfShieldBalance(), testWalletAccount.id, 0))
             #expect(store.state.hasConcreteBalance)
             #expect(!store.state.isProcessingZeroAvailableBalance)
         }
@@ -267,7 +267,7 @@ import ComposableArchitecture
             store.exhaustivity = .off
 
             await store.send(.synchronizerStateChanged(syncing.redacted))
-            await store.send(.balanceUpdated(pendingSelfShieldBalance()))
+            await store.send(.balanceUpdated(pendingSelfShieldBalance(), testWalletAccount.id, 0))
             #expect(store.state.hasConcreteBalance)
             #expect(store.state.spendability == .something)
 

--- a/zodlTests/WalletBalancesTests/WalletBalancesPoolDisplayTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesPoolDisplayTests.swift
@@ -13,11 +13,23 @@ import Testing
 @testable @preconcurrency import ZcashLightClientKit
 
 @Suite(.serialized) struct WalletBalancesPoolDisplayTests {
+    private static let testAccount = WalletAccount(
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 30, count: 16)),
+            name: "Zodl",
+            keySource: nil,
+            seedFingerprint: nil,
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    )
+
     @MainActor @Test func poolFiguresUseRawSDKBalances() async {
         let store = makeStore()
         let balance = fullPoolAccountBalance()
 
-        await store.send(.balanceUpdated(balance))
+        await store.send(.balanceUpdated(balance, Self.testAccount.id, 0))
 
         #expect(store.state.ironwoodPoolBalance == balance.ironwoodBalance.total())
         #expect(store.state.orchardPoolBalance == balance.orchardBalance.total())
@@ -30,7 +42,7 @@ import Testing
 
     @MainActor @Test func poolBalancesSumToTotal() async {
         let store = makeStore()
-        await store.send(.balanceUpdated(fullPoolAccountBalance()))
+        await store.send(.balanceUpdated(fullPoolAccountBalance(), Self.testAccount.id, 0))
 
         let sum = store.state.saplingPoolBalance
             + store.state.orchardPoolBalance
@@ -59,7 +71,7 @@ import Testing
             awaitingResolution: .zero
         )
 
-        await store.send(.balanceUpdated(balance))
+        await store.send(.balanceUpdated(balance, Self.testAccount.id, 0))
 
         #expect(store.state.orchardPoolBalance == Zatoshi(722_845_000))
         #expect(store.state.ironwoodPoolBalance == Zatoshi(277_000_000))
@@ -134,13 +146,19 @@ import Testing
 
     @MainActor
     private func makeStore() -> TestStoreOf<WalletBalances> {
-        let store = TestStore(initialState: WalletBalances.State()) {
-            WalletBalances()
-        } withDependencies: {
-            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
-            $0.migrationManager = .noOp
+        withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = Self.testAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+                $0.migrationManager = .noOp
+            }
+            store.exhaustivity = .off
+            return store
         }
-        store.exhaustivity = .off
-        return store
     }
 }

--- a/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
+++ b/zodlTests/WalletBalancesTests/WalletBalancesTests.swift
@@ -14,6 +14,20 @@ import ComposableArchitecture
 @testable @preconcurrency import ZcashLightClientKit
 
 @Suite(.serialized) struct WalletBalancesTests {
+    /// A stand-in account for the pool-aggregation tests below, which only care about how
+    /// `.balanceUpdated` shapes a payload into state, not about account provenance.
+    private static let poolTestAccount = WalletAccount(
+        Account(
+            id: AccountUUID(id: [UInt8](repeating: 20, count: 16)),
+            name: "Zodl",
+            keySource: nil,
+            seedFingerprint: nil,
+            hdAccountIndex: Zip32AccountIndex(0),
+            ufvk: nil,
+            uivk: nil
+        )
+    )
+
     // MARK: - Computed props
 
     /// "Processing with zero available" means the spendable value is still being worked out. No
@@ -76,79 +90,103 @@ import ComposableArchitecture
     // pick it up through the SDK's pool-agnostic `shielded*` accessors on `AccountBalance`
     // rather than a hand-summed sapling+orchard pair, or Ironwood funds would be invisible.
     @MainActor @Test func balanceUpdatedAggregatesSaplingOrchardIronwoodAndTransparent() async {
-        let store = TestStore(initialState: WalletBalances.State()) {
-            WalletBalances()
-        } withDependencies: {
-            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = Self.poolTestAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            let balance = AccountBalance(
+                saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
+                orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
+                ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
+                unshielded: Zatoshi(5),
+                awaitingResolution: Zatoshi(1)
+            )
+
+            await store.send(.balanceUpdated(balance, Self.poolTestAccount.id, 0))
+
+            #expect(store.state.shieldedBalance == Zatoshi(600))            // 100 + 200 + 300 spendable
+            #expect(store.state.shieldedWithPendingBalance == Zatoshi(810)) // 130 + 270 + 410 totals
+            #expect(store.state.transparentBalance == Zatoshi(5))           // unshielded
+            #expect(store.state.totalBalance == Zatoshi(816))               // 810 + 5 + 1 awaiting
         }
-        store.exhaustivity = .off
-
-        let balance = AccountBalance(
-            saplingBalance: PoolBalance(spendableValue: Zatoshi(100), changePendingConfirmation: Zatoshi(10), valuePendingSpendability: Zatoshi(20)),
-            orchardBalance: PoolBalance(spendableValue: Zatoshi(200), changePendingConfirmation: Zatoshi(30), valuePendingSpendability: Zatoshi(40)),
-            ironwoodBalance: PoolBalance(spendableValue: Zatoshi(300), changePendingConfirmation: Zatoshi(50), valuePendingSpendability: Zatoshi(60)),
-            unshielded: Zatoshi(5),
-            awaitingResolution: Zatoshi(1)
-        )
-
-        await store.send(.balanceUpdated(balance))
-
-        #expect(store.state.shieldedBalance == Zatoshi(600))            // 100 + 200 + 300 spendable
-        #expect(store.state.shieldedWithPendingBalance == Zatoshi(810)) // 130 + 270 + 410 totals
-        #expect(store.state.transparentBalance == Zatoshi(5))           // unshielded
-        #expect(store.state.totalBalance == Zatoshi(816))               // 810 + 5 + 1 awaiting
     }
 
     // MARK: - Pool balances
 
     @MainActor @Test func balanceUpdatedPopulatesPerPoolBalances() async {
-        let store = TestStore(initialState: WalletBalances.State()) {
-            WalletBalances()
-        } withDependencies: {
-            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = Self.poolTestAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            let balance = fullPoolAccountBalance()
+            await store.send(.balanceUpdated(balance, Self.poolTestAccount.id, 0))
+
+            #expect(store.state.saplingPoolBalance == balance.saplingBalance.total())
+            #expect(store.state.orchardPoolBalance == balance.orchardBalance.total())
+            #expect(store.state.ironwoodPoolBalance == balance.ironwoodBalance.total())
+            #expect(store.state.awaitingResolutionBalance == balance.awaitingResolution)
         }
-        store.exhaustivity = .off
-
-        let balance = fullPoolAccountBalance()
-        await store.send(.balanceUpdated(balance))
-
-        #expect(store.state.saplingPoolBalance == balance.saplingBalance.total())
-        #expect(store.state.orchardPoolBalance == balance.orchardBalance.total())
-        #expect(store.state.ironwoodPoolBalance == balance.ironwoodBalance.total())
-        #expect(store.state.awaitingResolutionBalance == balance.awaitingResolution)
     }
 
     @MainActor @Test func transparentPoolBalanceIncludesAwaitingResolution() async {
-        let store = TestStore(initialState: WalletBalances.State()) {
-            WalletBalances()
-        } withDependencies: {
-            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = Self.poolTestAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.balanceUpdated(fullPoolAccountBalance(), Self.poolTestAccount.id, 0))
+
+            #expect(store.state.transparentPoolBalance == store.state.transparentBalance + store.state.awaitingResolutionBalance)
         }
-        store.exhaustivity = .off
-
-        await store.send(.balanceUpdated(fullPoolAccountBalance()))
-
-        #expect(store.state.transparentPoolBalance == store.state.transparentBalance + store.state.awaitingResolutionBalance)
     }
 
     // The four displayed pool values must sum to totalBalance in every sync state — that
     // identity is what lets the pool-breakdown sheet show numbers that add up to the
     // home-screen total.
     @MainActor @Test func poolBalancesSumToTotalBalance() async {
-        let store = TestStore(initialState: WalletBalances.State()) {
-            WalletBalances()
-        } withDependencies: {
-            $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = WalletBalances.State()
+            state.$selectedWalletAccount.withLock { $0 = Self.poolTestAccount }
+            let store = TestStore(initialState: state) {
+                WalletBalances()
+            } withDependencies: {
+                $0.zcashSDKEnvironment.shieldingThreshold = { Zatoshi(1_000_000) }
+            }
+            store.exhaustivity = .off
+
+            await store.send(.balanceUpdated(fullPoolAccountBalance(), Self.poolTestAccount.id, 0))
+
+            let sum = store.state.saplingPoolBalance
+                + store.state.orchardPoolBalance
+                + store.state.ironwoodPoolBalance
+                + store.state.transparentPoolBalance
+            #expect(sum == store.state.totalBalance)
         }
-        store.exhaustivity = .off
-
-        await store.send(.balanceUpdated(fullPoolAccountBalance()))
-
-        let sum = store.state.saplingPoolBalance
-            + store.state.orchardPoolBalance
-            + store.state.ironwoodPoolBalance
-            + store.state.transparentPoolBalance
-        #expect(sum == store.state.totalBalance)
     }
 
     @MainActor @Test func synchronizerStateWithoutSelectedAccountEntryRetainsLastConcreteBalance() async {
@@ -176,7 +214,7 @@ import ComposableArchitecture
             store.exhaustivity = .off
 
             let balance = fullPoolAccountBalance()
-            await store.send(.balanceUpdated(balance))
+            await store.send(.balanceUpdated(balance, account.id, 0))
             await store.send(.synchronizerStateChanged(SynchronizerState.zero.redacted))
 
             #expect(store.state.saplingPoolBalance == balance.saplingBalance.total())


### PR DESCRIPTION
## Summary

Balance responses now carry the account they were looked up for and the request they answer. After switching accounts, a balance that was still loading for the previous account can no longer be stored as the new account's balance, and a response to an earlier request can no longer overwrite a later one.

- `WalletBalances` and the balance breakdown (`Balances`) tag every balance send with the account id and a per-request generation; the handler drops anything that no longer matches the selected account or the current request.
- Selecting a different account re-derives spendability immediately, before any balance for it arrives, so the previous account's "everything spendable" state does not linger on the new one.
- While the SDK still masks the spendable value, the breakdown shows the spendable row with a progress indicator and the "syncing" header copy instead of presenting the carried-forward number as final.
- The shared unmined-migration pending figure, which the breakdown subtracts from its Pending row, is now reset when the account changes and when a failed fetch clears rows that belonged to another account, so it cannot reduce the newly selected account's pending amount.

## Tests

New `WalletBalancesAccountProvenanceTests` (delayed previous-account balance rejected after a switch; the new account's own result becomes concrete; stale request generation dropped; selection change re-derives spendability), `RootAccountSwitchMigrationPendingResetTests`, a breakdown "updating while masked" case in `BalancesTests`, and a failure-path case in `RootTransactionsAccountProvenanceTests`. Existing balance suites adapted to the new action shapes.

Verified locally with the `zodl-internal` scheme: build succeeded; 70 tests in 9 suites passed (balance, breakdown, Root transactions and account-switch suites), plus the Send and Swap max-button suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
