### PR TITLE
[MOB-1854] Replay a deferred retryStart and tag pipelines so stale completions cannot release a newer one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 - [MOB-1863] A sent transaction now shows "Sent · awaiting confirmation" once a server has accepted it, instead of "Sending" until the wallet catches up.
 
 ### Fixed
+- [MOB-1854] Sync now resumes after a migration broadcast even when the resume request arrives while the previous start is still finishing.
 - [MOB-1862] After switching accounts, a balance or pending amount that was still loading for the previous account can no longer be shown as the new account's, and the balance breakdown shows that the spendable amount is still updating while the wallet confirms it.
 - [MOB-1862] The balance breakdown now shows the same spendable and pending amounts as the home screen, instead of zeros, while the wallet is still checking the chain. During that check the balance is shown as updating and Send and Swap wait for it rather than claiming you have insufficient funds, and funds that are merely waiting for confirmations no longer leave the balance spinning as if nothing could be spent. Swapping another asset into ZEC no longer waits for the wallet's spendable balance to be confirmed, since that swap doesn't spend it.
 - [MOB-1860] Leaving a voting screen while a proof is being prepared stops that work instead of letting it run in the background.

--- a/secant/Sources/Features/Root/RootInitialization.swift
+++ b/secant/Sources/Features/Root/RootInitialization.swift
@@ -87,9 +87,17 @@ extension Root {
         case restoreExistingWallet
         case seedValidationResult(Bool)
         case synchronizerStartFailed(ZcashError)
-        case registerForSynchronizersUpdate
+        /// MOB-1854: `generation` is `nil` for a call that did not originate from a `.retryStart`
+        /// pipeline (cold launch's `.initializeSDK` cascade) — always accepted. A non-nil generation
+        /// is a `.retryStart` pipeline's own tag; it is honored only while it still matches
+        /// `Root.State.retryStartGeneration`, so a pipeline superseded by a newer one (background,
+        /// or a fresh `.retryStart`) can never re-subscribe the synchronizer streams on its behalf.
+        case registerForSynchronizersUpdate(generation: Int?)
         case retryStart
-        case retryStartFinished
+        /// MOB-1854: tagged with the generation the admitting `.retryStart` assigned its pipeline —
+        /// see `Root.State.retryStartGeneration`'s doc for why a stale tag must not release a newer
+        /// pipeline's latch.
+        case retryStartFinished(generation: Int)
         case walletConfigChanged(WalletConfig)
     }
 
@@ -237,6 +245,14 @@ extension Root {
                 // MOB-1854: a pipeline whose finishing `send(.retryStartFinished)` was dropped by
                 // cancellation (store teardown) must never wedge the next foreground's retryStart.
                 state.isRetryStartInFlight = false
+                // MOB-1854 follow-up: bump the generation so a pre-background pipeline that is
+                // still somehow running (its `.run` effect carries no cancellable id of its own)
+                // cannot have its eventual `.retryStartFinished`/`.registerForSynchronizersUpdate`
+                // mistaken for the pipeline the next foreground's `.retryStart` admits. A request
+                // dropped behind the OLD pipeline is moot once backgrounding has already reset the
+                // latch — the next foreground starts its own resume from scratch.
+                state.retryStartGeneration += 1
+                state.retryStartRequestedWhileInFlight = false
                 // Tear down ALL synchronizer-driven subscriptions (plus the pending-transactions
                 // poller) over the now-stopped synchronizer; `.retryStart` on foreground rebuilds
                 // every one of them.
@@ -766,23 +782,33 @@ extension Root {
                 }
                 // (The Send-now silence-window fence read that lived here was REMOVED 2026-08-07
                 // with the Send-now lanes — nothing sets the fence anymore.)
-                // PAST the guards: consume the migration-resume arming flags (audit 2026-08-03,
-                // #12 — see the gate-resume comment above). An early return above leaves them
-                // armed so the gate's next emission can retry the whole resume.
-                state.syncDeferredByMigrationGate = false
-                @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
-                $migrationStoppedSyncForBroadcast.withLock { $0 = false }
                 // MOB-1854: drop a re-entrant retryStart rather than cancelling the in-flight
                 // pipeline — `SlipstreamSynchronizer.start()` has no cancellation points, so
                 // cancelling it mid-flight would let it run to completion anyway and a second
                 // pipeline would then call `start()` again, draining and restarting the engine. The
                 // in-flight pipeline performs the same work this one would have.
+                //
+                // MOB-1854 follow-up: checked BEFORE the migration-resume flags below are touched.
+                // The in-flight pipeline may be a broadcast-only pass that never calls `start()` at
+                // all, so a request dropped here is not lost — it is replayed once, by the in-flight
+                // pipeline's own `.retryStartFinished`, and until then the resume flags must stay
+                // exactly as armed as they were, not consumed by a request that never actually ran.
                 guard !state.isRetryStartInFlight else {
-                    LoggerProxy.event("[Root] retryStart ignored: a start pipeline is already in flight")
+                    state.retryStartRequestedWhileInFlight = true
+                    LoggerProxy.event("[Root] retryStart deferred: a start pipeline is already in flight")
                     return .none
                 }
+                // PAST the guards: consume the migration-resume arming flags (audit 2026-08-03,
+                // #12 — see the gate-resume comment above). An early return above leaves them
+                // armed so the gate's next emission (or the in-flight pipeline's own finish) can
+                // retry the whole resume.
+                state.syncDeferredByMigrationGate = false
+                @Shared(.inMemory(.migrationStoppedSyncForBroadcast)) var migrationStoppedSyncForBroadcast: Bool = false
+                $migrationStoppedSyncForBroadcast.withLock { $0 = false }
                 state.isRetryStartInFlight = true
-                return .run { [state] send in
+                state.retryStartGeneration += 1
+                let generation = state.retryStartGeneration
+                return .run { [state, generation] send in
                     do {
                         // ZIP 318 session separation, decided BEFORE the wire is touched: if any
                         // account has a proven transfer due, this open is a BROADCAST session and
@@ -890,7 +916,7 @@ extension Root {
                         // repairs a dropped nudge on every registration that genuinely happens —
                         // this only stops a no-op pass from manufacturing one.
                         if startedSyncThisPass {
-                            await send(.initialization(.registerForSynchronizersUpdate))
+                            await send(.initialization(.registerForSynchronizersUpdate(generation: generation)))
                         }
                         // Backgrounding cancels the transaction subscriptions (event stream and
                         // `.upToDate` fetch trigger); without re-establishing them here, the first
@@ -907,7 +933,7 @@ extension Root {
                         // MOB-1854: clears `isRetryStartInFlight` — must be the LAST statement of
                         // this exit path so a re-entrant retryStart is only ever dropped while this
                         // pipeline is genuinely still doing something.
-                        await send(.initialization(.retryStartFinished))
+                        await send(.initialization(.retryStartFinished(generation: generation)))
                     } catch {
                         if state.bgTask != nil {
                             LoggerProxy.event("BGTask synchronizer.start() failed \(error.toZcashError())")
@@ -917,19 +943,35 @@ extension Root {
                         // transient start error left BOTH the sync state stream and the migration
                         // gate feed unsubscribed for the whole foreground — no edges, no gate
                         // emissions, no resume until the next background→foreground round trip.
-                        await send(.initialization(.registerForSynchronizersUpdate))
+                        await send(.initialization(.registerForSynchronizersUpdate(generation: generation)))
                         await send(.initialization(.synchronizerStartFailed(error.toZcashError())))
                         // MOB-1854: same latch clear as the success path above — the last statement
                         // of this exit path too, so a start failure can't leave retryStart wedged.
-                        await send(.initialization(.retryStartFinished))
+                        await send(.initialization(.retryStartFinished(generation: generation)))
                     }
                 }
 
-            case .initialization(.retryStartFinished):
+            case .initialization(.retryStartFinished(let generation)):
+                // MOB-1854: a pipeline superseded by a newer one (background, or a fresh admitted
+                // retryStart) must not release that newer pipeline's latch — only the CURRENT
+                // generation's own finish may clear it.
+                guard generation == state.retryStartGeneration else { return .none }
                 state.isRetryStartInFlight = false
-                return .none
+                // A request dropped while this pipeline was in flight is replayed exactly once,
+                // now that this (still-current) pipeline is actually done — see the deferred guard
+                // in `.retryStart` above.
+                guard state.retryStartRequestedWhileInFlight else { return .none }
+                state.retryStartRequestedWhileInFlight = false
+                return .send(.initialization(.retryStart))
 
-            case .initialization(.registerForSynchronizersUpdate):
+            case .initialization(.registerForSynchronizersUpdate(let generation)):
+                // MOB-1854: `nil` (the cold-launch call site) is always honored; a `.retryStart`
+                // pipeline's own generation is honored only while it is still current — a pipeline
+                // superseded by a newer one must not re-subscribe the synchronizer streams on that
+                // newer pipeline's behalf.
+                if let generation, generation != state.retryStartGeneration {
+                    return .none
+                }
                 let stateStreamEffect = Effect.publisher {
                     sdkSynchronizer.stateStream()
                         .throttle(for: .seconds(0.2), scheduler: mainQueue, latest: true)
@@ -1317,7 +1359,7 @@ extension Root {
                 // going to do, so there is nothing to defer and nothing to replay. Entry parity
                 // stopped being maintained and became structural.
                 return .merge(
-                    .send(.initialization(.registerForSynchronizersUpdate)),
+                    .send(.initialization(.registerForSynchronizersUpdate(generation: nil))),
                     // Audit 2026-08-03 (#6): the launch-time sweep the snapshot docs always named
                     // but nothing implemented. A provisional network snapshot formed at the Tor
                     // sheet and abandoned (flow closed, app killed before commit) otherwise

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -155,6 +155,19 @@ struct Root {
         /// cancelling the in-flight pipeline. Reset at `.didEnterBackground` so a pipeline whose
         /// finishing `send` was dropped by cancellation can never wedge the next foreground.
         var isRetryStartInFlight = false
+        /// MOB-1854: which admitted `.retryStart` pipeline owns the latch above, incremented every
+        /// time one is admitted (and at `.didEnterBackground`, so a pipeline still running when the
+        /// app backgrounds can never be mistaken for the one a later foreground starts). Tags
+        /// `.retryStartFinished`/`.registerForSynchronizersUpdate` so a stale pipeline's completion
+        /// can neither release a newer pipeline's latch nor re-subscribe the synchronizer streams on
+        /// its behalf.
+        var retryStartGeneration = 0
+        /// MOB-1854: set when `.retryStart` is dropped because a pipeline is already in flight —
+        /// that pipeline may be a broadcast-only pass that never calls `start()`, so the request must
+        /// not simply be lost. Consumed (and replayed once, via `.send(.retryStart)`) by that
+        /// pipeline's own `.retryStartFinished`; reset at `.didEnterBackground` along with the latch
+        /// it shadows.
+        var retryStartRequestedWhileInFlight = false
         var isStaleWalletHealedAlertPending = false
         /// MOB-1853: true from the stall hook's own reaction (`gaveUp || attempt >= 2`, see
         /// `Root.Action.syncStalled`'s handler) until the next `.synchronizerStateChanged` reports

--- a/zodlTests/TestSupport/TestSignals.swift
+++ b/zodlTests/TestSupport/TestSignals.swift
@@ -37,6 +37,7 @@ final class SignalledRecords<Element: Sendable>: @unchecked Sendable {
 
     var values: [Element] { state.withLockUnchecked { $0.records } }
     var count: Int { state.withLockUnchecked { $0.records.count } }
+    var isEmpty: Bool { state.withLockUnchecked { $0.records.isEmpty } }
 
     /// Appends `element`, resumes every waiter the updated history now satisfies, and returns
     /// the new record count (this call's ordinal, for mocks that branch on it).

--- a/zodlTests/UtilTests/RootRetryStartReentrancyTests.swift
+++ b/zodlTests/UtilTests/RootRetryStartReentrancyTests.swift
@@ -12,6 +12,16 @@
 //  `.retryStartFinished` — sent as the last statement of both the success and failure exits of the
 //  `.run` effect — clears the latch once that pipeline is done.
 //
+//  MOB-1854 follow-up: a dropped `.retryStart` is not lost. The pipeline it was dropped behind may
+//  be a broadcast-only pass that never calls `start()` at all, so simply dropping the request could
+//  leave sync unresumed for the rest of the session. Each admitted pipeline is tagged with a
+//  generation (`Root.State.retryStartGeneration`); a request dropped while one is in flight arms
+//  `retryStartRequestedWhileInFlight` instead of clearing the migration-resume flags, and the
+//  in-flight pipeline's own `.retryStartFinished` replays it exactly once. `.retryStartFinished` and
+//  `.registerForSynchronizersUpdate` both carry the generation they were sent for, so a pipeline that
+//  finishes (or registers) after a newer one has already taken over can neither release that newer
+//  pipeline's latch nor re-subscribe the synchronizer streams on its behalf.
+//
 //  This suite holds `sdkSynchronizer.start` open on a gate to drive the race directly, mirroring
 //  `RootInitializeSDKSingleFlightTests`' `PrepareGate` pattern (itself the single-flight precedent
 //  for `isInitializingSDK`/`initializeSDKFinished`) and reusing `RootMigrationGateRefusalTests`'
@@ -28,7 +38,9 @@ import Testing
 // Serialized per repo convention for suites driving `.retryStart`/`.didEnterBackground` through a
 // real TestStore — see RootMigrationGateRefusalTests' identical `@Suite(.serialized)` rationale.
 // `.timeLimit` records a gate that genuinely never opens (or a finishing action that genuinely never
-// arrives) as a failure instead of hanging the run.
+// arrives) as a failure instead of hanging the run. Every wait a test actually depends on for its
+// pass/fail outcome also carries its own short, explicit timeout (see `.receive(timeout:)` below) so
+// a real regression fails in seconds rather than riding this suite-wide backstop.
 @Suite(.serialized, .timeLimit(.minutes(3))) @MainActor struct RootRetryStartReentrancyTests {
     private static let seedDerivedAccount = WalletAccount(
         Account(
@@ -42,17 +54,8 @@ import Testing
         )
     )
 
-    /// Builds a `Root` `TestStore` wired for a full, successful sync-branch `.retryStart` pass —
-    /// the same dependency shape as `RootMigrationGateRefusalTests.syncPassStillReRegistersSynchronizerStreams`.
-    /// Every `sdkSynchronizer.start` call is recorded into `startCalls` and then suspends on `gate`
-    /// until the test releases it, holding the pipeline "in flight" for as long as the race needs
-    /// the window held open.
-    private func makeStore(
-        startCalls: SignalledRecords<Void>,
-        gate: ResumableGate
-    ) -> TestStore<Root.State, Root.Action> {
-        let seedDerivedAccount = RootRetryStartReentrancyTests.seedDerivedAccount
-        let initialState = Root.State(
+    private static func makeInitialState() -> Root.State {
+        Root.State(
             destinationState: Root.DestinationState(internalDestination: .home),
             exportLogsState: ExportLogs.State(),
             onboardingState: RestoreWalletCoordFlow.State(),
@@ -60,62 +63,207 @@ import Testing
             walletConfig: .initial,
             welcomeState: Welcome.State()
         )
+    }
 
-        let store = TestStore(
-            initialState: initialState
-        ) {
-            Root()
-        } withDependencies: {
-            $0.mainQueue = .immediate
-            $0.continuousClock = TestClock()
+    /// Builds a `Root` `TestStore` wired for a full, successful sync-branch `.retryStart` pass —
+    /// the same dependency shape as `RootMigrationGateRefusalTests.syncPassStillReRegistersSynchronizerStreams`.
+    /// Every `sdkSynchronizer.start` call is recorded into `startCalls` and then parks on
+    /// `gates[min(ordinal, gates.count) - 1]` (1-based call ordinal) until the test releases that
+    /// gate — a single shared gate (the `gate:` overload below) holds every pipeline behind the
+    /// same latch, while a per-pipeline `gates:` array lets a test release one pipeline's `start()`
+    /// without releasing another's, which is what the generation tests need to drive a stale
+    /// completion independently of the pipeline that currently owns the latch.
+    ///
+    /// `isMigrationSyncBlockedCalls`, when supplied, records every `sdkSynchronizer.isMigrationSyncBlocked()`
+    /// call — the first thing `.registerForSynchronizersUpdate`'s subscription effect does — so a
+    /// test can prove a generation-stale register never re-subscribed anything, without needing a
+    /// production seam beyond the generation guard itself.
+    private func makeStore(
+        startCalls: SignalledRecords<Void>,
+        gates: [ResumableGate],
+        isMigrationSyncBlockedCalls: SignalledRecords<Void>? = nil
+    ) -> TestStore<Root.State, Root.Action> {
+        let seedDerivedAccount = RootRetryStartReentrancyTests.seedDerivedAccount
 
-            $0.exchangeRate = .noOp
-            $0.autolockHandler = .noOp
-            $0.shieldingProcessor = ShieldingProcessorClient(
-                observe: { Empty().eraseToAnyPublisher() },
-                shieldFunds: { }
-            )
+        // Pinned to a fresh, per-call `InMemoryStorage` — `Root.State` and the `TestStore` must be
+        // created INSIDE this scope, since every `@Shared(.inMemory(...))` slot (including the ones
+        // `RootInitialization.swift` reads/writes locally, like `.migrationStoppedSyncForBroadcast`)
+        // binds to whichever storage is current at the moment its owning state/reducer code runs.
+        // Left unpinned, this suite would share the process-global default storage with every other
+        // suite exercising the same slots (e.g. `RootMigrationTickLoopTests`), which — since Swift
+        // Testing runs different suites' tests concurrently — can flip a flag this suite depends on
+        // out from under it mid-test. See `RootTerminalStallRebuildTests.swift`'s identical pinning.
+        return withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = TestStore(
+                initialState: RootRetryStartReentrancyTests.makeInitialState()
+            ) {
+                Root()
+            } withDependencies: {
+                $0.mainQueue = .immediate
+                $0.continuousClock = TestClock()
 
-            $0.mnemonic = .noOp
-            $0.databaseFiles = .noOp
+                $0.exchangeRate = .noOp
+                $0.autolockHandler = .noOp
+                $0.shieldingProcessor = ShieldingProcessorClient(
+                    observe: { Empty().eraseToAnyPublisher() },
+                    shieldFunds: { }
+                )
 
-            $0.walletStorage = .noOp
-            $0.walletStorage.exportWallet = { .placeholder }
+                $0.mnemonic = .noOp
+                $0.databaseFiles = .noOp
 
-            $0.flexaHandler = .noOp
-            $0.flexaHandler.signOut = { }
+                $0.walletStorage = .noOp
+                $0.walletStorage.exportWallet = { .placeholder }
 
-            $0.userStoredPreferences.removeAll = { }
-            $0.readTransactionsStorage = .noOp
+                $0.flexaHandler = .noOp
+                $0.flexaHandler.signOut = { }
 
-            $0.userDefaults.objectForKey = { _ in nil }
-            $0.userDefaults.remove = { _ in }
-            $0.userDefaults.setValue = { _, _ in }
+                $0.userStoredPreferences.removeAll = { }
+                $0.readTransactionsStorage = .noOp
 
-            $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
-            $0.userMetadataProvider.load = { _ in }
+                $0.userDefaults.objectForKey = { _ in nil }
+                $0.userDefaults.remove = { _ in }
+                $0.userDefaults.setValue = { _, _ in }
 
-            $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+                $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
+                $0.userMetadataProvider.load = { _ in }
 
-            $0.sdkSynchronizer = .mocked(
-                stateStream: { Empty().eraseToAnyPublisher() },
-                latestState: {
-                    var syncState = SynchronizerState.zero
-                    syncState.syncStatus = .upToDate
-                    return syncState
-                },
-                prepareWith: { _, _, _, _ in .success },
-                start: { _ in
-                    startCalls.recordCall()
-                    await gate.wait()
-                },
-                getAllTransactions: { _ in [] },
-                isSeedRelevantToAnyDerivedAccount: { _ in true },
-                walletAccounts: { [seedDerivedAccount] }
-            )
+                $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+
+                $0.sdkSynchronizer = .mocked(
+                    stateStream: { Empty().eraseToAnyPublisher() },
+                    latestState: {
+                        var syncState = SynchronizerState.zero
+                        syncState.syncStatus = .upToDate
+                        return syncState
+                    },
+                    prepareWith: { _, _, _, _ in .success },
+                    start: { _ in
+                        let ordinal = startCalls.recordCall()
+                        await gates[min(ordinal, gates.count) - 1].wait()
+                    },
+                    isMigrationSyncBlocked: {
+                        isMigrationSyncBlockedCalls?.recordCall()
+                        return false
+                    },
+                    getAllTransactions: { _ in [] },
+                    isSeedRelevantToAnyDerivedAccount: { _ in true },
+                    walletAccounts: { [seedDerivedAccount] }
+                )
+            }
+            store.exhaustivity = .off
+            return store
         }
-        store.exhaustivity = .off
-        return store
+    }
+
+    /// Convenience for the common single-pipeline case: every `start()` call parks on the same gate.
+    /// Also pinned to a fresh `InMemoryStorage`, even though it only delegates to the `gates:`
+    /// overload (which pins its own) — kept explicit so this overload stays self-isolating on its
+    /// own terms if that delegation ever changes.
+    private func makeStore(
+        startCalls: SignalledRecords<Void>,
+        gate: ResumableGate
+    ) -> TestStore<Root.State, Root.Action> {
+        withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            makeStore(startCalls: startCalls, gates: [gate])
+        }
+    }
+
+    /// Builds a store whose FIRST `.retryStart` pipeline takes the broadcast-only (`visitKind() ==
+    /// .send`) branch and never calls `start()`, while every pipeline after it finds nothing left
+    /// due and takes the ordinary sync branch — the same shape a real broadcast going out and
+    /// clearing its own dueness produces. `migrationManager.advance` parks on `advanceGate` so a
+    /// test can hold the broadcast-only pass "in flight" for as long as the race needs the window
+    /// held open; `sdkSynchronizer.start` is recorded but not gated, since nothing in this scenario
+    /// needs a START call to stay in flight.
+    // Pinned to a fresh `InMemoryStorage`, same rationale and idiom as the `makeStore` overloads
+    // above — this is the store `gateFalseEdgeDuringABroadcastOnlyPipelineResumesSyncOnce` uses, and
+    // its final assertions depend on `.migrationSyncGateChanged`'s `shouldResume` reading
+    // `.migrationStoppedSyncForBroadcast` as this test left it, not as some other concurrently
+    // running suite last left the process-global default.
+    private func makeBroadcastOnlyStore(
+        startCalls: SignalledRecords<Void>,
+        advanceGate: ResumableGate,
+        visitKindCallCount: LockIsolated<Int>
+    ) -> TestStore<Root.State, Root.Action> {
+        let seedDerivedAccount = RootRetryStartReentrancyTests.seedDerivedAccount
+
+        return withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = TestStore(
+                initialState: RootRetryStartReentrancyTests.makeInitialState()
+            ) {
+                Root()
+            } withDependencies: {
+                $0.mainQueue = .immediate
+                $0.continuousClock = TestClock()
+
+                $0.exchangeRate = .noOp
+                $0.autolockHandler = .noOp
+                $0.shieldingProcessor = ShieldingProcessorClient(
+                    observe: { Empty().eraseToAnyPublisher() },
+                    shieldFunds: { }
+                )
+
+                $0.mnemonic = .noOp
+                $0.databaseFiles = .noOp
+
+                $0.walletStorage = .noOp
+                $0.walletStorage.exportWallet = { .placeholder }
+
+                $0.flexaHandler = .noOp
+                $0.flexaHandler.signOut = { }
+
+                $0.userStoredPreferences.removeAll = { }
+                $0.readTransactionsStorage = .noOp
+
+                $0.userDefaults.objectForKey = { _ in nil }
+                $0.userDefaults.remove = { _ in }
+                $0.userDefaults.setValue = { _, _ in }
+
+                $0.addressBook.allLocalContacts = { _ in (AddressBookContacts.empty, .notAttempted) }
+                $0.userMetadataProvider.load = { _ in }
+
+                $0.diskSpaceChecker.hasEnoughFreeSpaceForSync = { true }
+
+                // The first pipeline is a broadcast-only pass; every pipeline after it finds nothing
+                // left due and syncs normally.
+                $0.migrationManager.visitKind = {
+                    let ordinal = visitKindCallCount.withValue { count -> Int in
+                        count += 1
+                        return count
+                    }
+                    return ordinal == 1 ? .send : .sync
+                }
+                $0.migrationManager.advance = { _ in
+                    await advanceGate.wait()
+                    return .broadcast(id: 1)
+                }
+
+                $0.sdkSynchronizer = .mocked(
+                    stateStream: { Empty().eraseToAnyPublisher() },
+                    latestState: {
+                        var syncState = SynchronizerState.zero
+                        syncState.syncStatus = .upToDate
+                        return syncState
+                    },
+                    prepareWith: { _, _, _, _ in .success },
+                    start: { _ in
+                        startCalls.recordCall()
+                    },
+                    getAllTransactions: { _ in [] },
+                    isSeedRelevantToAnyDerivedAccount: { _ in true },
+                    walletAccounts: { [seedDerivedAccount] }
+                )
+            }
+            store.exhaustivity = .off
+            return store
+        }
     }
 
     /// Lets the rest of a cascade (SmartBanner evaluation, contacts, user metadata, the battery-state
@@ -191,6 +339,107 @@ import Testing
 
     @Test func retryStartAfterDidEnterBackgroundProceedsEvenIfThePreviousPipelineNeverFinished() async throws {
         let startCalls = SignalledRecords<Void>()
+        let gateA = ResumableGate()
+        let gateB = ResumableGate()
+        let store = makeStore(startCalls: startCalls, gates: [gateA, gateB])
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        let aGeneration = store.state.retryStartGeneration
+        await startCalls.countReached(1)
+
+        // Background WITHOUT releasing gateA — the first pipeline's `.run` effect carries no
+        // `.cancellable` id of its own, so it stays parked, and its finishing send never arrives on
+        // its own. This is exactly the "dropped by cancellation (store teardown)" scenario the
+        // background reset exists to guard against — reproduced here directly via a pipeline that
+        // simply never completes on its own.
+        await store.send(.initialization(.appDelegate(.didEnterBackground)))
+        #expect(!store.state.isRetryStartInFlight, "backgrounding must reset the latch even though the in-flight pipeline never finished")
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        let bGeneration = store.state.retryStartGeneration
+        #expect(bGeneration != aGeneration, "backgrounding must give the next pipeline its own generation")
+        await startCalls.countReached(2)
+        #expect(startCalls.count == 2, "a retryStart after backgrounding must proceed even though the previous pipeline never finished")
+
+        // Now let A's own long-parked start() finally return. Its completion is STALE (generation
+        // aGeneration, while B — generation bGeneration — is the current owner) and must not release
+        // the latch B is still using; B's own gate (gateB) stays closed throughout, so only A's
+        // completion is in play here.
+        gateA.open()
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStartFinished(let generation)) = action else { return false }
+                return generation == aGeneration
+            },
+            timeout: .seconds(10)
+        )
+        #expect(store.state.isRetryStartInFlight, "A's stale completion must not release the latch B still owns")
+
+        gateB.open()
+        await drain(store)
+    }
+
+    // MARK: - A retryStart dropped while a pipeline is in flight is replayed once that pipeline finishes
+
+    @Test func aRetryStartDroppedWhileInFlightIsReplayedOnceWhenThePipelineFinishes() async throws {
+        let startCalls = SignalledRecords<Void>()
+        let gate = ResumableGate()
+        let store = makeStore(startCalls: startCalls, gate: gate)
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        let generation = store.state.retryStartGeneration
+        await startCalls.countReached(1)
+
+        // Dropped: the first pipeline is still parked in `start()`. Unlike a plain drop, this must
+        // be remembered rather than lost.
+        await store.send(.initialization(.retryStart)) {
+            $0.retryStartRequestedWhileInFlight = true
+        }
+        #expect(startCalls.count == 1, "the dropped request must not call start() itself")
+
+        gate.open()
+
+        // The in-flight pipeline finishes — its own retryStartFinished replays the request that was
+        // dropped behind it.
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStartFinished(let receivedGeneration)) = action else { return false }
+                return receivedGeneration == generation
+            },
+            timeout: .seconds(10)
+        ) {
+            $0.isRetryStartInFlight = false
+            $0.retryStartRequestedWhileInFlight = false
+        }
+
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStart) = action else { return false }
+                return true
+            },
+            timeout: .seconds(5)
+        ) {
+            $0.isRetryStartInFlight = true
+        }
+
+        await startCalls.countReached(2)
+        #expect(startCalls.count == 2, "the replay must call start() exactly once more")
+
+        gate.open()
+        await drain(store)
+        #expect(startCalls.count == 2, "no third start() call must happen once the replay's own pipeline finishes")
+    }
+
+    // MARK: - The migration-resume flags survive a dropped retryStart
+
+    @Test func migrationResumeFlagsSurviveADroppedRetryStart() async throws {
+        let startCalls = SignalledRecords<Void>()
         let gate = ResumableGate()
         let store = makeStore(startCalls: startCalls, gate: gate)
 
@@ -199,21 +448,204 @@ import Testing
         }
         await startCalls.countReached(1)
 
-        // Background WITHOUT releasing the gate — the first pipeline's `.run` effect carries no
-        // `.cancellable` id of its own, so it stays parked, and its finishing send never arrives.
-        // This is exactly the "dropped by cancellation (store teardown)" scenario the background
-        // reset exists to guard against — reproduced here directly via a pipeline that simply never
-        // completes.
-        await store.send(.initialization(.appDelegate(.didEnterBackground)))
-        #expect(!store.state.isRetryStartInFlight, "backgrounding must reset the latch even though the in-flight pipeline never finished")
+        // Arm the migration-resume flag as if a broadcast-only pipeline had deferred sync while this
+        // (unrelated) pipeline is in flight.
+        await store.send(.migrationGateDeferredSyncStart) {
+            $0.syncDeferredByMigrationGate = true
+        }
+
+        // A second retryStart arrives while the first is in flight and must be dropped — and, unlike
+        // the pre-fix behavior, must not consume the flag on its way out.
+        await store.send(.initialization(.retryStart))
+
+        #expect(store.state.syncDeferredByMigrationGate, "a dropped retryStart must not consume the migration-resume flag")
+        #expect(store.state.isRetryStartInFlight, "the in-flight pipeline's own latch must be untouched by the dropped duplicate")
+        #expect(store.state.retryStartRequestedWhileInFlight, "the dropped request must be armed for replay")
+
+        gate.open()
+        await drain(store)
+    }
+
+    // MARK: - A gate-false edge during a broadcast-only pipeline still resumes sync, exactly once
+
+    @Test func gateFalseEdgeDuringABroadcastOnlyPipelineResumesSyncOnce() async throws {
+        let startCalls = SignalledRecords<Void>()
+        let advanceGate = ResumableGate()
+        let visitKindCallCount = LockIsolated<Int>(0)
+        let store = makeBroadcastOnlyStore(
+            startCalls: startCalls,
+            advanceGate: advanceGate,
+            visitKindCallCount: visitKindCallCount
+        )
 
         await store.send(.initialization(.retryStart)) {
             $0.isRetryStartInFlight = true
         }
+        let generation = store.state.retryStartGeneration
+
+        // The broadcast-only branch arms the resume flag before parking in `advance(.beforeSync)`.
+        await store.receive(
+            { action in
+                guard case .migrationGateDeferredSyncStart = action else { return false }
+                return true
+            },
+            timeout: .seconds(5)
+        ) {
+            $0.syncDeferredByMigrationGate = true
+        }
+
+        // Pipeline A is now parked inside `advance(.beforeSync)` — still in flight. A gate-false edge
+        // arrives; `shouldResume` reads true off the flag just armed, but the replay must be
+        // DEFERRED rather than dropped outright.
+        await store.send(.migrationSyncGateChanged(false))
+
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStart) = action else { return false }
+                return true
+            },
+            timeout: .seconds(5)
+        ) {
+            $0.retryStartRequestedWhileInFlight = true
+        }
+
+        #expect(store.state.syncDeferredByMigrationGate, "the deferred retryStart must not consume the flag pipeline A still needs")
+        #expect(store.state.isRetryStartInFlight, "pipeline A is still the latch's owner")
+
+        advanceGate.open()
+
+        // A finishes (broadcast-only — no start()) and its own retryStartFinished replays the
+        // deferred request — by now visitKind answers .sync, so this pipeline actually starts sync.
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStartFinished(let receivedGeneration)) = action else { return false }
+                return receivedGeneration == generation
+            },
+            timeout: .seconds(10)
+        ) {
+            $0.isRetryStartInFlight = false
+            $0.retryStartRequestedWhileInFlight = false
+        }
+
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStart) = action else { return false }
+                return true
+            },
+            timeout: .seconds(5)
+        ) {
+            $0.isRetryStartInFlight = true
+        }
+
+        await startCalls.countReached(1)
+        #expect(startCalls.count == 1, "the replayed pipeline must start sync exactly once")
+
+        await drain(store)
+        #expect(!store.state.syncDeferredByMigrationGate, "the replay's own retryStart consumed the flag past its guards")
+        #expect(!store.state.retryStartRequestedWhileInFlight, "the replay consumed its own request flag")
+
+        // A second gate emission, now that both resume flags are clear, must add nothing.
+        await store.send(.migrationSyncGateChanged(false))
+        await drain(store)
+        #expect(startCalls.count == 1, "a second gate emission after the resume already ran must not start sync again")
+    }
+
+    // MARK: - A stale pipeline finishing after backgrounding cannot clear a newer latch or re-register
+
+    @Test func aPipelineFinishingAfterBackgroundDoesNotClearTheNewerLatchOrReregister() async throws {
+        let startCalls = SignalledRecords<Void>()
+        let gateA = ResumableGate()
+        let gateB = ResumableGate()
+        let isMigrationSyncBlockedCalls = SignalledRecords<Void>()
+        let store = makeStore(
+            startCalls: startCalls,
+            gates: [gateA, gateB],
+            isMigrationSyncBlockedCalls: isMigrationSyncBlockedCalls
+        )
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        let aGeneration = store.state.retryStartGeneration
+        await startCalls.countReached(1)
+
+        await store.send(.initialization(.appDelegate(.didEnterBackground)))
+        #expect(!store.state.isRetryStartInFlight)
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        let bGeneration = store.state.retryStartGeneration
+        #expect(bGeneration != aGeneration, "backgrounding must give the next pipeline its own generation")
         await startCalls.countReached(2)
-        #expect(startCalls.count == 2, "a retryStart after backgrounding must proceed even though the previous pipeline never finished")
+
+        // Release ONLY A — B stays parked on its own gate, still the latch's current owner.
+        gateA.open()
+
+        await store.receive(
+            { action in
+                guard case .initialization(.registerForSynchronizersUpdate(let receivedGeneration)) = action else { return false }
+                return receivedGeneration == aGeneration
+            },
+            timeout: .seconds(10)
+        )
+        #expect(isMigrationSyncBlockedCalls.isEmpty, "A's stale register must not re-subscribe the synchronizer streams")
+
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStartFinished(let receivedGeneration)) = action else { return false }
+                return receivedGeneration == aGeneration
+            },
+            timeout: .seconds(5)
+        )
+        #expect(store.state.isRetryStartInFlight, "A's stale completion must not release the latch B still owns")
+
+        gateB.open()
+        await drain(store)
+    }
+
+    // MARK: - Backgrounding clears a deferred replay request, so a stale finish replays nothing
+
+    @Test func backgroundingClearsADeferredReplayRequestSoTheStaleFinishReplaysNothing() async throws {
+        let startCalls = SignalledRecords<Void>()
+        let gate = ResumableGate()
+        let store = makeStore(startCalls: startCalls, gate: gate)
+
+        await store.send(.initialization(.retryStart)) {
+            $0.isRetryStartInFlight = true
+        }
+        let generation = store.state.retryStartGeneration
+        await startCalls.countReached(1)
+
+        // Dropped while pipeline A is still parked in start() — armed for a replay, exactly like
+        // the replay-proof test above.
+        await store.send(.initialization(.retryStart)) {
+            $0.retryStartRequestedWhileInFlight = true
+        }
+        #expect(startCalls.count == 1, "the dropped request must not call start() itself")
+
+        // Backgrounding must clear the deferred-replay flag along with the latch — a backgrounded
+        // app has no business replaying a request that predates it.
+        await store.send(.initialization(.appDelegate(.didEnterBackground)))
+        #expect(!store.state.retryStartRequestedWhileInFlight, "backgrounding must clear a deferred replay request")
+        #expect(!store.state.isRetryStartInFlight, "backgrounding must clear the in-flight latch too")
 
         gate.open()
+
+        // A's own long-parked start() finally returns. Its completion is stale (tagged for the
+        // pre-background generation) and, even though a replay was armed behind it before
+        // backgrounding, that arming was already cleared above — so this finish must replay nothing.
+        await store.receive(
+            { action in
+                guard case .initialization(.retryStartFinished(let receivedGeneration)) = action else { return false }
+                return receivedGeneration == generation
+            },
+            timeout: .seconds(10)
+        )
+
         await drain(store)
+        #expect(startCalls.count == 1, "a stale finish after backgrounding must not replay retryStart")
+        #expect(!store.state.retryStartRequestedWhileInFlight, "the stale finish must not re-arm the replay flag")
+        #expect(!store.state.isRetryStartInFlight, "the stale finish must not re-set the latch")
     }
 }


### PR DESCRIPTION
## Summary

The synchronizer restart pipeline (`retryStart`) had a latch so overlapping pipelines could not call `start` twice, but a request that arrived while a pipeline was in flight was dropped **and** its migration-resume flags were consumed. When the in-flight pipeline was a broadcast-only pass (which never starts sync), sync never resumed after the migration broadcast.

- Each pipeline now carries a generation. A request that arrives while one is in flight is deferred and replayed exactly once when that pipeline finishes; its resume flags stay armed until a pipeline is actually admitted.
- Completions are tagged with their generation, so a stale pipeline finishing late can no longer release a newer pipeline's latch or re-register the synchronizer streams. Entering the background bumps the generation and clears the deferred request; the foreground path re-registers on its own.
- Cold launch still registers the streams unconditionally.

## Tests

`RootRetryStartReentrancyTests`: a dropped request is replayed once when the pipeline finishes; migration-resume flags survive a dropped request; a gate-false edge during a broadcast-only pipeline resumes sync exactly once; a pipeline finishing after the app went to the background neither clears the newer latch nor re-registers. The existing cross-background test now also asserts that the late completion does not release the newer latch, and a further case checks that backgrounding clears a deferred replay so a stale completion replays nothing. The suite's stores are built on isolated in-memory shared storage.

Verified locally with the `zodl-internal` scheme: build succeeded; the 4 focused suites (37 tests) and all 71 migration and initialization suites (553 tests) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
