### PR TITLE
[MOB-1889] Implement the sub-$300 refund warning for Swap and CrossPay

### DIFF
--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -8047,6 +8047,23 @@
         }
       }
     },
+    "general.continue" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Continuar"
+          }
+        }
+      }
+    },
     "general.copiedAddress" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -21390,6 +21407,74 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fondos devueltos"
+          }
+        }
+      }
+    },
+    "swapAndPay.refundWarning.dontShowAgain" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Don’t show this message again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No volver a mostrar este mensaje"
+          }
+        }
+      }
+    },
+    "swapAndPay.refundWarning.payMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NEAR doesn’t refund mistakes like a wrong address or wrong network for payments under $300. Please double-check all details before continuing."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "NEAR no reembolsa errores como una dirección o red incorrecta en pagos de menos de $300. Verifica todos los detalles antes de continuar."
+          }
+        }
+      }
+    },
+    "swapAndPay.refundWarning.swapMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NEAR doesn’t refund mistakes like a wrong address or wrong network for swaps under $300. Please double-check all details before continuing."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "NEAR no reembolsa errores como una dirección o red incorrecta en swaps de menos de $300. Verifica todos los detalles antes de continuar."
+          }
+        }
+      }
+    },
+    "swapAndPay.refundWarning.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Refunds Under $300"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sin reembolsos por debajo de $300"
           }
         }
       }

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -8251,6 +8251,23 @@
         }
       }
     },
+    "general.learnMore" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Learn more"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Más información"
+          }
+        }
+      }
+    },
     "general.less" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -6291,13 +6291,30 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "If the actual slippage and network conditions result in your recipient receiving less than the promised amount, your transaction will be reversed. You will receive a full refund minus network fees."
+            "value" : "If slippage or network conditions result in your recipient receiving less than the promised amount, your payment will be refunded minus network fees."
           }
         },
         "es" : {
           "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Si el deslizamiento o las condiciones de la red resultan en que tu destinatario reciba menos de la cantidad prometida, tu pago será reembolsado menos las comisiones de red."
+          }
+        }
+      }
+    },
+    "crosspay.help.descThreshold" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Si el deslizamiento real y las condiciones de la red resultan en que tu destinatario reciba menos de la cantidad prometida, tu transacción será revertida. Recibirás un reembolso completo menos las comisiones de red."
+            "value" : "Refunds only apply to payments of $300 or more. Payments under $300 aren’t eligible for a refund. Please double-check all details before continuing."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Los reembolsos solo se aplican a pagos de $300 o más. Los pagos de menos de $300 no son elegibles para reembolso. Verifica todos los detalles antes de continuar."
           }
         }
       }
@@ -8094,6 +8111,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eliminar"
+          }
+        }
+      }
+    },
+    "general.dismiss" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Descartar"
           }
         }
       }
@@ -20737,13 +20771,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Swap ZEC with any NEAR-supported token. "
+            "value" : "Swap between ZEC and any NEAR-supported coin or token."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haz swap de ZEC con cualquier token compatible con NEAR."
+            "state" : "needs_review",
+            "value" : "Haz swap entre ZEC y cualquier moneda o token compatible con NEAR."
           }
         }
       }
@@ -20754,13 +20788,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "If swapping TO ZEC, you will send funds from a 3rd party wallet and provide an address where change can be refunded."
+            "value" : "If swapping TO ZEC, you will send funds from a third-party wallet and provide an address where funds can be refunded."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si haces swap HACIA ZEC, enviarás fondos desde una wallet de terceros y deberás proporcionar una dirección donde se pueda reembolsar el cambio."
+            "state" : "needs_review",
+            "value" : "Si haces swap HACIA ZEC, enviarás fondos desde una wallet de terceros y deberás proporcionar una dirección donde se puedan reembolsar los fondos."
           }
         }
       }
@@ -20778,6 +20812,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Si haces swap DESDE ZEC, debes proporcionar una dirección válida para el activo al que haces swap."
+          }
+        }
+      }
+    },
+    "swapAndPay.help.swapDescThreshold" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refunds only apply to swaps of $300 or more. Swaps under $300 aren’t eligible for a refund if sent to a wrong address or wrong network."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Los reembolsos solo se aplican a swaps de $300 o más. Los swaps de menos de $300 no son elegibles para reembolso si se envían a una dirección o red incorrecta."
           }
         }
       }
@@ -22183,13 +22234,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "If the swap fails or market conditions change, your transaction may be refunded minus the transaction fees."
+            "value" : "If the swap fails or market conditions change, your transaction may be refunded minus network fees."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Si el swap falla o cambian las condiciones del mercado, tu transacción puede ser reembolsada menos las comisiones de transacción."
+            "state" : "needs_review",
+            "value" : "Si el swap falla o cambian las condiciones del mercado, tu transacción puede ser reembolsada menos las comisiones de red."
           }
         }
       }
@@ -22207,6 +22258,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "El monto reembolsado será devuelto a tu wallet en la moneda de origen en la misma red. Ingresa una dirección válida para evitar la pérdida de fondos."
+          }
+        }
+      }
+    },
+    "swapToZec.refundAddress.msgThreshold" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refunds only apply to swaps of $300 or more. Swaps under $300 aren’t eligible for a refund."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Los reembolsos solo se aplican a swaps de $300 o más. Los swaps de menos de $300 no son elegibles para reembolso."
           }
         }
       }

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowStore.swift
@@ -42,7 +42,9 @@ struct SwapAndPayCoordFlow {
         var failedDescription = ""
         var failedPcztMsg: String?
         var isHelpSheetPresented = false
+        var isInAppBrowserOn = false
         var isSwapExperience = true
+        var learnMoreRequested = false
         var isSwapToZecExperience = false
         var partialFailureTxIds: [String] = []
         var partialFailureStatuses: [String] = []
@@ -64,6 +66,15 @@ struct SwapAndPayCoordFlow {
             isSwapExperience || swapAndPayState.isSwapToZecExperienceEnabled
         }
 
+        /// Support article behind the explainer's `Learn more`, picked by which explainer is on
+        /// screen. The Refund Address explainer has no `Learn more` (MOB-1889), so only these
+        /// two destinations exist.
+        var helpArticleURL: URL? {
+            isSwapHelpContent
+            ? URL(string: "https://support.zodl.com/article/26-swapping-into-zec")
+            : URL(string: "https://support.zodl.com/article/24-using-crosspay-to-spend-zec")
+        }
+
         var isSensitiveButtonVisible: Bool {
             !swapAndPayState.isSwapToZecExperienceEnabled
         }
@@ -75,7 +86,9 @@ struct SwapAndPayCoordFlow {
         case backButtonTapped
         case binding(BindingAction<SwapAndPayCoordFlow.State>)
         case customBackRequired
+        case helpSheetDismissed
         case helpSheetRequested
+        case learnMoreTapped
         case onAppear
         case path(StackActionOf<Path>)
         case sendDone
@@ -124,6 +137,22 @@ struct SwapAndPayCoordFlow {
             case .helpSheetRequested,
                     .path(.element(id: _, action: .swapToZecSummary(.helpSheetRequested))):
                 state.isHelpSheetPresented.toggle()
+                return .none
+
+            case .learnMoreTapped:
+                // Close the explainer first and open the browser from its `onDismiss`: asking
+                // UIKit to present a second sheet while the first is still dismissing drops the
+                // presentation, leaving the tap dead.
+                state.learnMoreRequested = true
+                state.isHelpSheetPresented = false
+                return .none
+
+            case .helpSheetDismissed:
+                // Fires for every dismissal -- swipe and `Dismiss` included -- so the browser
+                // opens only when `Learn more` actually asked for it.
+                guard state.learnMoreRequested else { return .none }
+                state.learnMoreRequested = false
+                state.isInAppBrowserOn = true
                 return .none
 
             case .path(.element(id: _, action: .swapAndPayForm(.helpSheetRequested(let index)))):

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
@@ -101,8 +101,16 @@ struct SwapAndPayCoordFlowView: View {
                         TransactionDetailsView(store: store, tokenName: tokenName)
                     }
                 }
-                .zashiSheet(isPresented: $store.isHelpSheetPresented) {
+                .zashiSheet(
+                    isPresented: $store.isHelpSheetPresented,
+                    onDismiss: { store.send(.helpSheetDismissed) }
+                ) {
                     helpSheetContent()
+                }
+                .sheet(isPresented: $store.isInAppBrowserOn) {
+                    if let url = store.helpArticleURL {
+                        InAppBrowserView(url: url)
+                    }
                 }
                 .onAppear { store.send(.onAppear) }
             }
@@ -145,6 +153,14 @@ struct SwapAndPayCoordFlowView: View {
                 .padding(.bottom, 32)
             }
             
+            ZashiButton(
+                String(localizable: .generalLearnMore),
+                type: .secondary
+            ) {
+                store.send(.learnMoreTapped)
+            }
+            .padding(.bottom, 8)
+
             ZashiButton(String(localizable: .generalDismiss)) {
                 store.send(.helpSheetRequested)
             }

--- a/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
+++ b/secant/Sources/Features/CoordFlows/SwapAndPayCoordFlowView.swift
@@ -131,19 +131,21 @@ struct SwapAndPayCoordFlowView: View {
                     index: 0,
                     text: String(localizable: .swapAndPayHelpSwapDesc),
                     desc1: String(localizable: .swapAndPayHelpSwapDesc1),
-                    desc2: String(localizable: .swapAndPayHelpSwapDesc2)
+                    desc2: String(localizable: .swapAndPayHelpSwapDescThreshold),
+                    desc3: String(localizable: .swapAndPayHelpSwapDesc2)
                 )
                 .padding(.bottom, 32)
             } else {
                 infoContent(
                     index: 1,
                     text: String(localizable: .crosspayHelpDesc1),
-                    desc1: String(localizable: .crosspayHelpDesc2)
+                    desc1: String(localizable: .crosspayHelpDesc2),
+                    desc2: String(localizable: .crosspayHelpDescThreshold)
                 )
                 .padding(.bottom, 32)
             }
             
-            ZashiButton(String(localizable: .generalOk).uppercased()) {
+            ZashiButton(String(localizable: .generalDismiss)) {
                 store.send(.helpSheetRequested)
             }
             .padding(.bottom, Design.Spacing.sheetBottomSpace)
@@ -154,7 +156,8 @@ struct SwapAndPayCoordFlowView: View {
         index: Int,
         text: String,
         desc1: String? = nil,
-        desc2: String? = nil
+        desc2: String? = nil,
+        desc3: String? = nil
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(text)
@@ -172,6 +175,14 @@ struct SwapAndPayCoordFlowView: View {
 
             if let desc2 {
                 Text(desc2)
+                    .zFont(size: 16, style: Design.Text.tertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .lineSpacing(2)
+                    .padding(.top, 16)
+            }
+
+            if let desc3 {
+                Text(desc3)
                     .zFont(size: 16, style: Design.Text.tertiary)
                     .fixedSize(horizontal: false, vertical: true)
                     .lineSpacing(2)

--- a/secant/Sources/Features/Root/RootStore.swift
+++ b/secant/Sources/Features/Root/RootStore.swift
@@ -907,7 +907,8 @@ extension Root {
 
     /// Clears device/global-scoped wallet state that must never leak from one wallet into
     /// the next on the same device — voting configuration and history, the Flexa session,
-    /// cached preferences, and locally-cached read-transaction state. Shared by the full
+    /// cached preferences, the sub-$300 refund-warning suppression, and locally-cached
+    /// read-transaction state. Shared by the full
     /// `resetZashi` flow (`.resetZashiSDKSucceeded`) and by `reconcileWalletDatabaseWithSeed`,
     /// so a healed stale database (e.g. from a restored device backup) starts out just as
     /// clean as an explicit reset.
@@ -923,6 +924,12 @@ extension Root {
         userDefaults.remove(Constants.udIsRestoringWallet)
         userDefaults.remove(Constants.udIsResyncingWallet)
         userDefaults.remove(Constants.udLeavesScreenOpen)
+        // MOB-1889: the sub-$300 refund warning's per-surface suppression. Device-scoped like
+        // everything else here — the next wallet on this device has not been shown the warning
+        // and must not inherit a previous owner's decision to silence it.
+        userDefaults.remove(.refundWarningSuppressedSwapToZec)
+        userDefaults.remove(.refundWarningSuppressedSwapFromZec)
+        userDefaults.remove(.refundWarningSuppressedCrossPay)
         #if VOTING_ENABLED
         userDefaults.remove(.hasSeenHowToVote)
         userDefaults.remove(.hasSeenHowToVoteKeystone)

--- a/secant/Sources/Features/SwapAndPayForm/CrossPayForm.swift
+++ b/secant/Sources/Features/SwapAndPayForm/CrossPayForm.swift
@@ -150,7 +150,7 @@ extension SwapAndPayForm {
                                     .padding(.bottom, 56)
                             } else {
                                 ZashiButton(String(localizable: .sendReview)) {
-                                    store.send(.getQuoteTapped)
+                                    store.send(.getQuoteTapped(skipRefundWarning: false))
                                 }
                                 .accessibilityIdentifier(AccessibilityID.CrossPayForm.reviewButton)
                                 .padding(.top, keyboardVisible ? 40 : 0)
@@ -184,6 +184,9 @@ extension SwapAndPayForm {
             }
             .zashiSheet(isPresented: $store.isQuoteUnavailablePresented) {
                 quoteUnavailableContent(colorScheme)
+            }
+            .zashiSheet(isPresented: $store.isRefundWarningPresented) {
+                refundWarningSheetContent(colorScheme)
             }
             .zashiSheet(isPresented: $store.isCancelSheetVisible) {
                 cancelSheetContent(colorScheme)

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPaySheets.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPaySheets.swift
@@ -117,6 +117,62 @@ extension SwapAndPayForm {
             }
         }
     }
+    /// The sub-$300 refund warning (MOB-1889). One sheet serves all three surfaces; only the
+    /// noun in the body changes, and which suppression flag Continue writes is decided in the
+    /// reducer.
+    @ViewBuilder func refundWarningSheetContent(_ colorScheme: ColorScheme) -> some View {
+        WithPerceptionTracking {
+            VStack(alignment: .leading, spacing: 0) {
+                Asset.Assets.Icons.alertTriangle.image
+                    .zImage(size: 20, style: Design.Utility.WarningYellow._500)
+                    .background {
+                        Circle()
+                            .fill(Design.Utility.WarningYellow._50.color(colorScheme))
+                            .frame(width: 44, height: 44)
+                    }
+                    .padding(.top, 48)
+                    .padding(.leading, 12)
+
+                Text(localizable: .swapAndPayRefundWarningTitle)
+                    .zFont(.semiBold, size: 24, style: Design.Text.primary)
+                    .padding(.top, 24)
+                    .padding(.bottom, 12)
+
+                Text(
+                    store.refundWarningSurface == .crossPay
+                    ? String(localizable: .swapAndPayRefundWarningPayMessage)
+                    : String(localizable: .swapAndPayRefundWarningSwapMessage)
+                )
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.leading)
+                .lineSpacing(2)
+                .padding(.bottom, 20)
+
+                ZashiToggle(
+                    isOn: $store.refundWarningDontShowAgain,
+                    label: String(localizable: .swapAndPayRefundWarningDontShowAgain)
+                )
+                .accessibilityIdentifier(AccessibilityID.RefundWarning.dontShowAgainToggle)
+                .padding(.bottom, 24)
+
+                ZashiButton(
+                    String(localizable: .generalCancel),
+                    type: .secondary
+                ) {
+                    store.send(.refundWarningCancelTapped)
+                }
+                .accessibilityIdentifier(AccessibilityID.RefundWarning.cancelButton)
+                .padding(.bottom, 8)
+
+                ZashiButton(String(localizable: .generalContinue)) {
+                    store.send(.refundWarningContinueTapped)
+                }
+                .accessibilityIdentifier(AccessibilityID.RefundWarning.continueButton)
+                .padding(.bottom, Design.Spacing.sheetBottomSpace)
+            }
+        }
+    }
 }
 
 struct FocusableTextField: UIViewRepresentable {
@@ -181,4 +237,5 @@ struct FocusableTextField: UIViewRepresentable {
             isFirstResponder = false
         }
     }
+
 }

--- a/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapAndPayStore.swift
@@ -17,6 +17,20 @@ struct SwapAndPay {
     enum Constants {
         static let zecAsset = "zec.zec"
         static let defaultSlippage = Decimal(2.0)
+        /// NEAR refuses to refund user error below this deposit value, so it is their policy
+        /// figure rather than ours (MOB-1889). Evaluated at CTA tap against the estimated USD
+        /// value; near-boundary cases where the quote lands the other side of $300 are handled
+        /// manually by NEAR support, which is why an estimate is good enough here.
+        static let refundThresholdUsd = Decimal(300)
+    }
+
+    /// Which of the three forms the one reducer is currently serving. The store encodes this in
+    /// two booleans whose defaults overlap (`isSwapExperienceEnabled` starts true), so resolving
+    /// it once here keeps every caller from having to remember the precedence.
+    enum RefundWarningSurface: Equatable {
+        case swapToZec
+        case swapFromZec
+        case crossPay
     }
     
     @ObservableState
@@ -50,6 +64,8 @@ struct SwapAndPay {
         var isQuoteToZecPresented = false
         var isQuoteUnavailablePresented = false
         var isRefundAddressExplainerEnabled = false
+        var isRefundWarningPresented = false
+        var refundWarningDontShowAgain = false
         var isSlippagePresented = false
         var isSwapCanceled = false
         var isSwapExperienceEnabled = true
@@ -71,6 +87,12 @@ struct SwapAndPay {
         var selectedSlippageChip = 0
         @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
         @Shared(.appStorage(.sensitiveContent)) var isSensitiveContentHidden = false
+        @Shared(.appStorage(.refundWarningSuppressedSwapToZec))
+        var isRefundWarningSuppressedSwapToZec = false
+        @Shared(.appStorage(.refundWarningSuppressedSwapFromZec))
+        var isRefundWarningSuppressedSwapFromZec = false
+        @Shared(.appStorage(.refundWarningSuppressedCrossPay))
+        var isRefundWarningSuppressedCrossPay = false
         @Shared(.inMemory(.swapAPIAccess)) var swapAPIAccess: WalletStorage.SwapAPIAccess = .direct
         @Shared(.inMemory(.swapAssets)) var swapAssets: IdentifiedArrayOf<SwapAsset> = []
         var swapAssetFailedCounter = 0
@@ -110,6 +132,56 @@ struct SwapAndPay {
         /// Only a flow that spends local ZEC has to wait for the spendable value; an incoming swap
         /// deposits another asset and receives ZEC, so masking must not block funding a wallet
         /// that is still syncing. Mirrors the exemption in `isInsufficientFunds`.
+        var refundWarningSurface: RefundWarningSurface {
+            if isSwapToZecExperienceEnabled {
+                return .swapToZec
+            }
+            return isSwapExperienceEnabled ? .swapFromZec : .crossPay
+        }
+
+        var isRefundWarningSuppressed: Bool {
+            switch refundWarningSurface {
+            case .swapToZec: return isRefundWarningSuppressedSwapToZec
+            case .swapFromZec: return isRefundWarningSuppressedSwapFromZec
+            case .crossPay: return isRefundWarningSuppressedCrossPay
+            }
+        }
+
+        /// USD value of the deposit, which is the figure NEAR applies the $300 rule to.
+        ///
+        /// Derived from `amount` and the assets' own `usdPrice` rather than read off `usdAmount`:
+        /// that computed parses the formatted USD field through the live formatter and is
+        /// `_XCTIsTesting`-poisoned to 0, so a threshold built on it would read as under $300 in
+        /// every reducer test and prove nothing. `amount` has the `amountOverrideForTesting`
+        /// seam, so this stays drivable.
+        ///
+        /// The unit `amount` carries differs per surface, mirroring `isInsufficientFunds`:
+        /// ZEC when swapping FROM ZEC, the selected token otherwise, or USD directly when the
+        /// field is in USD mode. For CrossPay the deposit is ZEC but the entered token value is
+        /// the same figure in USD, so the selected asset's price is the right multiplier there
+        /// too.
+        var refundWarningDepositUsd: Decimal? {
+            if isInputInUsd {
+                return amount
+            }
+            switch refundWarningSurface {
+            case .swapFromZec:
+                guard let zecAsset, zecAsset.usdPrice > 0 else { return nil }
+                return amount * zecAsset.usdPrice
+            case .swapToZec, .crossPay:
+                guard let selectedAsset, selectedAsset.usdPrice > 0 else { return nil }
+                return amount * selectedAsset.usdPrice
+            }
+        }
+
+        /// Nil deposit value means no usable price. Unreachable in practice -- `isValidForm`
+        /// needs a selected asset and the CTA is disabled without one -- but if it ever happens
+        /// the safe answer is to warn rather than wave a swap through unwarned.
+        var isBelowRefundThreshold: Bool {
+            guard let deposit = refundWarningDepositUsd else { return true }
+            return deposit < Constants.refundThresholdUsd
+        }
+
         var isValidForm: Bool {
             selectedAsset != nil
             && !address.isEmpty
@@ -270,7 +342,7 @@ struct SwapAndPay {
         case eraseSearchTermTapped
         //case exchangeRateSetupChanged
         case getQuote
-        case getQuoteTapped
+        case getQuoteTapped(skipRefundWarning: Bool)
         case helpSheetRequested(Int)
         case internalBackButtonTapped
         case maxAmountFailed
@@ -331,6 +403,8 @@ struct SwapAndPay {
         case qrCodeTapped
         case refundAddressCloseTapped
         case refundAddressTapped
+        case refundWarningCancelTapped
+        case refundWarningContinueTapped
         case rememberEnlargedQR(CGImage?)
         case rememberQR(CGImage?)
         case sentTheFundsButtonTapped
@@ -816,7 +890,17 @@ struct SwapAndPay {
                 state.searchTerm = ""
                 return .send(.updateAssetsAccordingToSearchTerm)
                 
-            case .getQuoteTapped:
+            case .getQuoteTapped(let skipRefundWarning):
+                // MOB-1889: the sub-$300 warning is an interstitial, so it intercepts ahead of
+                // everything below -- the MOB-1803 UA rotation included, which is a wallet-DB
+                // write not worth spending on a swap the user is about to cancel.
+                // `skipRefundWarning` is how the sheet's Continue re-enters without re-arming
+                // the sheet; nothing else passes true.
+                if !skipRefundWarning, !state.isRefundWarningSuppressed, state.isBelowRefundThreshold {
+                    state.refundWarningDontShowAgain = false
+                    state.isRefundWarningPresented = true
+                    return .none
+                }
                 guard let account = state.selectedWalletAccount else {
                     return .send(.getQuote)
                 }
@@ -1350,6 +1434,30 @@ struct SwapAndPay {
             case .refundAddressCloseTapped:
                 state.isRefundAddressExplainerEnabled = false
                 return .none
+
+            case .refundWarningCancelTapped:
+                // Nothing submitted and nothing persisted: ticking the box and then cancelling
+                // must not silence the warning.
+                state.isRefundWarningPresented = false
+                state.refundWarningDontShowAgain = false
+                return .none
+
+            case .refundWarningContinueTapped:
+                // The preference is written here rather than on the toggle, so that the box only
+                // takes effect for a user who actually went ahead.
+                if state.refundWarningDontShowAgain {
+                    switch state.refundWarningSurface {
+                    case .swapToZec:
+                        state.$isRefundWarningSuppressedSwapToZec.withLock { $0 = true }
+                    case .swapFromZec:
+                        state.$isRefundWarningSuppressedSwapFromZec.withLock { $0 = true }
+                    case .crossPay:
+                        state.$isRefundWarningSuppressedCrossPay.withLock { $0 = true }
+                    }
+                }
+                state.isRefundWarningPresented = false
+                state.refundWarningDontShowAgain = false
+                return .send(.getQuoteTapped(skipRefundWarning: true))
                 
                 // MARK: deposit funds
                 

--- a/secant/Sources/Features/SwapAndPayForm/SwapComponents.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapComponents.swift
@@ -612,13 +612,18 @@ extension SwapAndPayForm {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 16)
 
+            Text(localizable: .swapToZecRefundAddressMsgThreshold)
+                .zFont(size: 14, style: Design.Text.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 16)
+
             Text(localizable: .swapToZecRefundAddressMsg2)
                 .zFont(size: 14, style: Design.Text.tertiary)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 16)
                 .padding(.bottom, 32)
 
-            ZashiButton(String(localizable: .generalOk)) {
+            ZashiButton(String(localizable: .generalDismiss)) {
                 store.send(.refundAddressCloseTapped)
             }
             .padding(.bottom, Design.Spacing.sheetBottomSpace)

--- a/secant/Sources/Features/SwapAndPayForm/SwapForm.swift
+++ b/secant/Sources/Features/SwapAndPayForm/SwapForm.swift
@@ -98,7 +98,7 @@ extension SwapAndPayForm {
                                     .padding(.bottom, 56)
                             } else {
                                 ZashiButton(String(localizable: .swapAndPayGetQuote)) {
-                                    store.send(.getQuoteTapped)
+                                    store.send(.getQuoteTapped(skipRefundWarning: false))
                                 }
                                 .accessibilityIdentifier(AccessibilityID.SwapForm.reviewButton)
                                 .padding(.bottom, 56)
@@ -229,6 +229,9 @@ extension SwapAndPayForm {
             }
             .zashiSheet(isPresented: $store.isRefundAddressExplainerEnabled) {
                 refundAddressSheetContent(colorScheme)
+            }
+            .zashiSheet(isPresented: $store.isRefundWarningPresented) {
+                refundWarningSheetContent(colorScheme)
             }
         }
         .onAppear {

--- a/secant/Sources/Generated/SharedStateKeys.swift
+++ b/secant/Sources/Generated/SharedStateKeys.swift
@@ -34,6 +34,15 @@ public extension String {
     static let votingConfigOverrideURL = "sharedStateKey_votingConfigOverrideURL"
     static let votingCustomChains = "sharedStateKey_votingCustomChains"
 
+    // MARK: - Sub-$300 refund warning (MOB-1889)
+    //
+    // One flag per surface, not one shared flag: product wants the warning silenced only for the
+    // flow the user silenced it in, so somebody who dismisses it on Swap still sees it the first
+    // time they try a small CrossPay. Cleared on wipe/reset by `clearDeviceScopedWalletState`.
+    static let refundWarningSuppressedSwapToZec = "sharedStateKey_refundWarningSuppressedSwapToZec"
+    static let refundWarningSuppressedSwapFromZec = "sharedStateKey_refundWarningSuppressedSwapFromZec"
+    static let refundWarningSuppressedCrossPay = "sharedStateKey_refundWarningSuppressedCrossPay"
+
     // MARK: - Migration (Orchard -> Ironwood)
     //
     // PHASE 3 working set, keys verbatim from #1930 so a wallet that ever ran that build reads its

--- a/secant/Sources/Utils/AccessibilityID.swift
+++ b/secant/Sources/Utils/AccessibilityID.swift
@@ -58,6 +58,12 @@ enum AccessibilityID {
         static let maxButton = "crossPayForm.maxButton"
     }
 
+    enum RefundWarning {
+        static let cancelButton = "refundWarning.cancelButton"
+        static let continueButton = "refundWarning.continueButton"
+        static let dontShowAgainToggle = "refundWarning.dontShowAgainToggle"
+    }
+
     enum SwapForm {
         static let assetSelectButton = "swapForm.assetSelectButton"
         static let changeModeButton = "swapForm.changeModeButton"

--- a/zodlTests/SwapAndPayTests/SwapAndPayQuoteRotationTests.swift
+++ b/zodlTests/SwapAndPayTests/SwapAndPayQuoteRotationTests.swift
@@ -7,6 +7,8 @@
 //  hard-requires `privateUnifiedAddress` (the refund address), so with a stash the
 //  tap promotes it synchronously and quotes immediately, while without one it keeps
 //  the pre-rotation await-then-quote behavior — plus a stash self-heal either way.
+//  These pass `skipRefundWarning: true` so the MOB-1889 sub-$300 interstitial cannot
+//  intercept ahead of the rotation under test; the interstitial has its own suite.
 //
 
 import Testing
@@ -71,7 +73,7 @@ import ComposableArchitecture
         }
         store.exhaustivity = .off
 
-        await store.send(.getQuoteTapped)
+        await store.send(.getQuoteTapped(skipRefundWarning: true))
 
         // The stash became the refund address synchronously.
         #expect(store.state.selectedWalletAccount?.privateUA == Const.stashUA)
@@ -119,7 +121,7 @@ import ComposableArchitecture
         }
         store.exhaustivity = .off
 
-        await store.send(.getQuoteTapped)
+        await store.send(.getQuoteTapped(skipRefundWarning: true))
 
         // The refund address arrives first...
         await store.receive(\.updatePrivateUA, timeout: .seconds(5))
@@ -168,7 +170,7 @@ import ComposableArchitecture
         }
         store.exhaustivity = .off
 
-        await store.send(.getQuoteTapped)
+        await store.send(.getQuoteTapped(skipRefundWarning: true))
         await store.receive(\.updatePrivateUA, timeout: .seconds(5))
         await store.receive(\.getQuote, timeout: .seconds(5))
         await store.finish()

--- a/zodlTests/SwapAndPayTests/SwapAndPayRefundWarningTests.swift
+++ b/zodlTests/SwapAndPayTests/SwapAndPayRefundWarningTests.swift
@@ -1,0 +1,282 @@
+//
+//  SwapAndPayRefundWarningTests.swift
+//  zodlTests
+//
+//  Covers the sub-$300 refund warning (MOB-1889,
+//  Features/SwapAndPayForm/SwapAndPayStore.swift): the `.getQuoteTapped` guard, the
+//  per-surface suppression flags, and what Cancel / Continue persist.
+//  NOTE: `usdAmount` is _XCTIsTesting-poisoned to 0, which is exactly why the threshold
+//  reads `amount` (which has the `amountOverrideForTesting` seam) times the assets' own
+//  `usdPrice` — so these tests drive real numbers rather than a constant zero.
+//
+
+import Testing
+import Foundation
+import ComposableArchitecture
+@testable import zodl_internal
+@testable @preconcurrency import ZcashLightClientKit
+
+// Mutates process-global `@Shared` slots: the in-memory selected account and the three
+// appStorage suppression flags.
+@Suite(.serialized) struct SwapAndPayRefundWarningTests {
+    private enum Const {
+        static let zecUsdPrice = Decimal(40)
+        static let tokenUsdPrice = Decimal(2)
+        /// 7.5 ZEC at $40 is exactly $300 — the boundary the policy calls eligible.
+        static let exactlyThresholdZec = Decimal(7.5)
+        /// 7.4 ZEC at $40 is $296 — the first value under it.
+        static let belowThresholdZec = Decimal(7.4)
+        static let aboveThresholdZec = Decimal(10)
+    }
+
+    private func asset(token: String, usdPrice: Decimal) -> SwapAsset {
+        SwapAsset(
+            provider: "near",
+            chain: token.lowercased(),
+            token: token,
+            assetId: "\(token)-id",
+            usdPrice: usdPrice,
+            decimals: 8
+        )
+    }
+
+    /// Swap FROM ZEC: the amount is in ZEC, so the deposit value goes through the ZEC price.
+    private func swapFromZecState(amount: Decimal) -> SwapAndPay.State {
+        var state = SwapAndPay.State.initial
+        state.isSwapExperienceEnabled = true
+        state.isSwapToZecExperienceEnabled = false
+        state.isInputInUsd = false
+        state.amountOverrideForTesting = amount
+        state.zecAsset = asset(token: "ZEC", usdPrice: Const.zecUsdPrice)
+        state.selectedAsset = asset(token: "BTC", usdPrice: Const.tokenUsdPrice)
+        return state
+    }
+
+    /// Swap TO ZEC: the deposit is the selected token, so its price is the multiplier.
+    private func swapToZecState(amount: Decimal) -> SwapAndPay.State {
+        var state = swapFromZecState(amount: amount)
+        state.isSwapToZecExperienceEnabled = true
+        return state
+    }
+
+    /// CrossPay: both experience flags off.
+    private func crossPayState(amount: Decimal) -> SwapAndPay.State {
+        var state = swapFromZecState(amount: amount)
+        state.isSwapExperienceEnabled = false
+        return state
+    }
+
+    /// The suppression flags are appStorage-backed and outlive a single test, and the
+    /// selected account is a process-global `@Shared` slot other suites write to. Every test
+    /// starts from a known state here and clears it again via `defer`.
+    private func resetFlags(_ state: SwapAndPay.State) {
+        state.$isRefundWarningSuppressedSwapToZec.withLock { $0 = false }
+        state.$isRefundWarningSuppressedSwapFromZec.withLock { $0 = false }
+        state.$isRefundWarningSuppressedCrossPay.withLock { $0 = false }
+    }
+
+    /// No selected account, so `.getQuoteTapped` takes its short path straight to `.getQuote`
+    /// rather than the MOB-1803 rotation, which is covered by its own suite.
+    private func prepared(_ state: SwapAndPay.State) -> SwapAndPay.State {
+        state.$selectedWalletAccount.withLock { $0 = nil }
+        resetFlags(state)
+        return state
+    }
+
+    // MARK: - Surface resolution
+
+    // Two booleans encode three surfaces and `isSwapExperienceEnabled` defaults to true, so
+    // the TO-ZEC flag has to win regardless of it.
+    @MainActor @Test func surfaceResolvesAllThreeForms() {
+        #expect(swapFromZecState(amount: 1).refundWarningSurface == .swapFromZec)
+        #expect(swapToZecState(amount: 1).refundWarningSurface == .swapToZec)
+        #expect(crossPayState(amount: 1).refundWarningSurface == .crossPay)
+
+        var bothFlags = swapToZecState(amount: 1)
+        bothFlags.isSwapExperienceEnabled = true
+        #expect(bothFlags.refundWarningSurface == .swapToZec)
+    }
+
+    // MARK: - The threshold
+
+    @MainActor @Test func warningShownBelowThreshold() async {
+        let state = prepared(swapFromZecState(amount: Const.belowThresholdZec))
+        defer { resetFlags(state) }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false)) {
+            $0.isRefundWarningPresented = true
+        }
+        await store.finish()
+
+        #expect(store.state.isRefundWarningPresented)
+    }
+
+    // "$300 or more" is eligible, so the boundary itself must go straight through.
+    @MainActor @Test func noWarningAtExactlyThreshold() async {
+        let state = prepared(swapFromZecState(amount: Const.exactlyThresholdZec))
+        defer { resetFlags(state) }
+
+        #expect(state.refundWarningDepositUsd == 300)
+        #expect(!state.isBelowRefundThreshold)
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false))
+        await store.receive(\.getQuote)
+        await store.finish()
+
+        #expect(!store.state.isRefundWarningPresented)
+    }
+
+    @MainActor @Test func noWarningAboveThreshold() async {
+        let state = prepared(swapFromZecState(amount: Const.aboveThresholdZec))
+        defer { resetFlags(state) }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false))
+        await store.receive(\.getQuote)
+        await store.finish()
+
+        #expect(!store.state.isRefundWarningPresented)
+    }
+
+    // Each surface measures a different field in a different unit.
+    @MainActor @Test func depositValueUsesTheRightPricePerSurface() {
+        // FROM ZEC: 7.4 ZEC * $40 = $296
+        #expect(swapFromZecState(amount: Const.belowThresholdZec).refundWarningDepositUsd == 296)
+        // TO ZEC and CrossPay: 7.4 tokens * $2 = $14.8
+        #expect(swapToZecState(amount: Const.belowThresholdZec).refundWarningDepositUsd == Decimal(14.8))
+        #expect(crossPayState(amount: Const.belowThresholdZec).refundWarningDepositUsd == Decimal(14.8))
+
+        // USD input mode: the entered figure is already the deposit value.
+        var usdInput = swapFromZecState(amount: 250)
+        usdInput.isInputInUsd = true
+        #expect(usdInput.refundWarningDepositUsd == 250)
+        #expect(usdInput.isBelowRefundThreshold)
+    }
+
+    // Unreachable through the UI (`isValidForm` needs an asset), but if it ever happens the
+    // safe answer is to warn rather than let a swap through unwarned.
+    @MainActor @Test func missingPriceFailsSafeToWarning() {
+        var noAssets = SwapAndPay.State.initial
+        noAssets.amountOverrideForTesting = Decimal(1000)
+        #expect(noAssets.refundWarningDepositUsd == nil)
+        #expect(noAssets.isBelowRefundThreshold)
+    }
+
+    // MARK: - Suppression
+
+    @MainActor @Test func suppressedSurfaceSkipsTheWarning() async {
+        let state = prepared(swapFromZecState(amount: Const.belowThresholdZec))
+        defer { resetFlags(state) }
+
+        state.$isRefundWarningSuppressedSwapFromZec.withLock { $0 = true }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false))
+        await store.receive(\.getQuote)
+        await store.finish()
+
+        #expect(!store.state.isRefundWarningPresented)
+    }
+
+    // Product asked for per-surface flags: silencing Swap must not silence CrossPay.
+    @MainActor @Test func suppressionDoesNotLeakAcrossSurfaces() async {
+        let state = prepared(crossPayState(amount: Const.belowThresholdZec))
+        defer { resetFlags(state) }
+
+        state.$isRefundWarningSuppressedSwapFromZec.withLock { $0 = true }
+        state.$isRefundWarningSuppressedSwapToZec.withLock { $0 = true }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false)) {
+            $0.isRefundWarningPresented = true
+        }
+        await store.finish()
+
+        #expect(store.state.isRefundWarningPresented)
+    }
+
+    // MARK: - Cancel / Continue
+
+    @MainActor @Test func cancelPersistsNothingAndSubmitsNothing() async {
+        let state = prepared(swapFromZecState(amount: Const.belowThresholdZec))
+        defer { resetFlags(state) }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false))
+        await store.send(.binding(.set(\.refundWarningDontShowAgain, true)))
+        await store.send(.refundWarningCancelTapped)
+        await store.finish()
+
+        #expect(!store.state.isRefundWarningPresented)
+        #expect(!store.state.refundWarningDontShowAgain)
+        // Ticking the box and then cancelling must not silence anything.
+        #expect(!store.state.isRefundWarningSuppressedSwapFromZec)
+    }
+
+    @MainActor @Test func continueProceedsWithoutPersistingWhenBoxUnchecked() async {
+        let state = prepared(swapFromZecState(amount: Const.belowThresholdZec))
+        defer { resetFlags(state) }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false))
+        await store.send(.refundWarningContinueTapped)
+        await store.receive(\.getQuoteTapped)
+        await store.receive(\.getQuote)
+        await store.finish()
+
+        #expect(!store.state.isRefundWarningPresented)
+        #expect(!store.state.isRefundWarningSuppressedSwapFromZec)
+    }
+
+    @MainActor @Test func continueWithBoxCheckedPersistsAndProceeds() async {
+        let state = prepared(swapFromZecState(amount: Const.belowThresholdZec))
+        defer { resetFlags(state) }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: false))
+        await store.send(.binding(.set(\.refundWarningDontShowAgain, true)))
+        await store.send(.refundWarningContinueTapped)
+        await store.receive(\.getQuoteTapped)
+        await store.receive(\.getQuote)
+        await store.finish()
+
+        #expect(store.state.isRefundWarningSuppressedSwapFromZec)
+        // Only this surface.
+        #expect(!store.state.isRefundWarningSuppressedCrossPay)
+        #expect(!store.state.isRefundWarningSuppressedSwapToZec)
+    }
+
+    // Continue re-enters `.getQuoteTapped`; without the skip it would re-arm the sheet and
+    // the user could never get past it.
+    @MainActor @Test func skipRefundWarningBypassesTheGuardEntirely() async {
+        let state = prepared(swapFromZecState(amount: Const.belowThresholdZec))
+        defer { resetFlags(state) }
+
+        let store = TestStore(initialState: state) { SwapAndPay() }
+        store.exhaustivity = .off
+
+        await store.send(.getQuoteTapped(skipRefundWarning: true))
+        await store.receive(\.getQuote)
+        await store.finish()
+
+        #expect(!store.state.isRefundWarningPresented)
+    }
+}

--- a/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
+++ b/zodlTests/UtilTests/RootInitializeSDKHealTests.swift
@@ -455,6 +455,19 @@ extension Root.State: @retroactive Equatable {
         )
         #endif
 
+        // MOB-1889: all three surfaces, so the next wallet on this device is warned about the
+        // $300 floor rather than inheriting a previous owner's dismissal.
+        for key in [
+            String.refundWarningSuppressedSwapToZec,
+            .refundWarningSuppressedSwapFromZec,
+            .refundWarningSuppressedCrossPay
+        ] {
+            #expect(
+                removedKeys.value.contains(key),
+                "\(key) must be cleared before healing a stale database"
+            )
+        }
+
         await drain(store)
     }
 


### PR DESCRIPTION
Implements [MOB-1889](https://linear.app/zodl/issue/MOB-1889/implement-sub-dollar300-refund-warning-for-swap-and-crosspay).

NEAR won't refund a swap or payment under $300 when the loss is user error — a wrong address or the wrong network. Nothing in the app said so, and all three NEAR explainers described refunds as unconditional.

### Rebased onto main

This branch was written on top of `michal/MOB-1848-slipstream-sync-contention-fixes`. Now that #2071 has merged that stack into `main`, the branch has been rebased onto `main` and is four commits:

| | |
|---|---|
| `aee2c981` | Update NEAR explainers for the sub-$300 refund policy |
| `b99a0cef` | Add Learn more to the Swap and CrossPay NEAR explainers |
| `04ea22d8` | Warn before quoting a swap or payment under $300 |
| `6fffa877` | Clear the refund-warning suppression on wipe and reset |

The rebase was patch-preserving; `git range-diff` reports all four unchanged:

```
1:  4200b927 = 1:  aee2c981 [MOB-1889] Update NEAR explainers for the sub-$300 refund policy
2:  3d3b816f = 2:  b99a0cef [MOB-1889] Add Learn more to the Swap and CrossPay NEAR explainers
3:  db7e566b = 3:  04ea22d8 [MOB-1889] Warn before quoting a swap or payment under $300
4:  4296b33b = 4:  6fffa877 [MOB-1889] Clear the refund-warning suppression on wipe and reset
```

### What changed

**Explainer copy.** Each of the three NEAR explainers gains a refund-eligibility paragraph. The Figma frames were taken as the source of truth for the whole text, not just the sentences the ticket listed, which surfaced one delta the ticket missed: CrossPay's slippage paragraph also changes at the head. The new paragraph is inserted where the design places it — third on the Swap explainer, so `infoContent` grew a `desc3` slot.

**Learn more.** Swap and CrossPay only, opening in `InAppBrowserView` so the user never leaves Zodl. The Refund Address explainer keeps `Dismiss` alone: the design shows no `Learn more` there and only two support articles exist. The ticket's acceptance criteria said all three, which Andrea confirmed is wrong and is correcting.

**The warning.** Tapping the primary CTA under $300 opens an interstitial naming the threshold, with Cancel, Continue, and a "Don't show this message again" checkbox. The guard sits at the top of `.getQuoteTapped`, ahead of the MOB-1803 UA rotation — a wallet-DB write not worth spending on a swap about to be cancelled. Continue re-enters the same action with `skipRefundWarning: true` rather than a transient flag, so there is nothing to reset and no way to strand the sheet armed. The preference is written on Continue, not on the toggle, so ticking the box and then cancelling silences nothing.

Suppression is one flag per surface, as product asked: silencing it on Swap leaves it armed for CrossPay. All three are cleared by `clearDeviceScopedWalletState`, so the next wallet on the device does not inherit a previous owner's dismissal.

### Two decisions worth a reviewer's eye

**The threshold reads `amount * usdPrice`, not `usdAmount`.** `usdAmount` parses the formatted USD field through the live formatter and is `_XCTIsTesting`-poisoned to zero, so a threshold built on it would read as under $300 in every reducer test and prove nothing. Both figures come from NEAR's asset prices either way — never the app-wide currency conversion, which measures something else.

**The estimate can disagree with the quote near the boundary.** The check runs pre-quote on the estimated deposit value, per Andrea. An amount estimated at $301 can quote at $299 and so be ineligible without the user having been warned. Evan confirmed NEAR applies the rule to the quoted `amountIn` and handles near-boundary cases manually through support, so this is accepted rather than fixed. Warning post-quote was rejected as too late — the point is to stop the user before they commit.

### Testing

Full suite green after the rebase, built against the pinned SDK `3cecc010` with a freshly rebuilt FFI: `Test run with 1841 tests in 246 suites passed`, with the 5 pre-existing known issues unchanged.

Nine new reducer tests cover the boundary at exactly $300 (eligible, so it goes straight through), the per-surface unit each form measures, suppression not leaking across surfaces, Cancel persisting nothing, Continue persisting only when checked, and the skip bypass. The quote-rotation tests now pass `skipRefundWarning: true` so the interstitial cannot intercept ahead of the rotation they cover.

Manually verified on device by @LukasKorba.

### Not done

Thirteen Spanish strings are machine-drafted and marked `needs_review`, awaiting a translator. The acceptance criteria's no-truncation sweep across en/es-419, light/dark, small screen is still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)