### PR TITLE
[MOB-1786] Give the seed-backup prompt the top banner slot

### DIFF
--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -1104,10 +1104,18 @@ struct SmartBanner {
             case .evaluatePriority5:
                 return .send(.evaluatePriority6)
 
-                // MOB-1786: rung 6 is now a pass-through. The backup decision moved to
-                // `.evaluatePriorityWalletBackup` at the head of the walk; leaving the rung in
-                // place keeps the numbering and the rest of the chain (and its tests) intact.
+                // MOB-1786: the backup rung is asked at the head of the walk now, but it is
+                // ALSO still asked here. `RootTransactions` re-enters the ladder at this rung
+                // whenever the transactions array changes -- that is the hook that shows the
+                // prompt when a new wallet's first receive lands, at which point the head has
+                // already walked past an empty history. A pass-through here (the first cut of
+                // this change) rerouted that hook straight onto the shielding rung, so a
+                // transparent first receive seated the shielding offer and backup was never
+                // asked again. Field-caught by Lukas, 2026-09-10.
             case .evaluatePriority6:
+                if walletBackupClaimsSlot(state: &state) {
+                    return .send(.triggerPriority(.priority6))
+                }
                 return .send(.evaluatePriority7)
 
                 // wallet backup — MOB-1786: asked first, seats at rank -1.
@@ -1120,24 +1128,8 @@ struct SmartBanner {
                 // snooze is deliberately still honoured: MOB-1786 reorders, it does not override a
                 // choice the user made (reminder cadence is PRO-276's).
             case .evaluatePriorityWalletBackup:
-                guard let account = state.selectedWalletAccount, account.vendor == .zcash else {
-                    return .send(.evaluatePriority2)
-                }
-                guard !state.transactions.isEmpty else {
-                    return .send(.evaluatePriority2)
-                }
-                if let storedWallet = try? walletStorage.exportWallet(), !storedWallet.hasUserPassedPhraseBackupTest {
-                    if let walletBackupReminder = walletStorage.exportWalletBackupReminder() {
-                        state.remindMeWalletBackupPhaseCounter = walletBackupReminder.occurence
-                        let now = Date().timeIntervalSince1970
-
-                        if walletBackupReminder.isDue(now: now) {
-                            return .send(.triggerPriority(.priority6))
-                        }
-                    } else {
-                        // phase 1
-                        return .send(.triggerPriority(.priority6))
-                    }
+                if walletBackupClaimsSlot(state: &state) {
+                    return .send(.triggerPriority(.priority6))
                 }
                 return .send(.evaluatePriority2)
 
@@ -1484,6 +1476,31 @@ struct SmartBanner {
     /// subject is created and a first build kicked), which is what makes the status screen's
     /// first-frame paint non-empty. Full consolidation (the variant computed inside the loader,
     /// this store rendering `snapshot.banner`) is Brick 2b.
+    /// The wallet-backup decision (MOB-1786), shared by the two rungs that ask it: the head of
+    /// the walk (`.evaluatePriorityWalletBackup`) and rung 6, which `RootTransactions` re-enters
+    /// when the transactions array changes. Returns `true` when the prompt claims the slot; the
+    /// caller decides where a decline continues the walk. The gates are the original rung-6
+    /// gates, unchanged: a Zcash account, at least one transaction (a new wallet cannot spend, so
+    /// any transaction is a receive), a stored wallet whose phrase is not yet verified, and no
+    /// "Remind me later" snooze still running.
+    private func walletBackupClaimsSlot(state: inout State) -> Bool {
+        guard let account = state.selectedWalletAccount, account.vendor == .zcash else {
+            return false
+        }
+        guard !state.transactions.isEmpty else {
+            return false
+        }
+        guard let storedWallet = try? walletStorage.exportWallet(), !storedWallet.hasUserPassedPhraseBackupTest else {
+            return false
+        }
+        guard let walletBackupReminder = walletStorage.exportWalletBackupReminder() else {
+            // phase 1
+            return true
+        }
+        state.remindMeWalletBackupPhaseCounter = walletBackupReminder.occurence
+        return walletBackupReminder.isDue(now: Date().timeIntervalSince1970)
+    }
+
     private func migrationStateStreamEffect(accountUUID: AccountUUID?, cancelID: UUID) -> Effect<Action> {
         .publisher {
             Publishers.Merge(

--- a/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
+++ b/secant/Sources/Features/SmartBanner/SmartBannerStore.swift
@@ -100,6 +100,14 @@ struct SmartBanner {
             /// — there is nothing to retry against until connectivity itself returns.
             var rank: Double {
                 switch self {
+                // MOB-1786 (2026-09-09, approved): a wallet that has received funds and whose seed
+                // is still unbacked outranks EVERYTHING, a lost connection included. Three users
+                // lost funds while this rung sat at 6 and never reached the seat because migration
+                // or an error state held it. This supersedes two rulings documented above: the
+                // residual's 1.75 (2026-08-25) no longer outranks backup, and `priorityStalled`'s
+                // Retry (MOB-1853) yields to it. Neither of those moves relative to the other —
+                // only backup moves. `rawValue` stays 6 so the `next()` helper is untouched.
+                case .priority6: return -1
                 case .priorityMigration: return 1.5
                 case .priorityResidual: return 1.75
                 case .priorityStalled: return 0.75   // below a lost connection (0), above a sync error (1): a
@@ -289,6 +297,7 @@ struct SmartBanner {
         case evaluatePriority45
         case evaluatePriority5
         case evaluatePriority6
+        case evaluatePriorityWalletBackup
         case evaluatePriority7
         case shieldingOfferReevaluationRequested
         case shieldingBalanceFetched(AccountUUID, Zatoshi?)
@@ -866,7 +875,11 @@ struct SmartBanner {
                     MigrationTrace.event("banner ladder HELD — no account yet; waiting for accounts to load")
                     return .none
                 }
-                return .send(.evaluatePriority2)
+                // MOB-1786: the wallet-backup rung is asked FIRST, immediately after the account
+                // guard it also depends on. Rank alone is not enough — the walk short-circuits at
+                // the first match, so from rung 6 the prompt was never even asked while anything
+                // above it held the seat.
+                return .send(.evaluatePriorityWalletBackup)
 
                 // syncing error
             case .evaluatePriority2:
@@ -1091,13 +1104,27 @@ struct SmartBanner {
             case .evaluatePriority5:
                 return .send(.evaluatePriority6)
 
-                // wallet backup
+                // MOB-1786: rung 6 is now a pass-through. The backup decision moved to
+                // `.evaluatePriorityWalletBackup` at the head of the walk; leaving the rung in
+                // place keeps the numbering and the rest of the chain (and its tests) intact.
             case .evaluatePriority6:
+                return .send(.evaluatePriority7)
+
+                // wallet backup — MOB-1786: asked first, seats at rank -1.
+                //
+                // The gates are unchanged from the old rung 6. A brand-new wallet cannot spend, so
+                // any transaction at all is a receive — which is why `transactions.isEmpty` is the
+                // right "has received funds" test and why spending back down to zero must not
+                // retract the prompt. `hasUserPassedPhraseBackupTest` lives in the keychain and
+                // ends the prompt for good once the user has backed up. The "Remind me later"
+                // snooze is deliberately still honoured: MOB-1786 reorders, it does not override a
+                // choice the user made (reminder cadence is PRO-276's).
+            case .evaluatePriorityWalletBackup:
                 guard let account = state.selectedWalletAccount, account.vendor == .zcash else {
-                    return .send(.evaluatePriority7)
+                    return .send(.evaluatePriority2)
                 }
                 guard !state.transactions.isEmpty else {
-                    return .send(.evaluatePriority7)
+                    return .send(.evaluatePriority2)
                 }
                 if let storedWallet = try? walletStorage.exportWallet(), !storedWallet.hasUserPassedPhraseBackupTest {
                     if let walletBackupReminder = walletStorage.exportWalletBackupReminder() {
@@ -1112,7 +1139,7 @@ struct SmartBanner {
                         return .send(.triggerPriority(.priority6))
                     }
                 }
-                return .send(.evaluatePriority7)
+                return .send(.evaluatePriority2)
 
                 // shielding
             case .evaluatePriority7:

--- a/zodlTests/SmartBannerTests/SmartBannerResidualSlotTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerResidualSlotTests.swift
@@ -9,6 +9,10 @@
 //  Tor, currency conversion) rank below it. The suppression trade-off was accepted knowingly —
 //  at the old bottom rank a dust wallet could wait behind currency conversion forever.
 //
+//  PARTLY SUPERSEDED 2026-09-09 by MOB-1786 (approved): wallet backup left the informational
+//  rungs and now ranks -1, above everything. The residual keeps 1.75 and keeps outranking
+//  shielding, Tor and currency conversion; it no longer outranks backup. Nothing else moved.
+//
 
 import ComposableArchitecture
 import Foundation
@@ -81,12 +85,13 @@ import Testing
         }
     }
 
-    /// REVERSED 2026-08-25 (approved): the residual now ranks 1.75 — directly below the migration
-    /// slot — so a residual answer arriving while wallet backup (`priority6`) holds the slot
-    /// re-runs the ladder and takes it. The suppression trade-off was accepted knowingly: the
-    /// residual is actionable and self-retiring, and at rank 11 a dust wallet could wait forever
-    /// behind currency conversion (the field report that triggered the reversal).
-    @Test func residualDisplacesTheInformationalBannersBelowIt() async {
+    /// RE-REVERSED 2026-09-09 by MOB-1786 (approved), for the backup rung only: at rank -1 a
+    /// wallet that has received funds with an unbacked seed outranks the residual, so a residual
+    /// answer arriving while backup holds the slot must NOT take it. The 2026-08-25 reasoning
+    /// still stands against every other informational rung — see
+    /// `residualDisplacesTheInformationalBannersBelowIt` below, which keeps that coverage against
+    /// currency conversion. Three users losing funds outranks a dust wallet waiting.
+    @Test func aResidualCannotDisplaceASeatedWalletBackup() async {
         await withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
@@ -114,7 +119,49 @@ import Testing
             await store.receive(\.triggerPriority)
             await store.receive(\.openBannerRequest)
 
-            #expect(store.state.priorityContent == .priorityResidual, "at rank 1.75 the residual outranks the wallet-backup seat")
+            #expect(
+                store.state.priorityContent == .priority6,
+                "MOB-1786: at rank -1 the wallet-backup seat outranks an arriving residual"
+            )
+        }
+    }
+
+    /// The 2026-08-25 ruling, kept alive against a rung that is still below the residual. The
+    /// original version of this test used wallet backup as the seated banner; MOB-1786 moved
+    /// backup above the residual (see `aResidualCannotDisplaceASeatedWalletBackup`), so the
+    /// coverage moved to currency conversion (rung 8) — informational, and still outranked.
+    @Test func residualDisplacesTheInformationalBannersBelowIt() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = SmartBanner.State()
+            state.$featureFlags.withLock { $0 = FeatureFlags(migration: true) }
+            state.$selectedWalletAccount.withLock { $0 = Self.walletAccount() }
+            state.priorityContent = .priority8
+
+            let answer = Self.residual
+
+            let store = TestStore(initialState: state) {
+                SmartBanner()
+            } withDependencies: {
+                $0.mainQueue = .immediate
+                var client = MigrationManagerClient.noOp
+                client.bannerVariant = { _ in answer }
+                $0.migrationManager = client
+                $0.sdkSynchronizer = .mocked()
+            }
+            store.exhaustivity = .off
+
+            await store.send(.migrationVariantUpdated(Self.residual))
+            await store.receive(\.evaluatePriority1)
+            await store.receive(\.evaluatePriorityResidual)
+            await store.receive(\.triggerPriority)
+            await store.receive(\.openBannerRequest)
+
+            #expect(
+                store.state.priorityContent == .priorityResidual,
+                "at rank 1.75 the residual still outranks the currency-conversion seat"
+            )
         }
     }
 
@@ -251,11 +298,11 @@ import Testing
         }
     }
 
-    /// REVERSED 2026-08-25 (approved): at rank 1.75 the residual outranks wallet backup, and the
-    /// walk order agrees — the migration rung sits above rung 6, so a residual answer seats before
-    /// the backup rung is ever asked. Same backup-owed fixture as the original test, opposite
-    /// expectation, so the reversal is pinned rather than implied.
-    @Test func aResidualArrivingOnAnEmptySlotOutranksWalletBackup() async {
+    /// RE-REVERSED 2026-09-09 by MOB-1786 (approved): backup is now asked FIRST — the walk runs
+    /// it straight after the account guard, before the migration and residual rungs — and it
+    /// seats at rank -1. Same backup-owed fixture as the two previous versions of this test,
+    /// opposite expectation again, so each reversal stays pinned rather than implied.
+    @Test func walletBackupOutranksAResidualArrivingOnAnEmptySlot() async {
         await withDependencies {
             $0.defaultInMemoryStorage = InMemoryStorage()
         } operation: {
@@ -285,13 +332,13 @@ import Testing
 
             await store.send(.migrationVariantUpdated(Self.residual))
             await store.receive(\.evaluatePriority1)
-            await store.receive(\.evaluatePriorityResidual)
+            await store.receive(\.evaluatePriorityWalletBackup)
             await store.receive(\.triggerPriority)
             await store.receive(\.openBannerRequest)
 
             #expect(
-                store.state.priorityContent == .priorityResidual,
-                "the migration rung sits above the backup rung — a residual answer seats before backup is asked"
+                store.state.priorityContent == .priority6,
+                "MOB-1786: the backup rung is asked before the residual rung and outranks it"
             )
         }
     }

--- a/zodlTests/SmartBannerTests/SmartBannerWalletBackupPriorityTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerWalletBackupPriorityTests.swift
@@ -206,6 +206,64 @@ import Testing
         }
     }
 
+    // MARK: - The first-receive hook (rung 6)
+
+    // `RootTransactions` re-enters the ladder at `.evaluatePriority6` whenever the transactions
+    // array changes. That hook is how a NEW wallet gets the prompt: at init-done the head rung
+    // walked past an empty history, so the first receive is the first time backup can claim.
+    // The first cut of MOB-1786 made rung 6 a pass-through and the hook landed on the shielding
+    // rung instead -- a transparent first receive seated the shielding offer and backup was never
+    // asked again (field-caught 2026-09-10). Both directions are pinned here.
+    @Test func theFirstReceiveReasksBackupAtRungSixAndDisplacesShielding() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Self.backupOwedState()
+            // The transparent-receive shielding offer already holds the slot.
+            state.priorityContent = .priority7
+            let store = Self.store(state)
+
+            await store.send(.evaluatePriority6)
+            await store.receive(\.triggerPriority)
+            await store.receive(\.openBannerRequest)
+            await store.finish()
+
+            #expect(store.state.priorityContent == .priority6, "the first receive must surface backup even over a seated shielding offer")
+        }
+    }
+
+    @Test func theFirstReceiveReasksBackupAtRungSixOnAnEmptySlot() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Self.store(Self.backupOwedState())
+
+            await store.send(.evaluatePriority6)
+            await store.receive(\.triggerPriority)
+            await store.receive(\.openBannerRequest)
+            await store.finish()
+
+            #expect(store.state.priorityContent == .priority6)
+        }
+    }
+
+    // With nothing owed, rung 6 walks on exactly as it always did.
+    @Test func rungSixStillWalksOnWhenNoBackupIsOwed() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Self.backupOwedState()
+            state.$transactions.withLock { $0 = [] }
+            let store = Self.store(state)
+
+            await store.send(.evaluatePriority6)
+            await store.receive(\.evaluatePriority7)
+            await store.finish()
+
+            #expect(store.state.priorityContent != .priority6)
+        }
+    }
+
     // MARK: - Gates that did not change
 
     // A wallet with no transactions has received nothing — nothing is at risk yet, so the walk

--- a/zodlTests/SmartBannerTests/SmartBannerWalletBackupPriorityTests.swift
+++ b/zodlTests/SmartBannerTests/SmartBannerWalletBackupPriorityTests.swift
@@ -1,0 +1,246 @@
+//
+//  SmartBannerWalletBackupPriorityTests.swift
+//  zodlTests
+//
+//  MOB-1786 (approved 2026-09-09): a wallet that has received funds while its seed is still
+//  unbacked shows the backup prompt ahead of every other banner. Three users lost funds because
+//  the rung sat at 6 — bottom half of the ladder — and the walk short-circuits at the first
+//  match, so migration or an error state holding the seat meant the prompt was never even asked.
+//
+//  Two things had to change together and this suite pins both: the rung is now asked FIRST
+//  (straight after the ladder's account guard, as `.evaluatePriorityWalletBackup`), and it seats
+//  at rank -1 so it also wins in the displacement direction. Changing only one leaves the other
+//  ordering wrong.
+//
+//  What did NOT change: the gates. A new wallet cannot spend, so any transaction is a receive —
+//  which is why `transactions.isEmpty` is the "has received funds" test, and why spending back
+//  down to zero must not retract the prompt. The keychain's `hasUserPassedPhraseBackupTest` ends
+//  it for good, and the user's own "Remind me later" is still honoured (reminder cadence belongs
+//  to PRO-276).
+//
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct SmartBannerWalletBackupPriorityTests {
+    private static func walletAccount() -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: 9, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+
+    /// Currency conversion (rung 8) claims the slot whenever it is unconfigured, which would end
+    /// any walk before the rungs under test.
+    private static func preferencesWithCurrencyConversionSetUp() -> UserPreferencesStorageClient {
+        var preferences = UserPreferencesStorageClient()
+        preferences.exchangeRate = { UserPreferencesStorage.ExchangeRate(manual: true, automatic: true) }
+        return preferences
+    }
+
+    /// The backup rung's own conditions: a Zcash account, at least one transaction (i.e. funds
+    /// were received), and `.noOp` wallet storage, whose `StoredWallet.placeholder` has not
+    /// passed the phrase backup test and has no reminder on record — so it claims at phase 1.
+    private static func backupOwedState() -> SmartBanner.State {
+        var state = SmartBanner.State()
+        state.$selectedWalletAccount.withLock { $0 = walletAccount() }
+        state.$transactions.withLock { $0 = [TransactionState.mockedReceived] }
+        return state
+    }
+
+    private static func store(_ state: SmartBanner.State) -> TestStore<SmartBanner.State, SmartBanner.Action> {
+        let store = TestStore(initialState: state) {
+            SmartBanner()
+        } withDependencies: {
+            $0.mainQueue = .immediate
+            $0.migrationManager = .noOp
+            $0.sdkSynchronizer = .mocked()
+            $0.walletStorage = .noOp
+            $0.userStoredPreferences = preferencesWithCurrencyConversionSetUp()
+            $0.continuousClock = ImmediateClock()
+        }
+        store.exhaustivity = .off
+        return store
+    }
+
+    // MARK: - Rank
+
+    // Rank is the single ordering authority for displacement. -1 has to beat every other rung,
+    // including the two this ticket knowingly supersedes: the residual (1.75, 2026-08-25) and
+    // the terminal-stall Retry (0.75, MOB-1853).
+    @Test func backupOutranksEveryOtherRung() {
+        let backup = SmartBanner.State.PriorityContent.priority6.rank
+        for other in [
+            SmartBanner.State.PriorityContent.priority1,       // disconnected, 0
+            .priorityStalled,                                  // 0.75, MOB-1853
+            .priority2,                                        // sync error, 1
+            .priorityMigration,                                // 1.5
+            .priorityResidual,                                 // 1.75, MOB-1749
+            .priority3, .priority4, .priority5, .priority7, .priority8, .priority9
+        ] {
+            #expect(backup < other.rank, "wallet backup must outrank \(other)")
+        }
+    }
+
+    // The walk-down helper reads `rawValue`, which deliberately did NOT move — only `rank` did.
+    @Test func rawValueIsUnchangedSoTheWalkDownHelperIsUntouched() {
+        #expect(SmartBanner.State.PriorityContent.priority6.rawValue == 6)
+        #expect(SmartBanner.State.PriorityContent.priority7.next() == .priority6)
+    }
+
+    // MARK: - Walk order
+
+    // The ladder asks backup straight after the account guard, ahead of the migration and
+    // residual rungs. Rank alone would not save it: the walk stops at the first match.
+    @Test func theLadderAsksBackupFirst() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            let store = Self.store(Self.backupOwedState())
+
+            await store.send(.evaluatePriority1)
+            await store.receive(\.evaluatePriorityWalletBackup)
+            await store.receive(\.triggerPriority)
+            // `.triggerPriority` only records the request; `.openBannerRequest` applies the rank
+            // guard and assigns the seat.
+            await store.receive(\.openBannerRequest)
+            await store.finish()
+
+            #expect(store.state.priorityContent == .priority6)
+        }
+    }
+
+    // The reported bug, from the displacement side: a banner already seated must give the slot up.
+    @Test func backupDisplacesASeatedMigrationBanner() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Self.backupOwedState()
+            state.priorityContent = .priorityMigration
+            let store = Self.store(state)
+
+            await store.send(.evaluatePriority1)
+            await store.receive(\.evaluatePriorityWalletBackup)
+            await store.receive(\.triggerPriority)
+            // `.triggerPriority` only records the request; `.openBannerRequest` applies the rank
+            // guard and assigns the seat.
+            await store.receive(\.openBannerRequest)
+            await store.finish()
+
+            #expect(store.state.priorityContent == .priority6, "migration held the seat for days in the field report")
+        }
+    }
+
+    @Test func backupDisplacesASeatedStalledBanner() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Self.backupOwedState()
+            state.priorityContent = .priorityStalled
+            state.isSyncStalledTerminally = true
+            let store = Self.store(state)
+
+            await store.send(.evaluatePriority1)
+            await store.receive(\.evaluatePriorityWalletBackup)
+            await store.receive(\.triggerPriority)
+            // `.triggerPriority` only records the request; `.openBannerRequest` applies the rank
+            // guard and assigns the seat.
+            await store.receive(\.openBannerRequest)
+            await store.finish()
+
+            #expect(
+                store.state.priorityContent == .priority6,
+                "MOB-1786 knowingly supersedes MOB-1853: the stall's Retry yields to an unbacked seed holding funds"
+            )
+        }
+    }
+
+    // The production path. `featureFlags.migration` gates only the ladder's PULL rung; in a
+    // production build (flag off) the migration banner arrives by PUSH — the manager's state
+    // stream funnels into `.migrationVariantUpdated`, which seats `priorityMigration` with no
+    // flag check at all. So the displacement test above is not enough: backup must also HOLD
+    // when a `.required` variant is pushed at it while it owns the slot. The R3 claim branch
+    // still fires `triggerPriority(.priorityMigration)`; the rank guard in `.openBannerRequest`
+    // (1.5 >= -1) has to be what rejects it.
+    @Test func aPushedMigrationVariantCannotDisplaceASeatedWalletBackup() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Self.backupOwedState()
+            state.$featureFlags.withLock { $0 = FeatureFlags(migration: false) }
+            state.priorityContent = .priority6
+
+            let store = TestStore(initialState: state) {
+                SmartBanner()
+            } withDependencies: {
+                $0.mainQueue = .immediate
+                var client = MigrationManagerClient.noOp
+                client.bannerVariant = { _ in .required }
+                $0.migrationManager = client
+                $0.sdkSynchronizer = .mocked()
+                $0.walletStorage = .noOp
+                $0.userStoredPreferences = Self.preferencesWithCurrencyConversionSetUp()
+                $0.continuousClock = ImmediateClock()
+            }
+            store.exhaustivity = .off
+
+            await store.send(.migrationVariantUpdated(.required))
+            await store.receive(\.triggerPriority)
+            await store.receive(\.openBannerRequest)
+            await store.finish()
+
+            #expect(
+                store.state.priorityContent == .priority6,
+                "a pushed migration variant (the production path, flag off) must not take the seat from backup"
+            )
+        }
+    }
+
+    // MARK: - Gates that did not change
+
+    // A wallet with no transactions has received nothing — nothing is at risk yet, so the walk
+    // must fall through to the rest of the ladder rather than claim the top slot.
+    @Test func noTransactionsMeansNoPrompt() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Self.backupOwedState()
+            state.$transactions.withLock { $0 = [] }
+            let store = Self.store(state)
+
+            await store.send(.evaluatePriority1)
+            await store.receive(\.evaluatePriorityWalletBackup)
+            await store.receive(\.evaluatePriority2)
+            await store.finish()
+
+            #expect(store.state.priorityContent != .priority6)
+        }
+    }
+
+    // The ladder refuses to walk at all without an account — backup is asked after that guard,
+    // never before it.
+    @Test func noAccountHoldsTheLadderBeforeBackupIsAsked() async {
+        await withDependencies {
+            $0.defaultInMemoryStorage = InMemoryStorage()
+        } operation: {
+            var state = Self.backupOwedState()
+            state.$selectedWalletAccount.withLock { $0 = nil }
+            let store = Self.store(state)
+
+            await store.send(.evaluatePriority1)
+            await store.finish()
+
+            #expect(store.state.priorityContent == nil)
+        }
+    }
+}


### PR DESCRIPTION
Implements [MOB-1786](https://linear.app/zodl/issue/MOB-1786/seed-backup-prompt-should-take-priority-over-migration-and-error-state).

Three users lost funds because they never backed up their recovery phrase. The backup prompt sat at rung 6 — the bottom half of the ladder — so whenever migration or an error state held the banner slot, the prompt was not merely outranked: the walk short-circuits at the first match, so it was **never asked**.

### Stacked on #2107

Based on `MOB-1889-under-300` ([#2107](https://github.com/zodl-inc/zodl-ios/pull/2107)), so this PR shows only its own commit. It retargets to `main` automatically once #2107 merges.

### What changed

Both orderings had to move together, because the ladder decides the *initial* seat by walk position and *displacement* by rank — changing one leaves the other wrong:

- The rung is asked **first**, immediately after the account guard it already depended on, as `.evaluatePriorityWalletBackup`.
- It seats at **rank -1**, above everything including a lost connection.

`rawValue` deliberately stays 6, so the `next()` walk-down helper and its existing tests are untouched. Rung 6 remains as a pass-through, keeping the rest of the chain and its tests intact.

### What did not change

The gates are exactly as they were. A brand-new wallet cannot spend, so any transaction at all is a receive — which is why `transactions.isEmpty` is the right "has received funds" test, and why spending back down to zero must not retract the prompt. `hasUserPassedPhraseBackupTest` lives in the keychain and ends the prompt for good once the user has backed up.

The user's own **"Remind me later" is still honoured**. This ticket reorders; it does not override a choice the user made. Reminder cadence belongs to PRO-276.

### How the migration banner actually reaches production — and why it matters here

`featureFlags.migration` is `false` in every mainnet flavour and gates only the ladder's **pull** rung (`.evaluatePriorityMigration`), the foreground check, and the `.upToDate` recheck. In production the migration banner arrives by **push**: `.onAppear` arms `migrationStateStreamEffect` (no flag), the manager's state/snapshot events funnel through `.migrationStateChanged` / `.migrationReevaluationRequested` into `bannerVariant` (no flag), and `.migrationVariantUpdated` seats `priorityMigration` (no flag). The only gate on that path is inside the manager — `isIronwoodActivated()` plus funds to migrate.

So a displacement test that re-runs the ladder is not sufficient on its own. This PR also proves the **hold** direction against the production path: with backup seated, a pushed `.required` variant still fires `triggerPriority(.priorityMigration)`, and the rank guard in `.openBannerRequest` (1.5 ≥ -1) is what rejects it — `aPushedMigrationVariantCannotDisplaceASeatedWalletBackup`.

### Review-round fix: the first-receive hook (rung 6)

Field-caught by Lukas while testing this PR: a new wallet that received 1 TAZ to its transparent address got the **shielding** banner, never backup. Cause: `RootTransactions` re-enters the ladder at `.evaluatePriority6` whenever the transactions array changes — that hook is how a *new* wallet gets the prompt at all, since at init-done the head rung walked past an empty history. The first cut of this PR made rung 6 a pass-through to rung 7, so the hook landed on the shielding rung instead.

Fixed by extracting the backup decision into `walletBackupClaimsSlot(state:)`, used by both the head rung (declines continue at rung 2) and rung 6 (declines continue at rung 7, exactly as before). Rank -1 wins wherever it is asked, so a seated shielding offer is displaced. Pinned by `theFirstReceiveReasksBackupAtRungSixAndDisplacesShielding`, the empty-slot variant, and a nothing-owed walk-on test; the existing rung-6 test in the residual suite is unaffected.

### This supersedes two approved rulings

Both were pinned by tests that failed on the rank change. They have been flipped with the new reasoning recorded in the file's own convention, not quietly adjusted:

- **MOB-1749's residual dust at 1.75** (approved 2026-08-25) no longer outranks backup. It keeps 1.75 and still outranks shielding, Tor and currency conversion — `residualDisplacesTheInformationalBannersBelowIt` keeps that coverage, now against currency conversion instead of backup.
- **MOB-1853's terminal-stall Retry at 0.75** now yields to an unbacked seed holding funds. During a terminal stall the Retry is displaced until the user backs up or dismisses.

Neither moves relative to the other; only backup moves. Flagging both explicitly for @michal-fousek, since they were deliberate calls.

### Testing

Full suite green with the 5 pre-existing known issues unchanged. The existing suite was run *before* any test was touched, so the code identified what the reorder broke rather than the expectations being adjusted to fit — exactly two tests failed, both predicted.

New `SmartBannerWalletBackupPriorityTests` covers rank against every other rung, `rawValue` staying put, the ladder asking backup first, displacement of a seated migration banner and a seated stalled banner, the pushed-variant hold above, and the gates that must still hold — no transactions, and no account holding the ladder before backup is asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
