### PR TITLE
[#2113] Read @Shared on demand in liveValue-built classes to break a cold-launch deadlock

### DIFF
--- a/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
+++ b/secant/Sources/Dependencies/MigrationManager/MigrationManagerLiveKey.swift
@@ -309,8 +309,22 @@ final class MigrationManagerImpl: @unchecked Sendable {
     // `RandomNumberGenerator`.
     @Dependency(\.migrationRandomness) var migrationRandomness
 
-    @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
-    @Shared(.inMemory(.walletAccounts)) var walletAccounts: [WalletAccount] = []
+    // #2113: resolved on demand, never stored. A stored `@Shared` retains its persistent reference
+    // in `init`, and `init` runs inside swift-dependencies' `liveValue` construction, which holds
+    // the dependency-cache lock. A store sitting in `$walletAccounts.withLock` on another thread
+    // at that instant holds the reference lock and reads a dependency inside the closure — the two
+    // lock orders cross and the app freezes behind the "hi" splash at cold launch. Resolving the
+    // reference at read time takes the reference lock without the cache lock, so no cycle exists.
+    var selectedWalletAccount: WalletAccount? {
+        @Shared(.inMemory(.selectedWalletAccount)) var shared: WalletAccount? = nil
+        return shared
+    }
+
+    var walletAccounts: [WalletAccount] {
+        @Shared(.inMemory(.walletAccounts)) var shared: [WalletAccount] = []
+        return shared
+    }
+
     @Dependency(\.userNotifications) var userNotifications
 
     // The three seams `MigrationStepDriver` needs to discharge the engine's `.rebuild` step without

--- a/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorLiveKey.swift
+++ b/secant/Sources/Dependencies/ShieldingProcessor/ShieldingProcessorLiveKey.swift
@@ -23,9 +23,8 @@ extension ShieldingProcessorClient: DependencyKey {
     }
 }
 
-// TCA's `@Dependency` and `@Shared` property wrappers synthesize `var` storage but are themselves
-// thread-safe (task-local dependency lookup / shared-state machinery). The Combine `subject` is
-// reference-counted Sendable storage.
+// TCA's `@Dependency` property wrappers synthesize `var` storage but are themselves thread-safe
+// (task-local dependency lookup). The Combine `subject` is reference-counted Sendable storage.
 private final class ShieldingProcessorImpl: @unchecked Sendable {
     @Dependency(\.derivationTool) var derivationTool
     @Dependency(\.mnemonic) var mnemonic
@@ -33,7 +32,13 @@ private final class ShieldingProcessorImpl: @unchecked Sendable {
     @Dependency(\.walletStorage) var walletStorage
     @Dependency(\.zcashSDKEnvironment) var zcashSDKEnvironment
 
-    @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+    // #2113: resolved on demand, never stored — a stored `@Shared` retains its persistent
+    // reference inside `liveValue` construction, under swift-dependencies' cache lock; see
+    // `MigrationManagerImpl` for the lock cycle that produces. Same fix for the same reason.
+    var selectedWalletAccount: WalletAccount? {
+        @Shared(.inMemory(.selectedWalletAccount)) var shared: WalletAccount? = nil
+        return shared
+    }
 
     let subject = CurrentValueSubject<ShieldingProcessorClient.State, Never>(.unknown)
 

--- a/zodlTests/DependenciesTests/LiveValueConstructionLockTests.swift
+++ b/zodlTests/DependenciesTests/LiveValueConstructionLockTests.swift
@@ -1,0 +1,137 @@
+//
+//  LiveValueConstructionLockTests.swift
+//  zodlTests
+//
+//  #2113 — a dependency's live implementation must be constructible while another thread holds a
+//  swift-sharing reference lock.
+//
+//  swift-dependencies builds `liveValue` under its dependency-cache lock; `Shared.withLock` reads a
+//  dependency (`sharedChangeTracker`) while holding the reference lock. A stored `@Shared` on a
+//  class that `liveValue` creates retains that reference INSIDE the build — so the moment a store
+//  sits in `$walletAccounts.withLock` on another thread, the two lock orders cross and both threads
+//  wait forever. That is the cold-launch freeze behind the "hi" splash: `.loadedWalletAccounts`
+//  spawns both the smart-banner ladder (which resolves `migrationManager` cold, on the cooperative
+//  pool) and the private-UA stash refill (which writes through `$walletAccounts.withLock` on main).
+//
+//  The property is pinned directly, without the library's cache lock: the reference locks are held
+//  on a plain thread, construction runs on a child task that shares this test's dependency context
+//  (swift-dependencies keys its cache by the current swift-testing test, so a GCD thread would
+//  resolve a DIFFERENT `PersistentReferences` and prove nothing), and construction must finish.
+//  With a stored `@Shared` the constructor blocks in `_PersistentReference.retain()` until the
+//  timeout. The last test pins that the on-demand accessors still read the live shared value.
+//
+
+import Foundation
+import Testing
+@testable @preconcurrency import ZcashLightClientKit
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite(.serialized) struct LiveValueConstructionLockTests {
+    @Test func migrationManagerConstructsWhileAccountReferencesAreLocked() async {
+        @Shared(.inMemory(.walletAccounts)) var walletAccounts: [WalletAccount] = []
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        nonisolated(unsafe) let accounts = $walletAccounts
+        nonisolated(unsafe) let selected = $selectedWalletAccount
+
+        let finished = await Self.constructionFinishes(
+            whileHolding: { body in
+                accounts.withLock { _ in
+                    selected.withLock { _ in body() }
+                }
+            },
+            construct: { _ = Self.migrationManager() }
+        )
+
+        #expect(finished, "MigrationManagerImpl.init must not take a shared-state reference lock")
+    }
+
+    @Test func shieldingProcessorConstructsWhileSelectedAccountIsLocked() async {
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        nonisolated(unsafe) let selected = $selectedWalletAccount
+
+        let finished = await Self.constructionFinishes(
+            whileHolding: { body in selected.withLock { _ in body() } },
+            construct: { _ = ShieldingProcessorClient.live() }
+        )
+
+        #expect(finished, "ShieldingProcessorClient.live() must not take a shared-state reference lock")
+    }
+
+    @Test func onDemandAccessorsReadTheLiveSharedValue() {
+        @Shared(.inMemory(.walletAccounts)) var walletAccounts: [WalletAccount] = []
+        @Shared(.inMemory(.selectedWalletAccount)) var selectedWalletAccount: WalletAccount? = nil
+        let manager = Self.migrationManager()
+        let account = Self.walletAccount(idByte: 7)
+
+        $walletAccounts.withLock { $0 = [account] }
+        $selectedWalletAccount.withLock { $0 = account }
+
+        #expect(manager.walletAccounts == [account])
+        #expect(manager.selectedWalletAccount == account)
+    }
+
+    // MARK: - Helpers
+
+    /// Holds whatever `hold` locks on a plain thread, then runs `construct` on a child task (which
+    /// inherits this test's dependency context) and reports whether it finished within `timeout`.
+    /// The locks are released as soon as the race is decided, so a constructor that did block is
+    /// freed rather than leaked.
+    private static func constructionFinishes(
+        whileHolding hold: @escaping @Sendable (_ body: () -> Void) -> Void,
+        construct: @escaping @Sendable () -> Void,
+        timeout: Swift.Duration = .seconds(5)
+    ) async -> Bool {
+        let release = DispatchSemaphore(value: 0)
+        await withCheckedContinuation { (locked: CheckedContinuation<Void, Never>) in
+            Thread {
+                hold {
+                    locked.resume()
+                    release.wait()
+                }
+            }.start()
+        }
+
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                construct()
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            let finished = await group.next() ?? false
+            release.signal()
+            group.cancelAll()
+            return finished
+        }
+    }
+
+    /// Scoped storage, so constructing the manager never touches `UserDefaults.standard`.
+    private static func migrationManager() -> MigrationManagerImpl {
+        let suiteName = "LiveValueConstructionLockTests.\(UUID().uuidString)"
+        // swiftlint:disable:next force_unwrapping
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        return MigrationManagerImpl(
+            gateStorage: MigrationGateStorage(userDefaults: userDefaults),
+            scheduleStorage: MigrationScheduleStorage(userDefaults: userDefaults),
+            snapshotStorage: MigrationSnapshotStorage(userDefaults: userDefaults),
+            failureRoutingStorage: MigrationFailureRoutingStorage(userDefaults: userDefaults)
+        )
+    }
+
+    private static func walletAccount(idByte: UInt8) -> WalletAccount {
+        WalletAccount(
+            Account(
+                id: AccountUUID(id: [UInt8](repeating: idByte, count: 16)),
+                name: "Zodl",
+                keySource: nil,
+                seedFingerprint: nil,
+                hdAccountIndex: Zip32AccountIndex(0),
+                ufvk: nil,
+                uivk: nil
+            )
+        )
+    }
+}


### PR DESCRIPTION
Fixes #2113. Related: #2112 (launch-path hardening umbrella).

## What
`MigrationManagerImpl` and `ShieldingProcessorImpl` read their `@Shared` values on demand instead of holding them as stored properties. No behavior change at any read site; the class no longer takes a swift-sharing reference lock while being constructed.

## Why
ABBA deadlock, taken from a `sample` of a hung testnet build:

- **main:** `.privateUAStashRefilled` → `PrivateUAStash.write` → `$walletAccounts.withLock` — holds swift-sharing's `_PersistentReference.lock`; inside the closure swift-sharing reads `@Dependency(\.sharedChangeTracker)` → waits on swift-dependencies' `CachedValues.lock`.
- **cooperative pool:** SmartBanner `.evaluatePriorityMigration` → `.run { migrationManager.bannerVariant(…) }` resolves `\.migrationManager` cold → swift-dependencies 1.6.4 holds `CachedValues.lock` for the whole `liveValue` build → `MigrationManagerImpl.init` → stored `@Shared(.inMemory(.walletAccounts))` → `_PersistentReference.retain()` → waits on the lock main holds.

Both effects come from the same `.loadedWalletAccounts` merge and nothing warms `migrationManager` on main before it at cold launch, so the first touch is always cold. Half B (stored `@Shared`, f36fd417) has shipped since 3.9.x; half A (launch-time stash refill, 6c7a458c) reached `main` with #2071, ~5½ h after the 3.12.0 tag. No tagged build has both; `main` does. Mainnet/internal are protected only by `featureFlags.migration == false` on the ladder rung; testnet builds from `main` hang intermittently.

## Test
`LiveValueConstructionLockTests` holds `$walletAccounts` / `$selectedWalletAccount` locks on a plain thread while constructing `MigrationManagerImpl` and `ShieldingProcessorClient.live()` on a child task that shares the test's dependency context (swift-dependencies keys its cache by the current swift-testing test, so a GCD thread would prove nothing). Red on the unfixed sources (both construction tests timed out at the 5 s bound, `LiveValueConstructionLockTests.swift:46` / `:58`), green after (3/3 in 18 ms). A third test pins that the on-demand accessors read the live shared value.

Full `zodl-internal` suite on a dedicated simulator: `** TEST SUCCEEDED **` — `━ Test run with 1844 tests in 247 suites passed after 43.234 seconds with 5 known issues.` (the 5 are the pre-existing `withKnownIssue` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
