### PR TITLE
[MOB-1863] Remove the awaiting-confirmation label from sent transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ tooling, CI, tests, and internal refactors are deliberately not listed.
 ### Changed
 
 - [MOB-1858] Sending no longer waits behind unrelated network work. Preparing a payment now runs alongside other activity instead of blocking it, and if the wallet is still busy with something else by the time it's ready to broadcast, the transaction is shown as pending and submitted automatically in the background instead of being reported as a failure.
-- [MOB-1863] A sent transaction now shows "Sent · awaiting confirmation" once a server has accepted it, instead of "Sending" until the wallet catches up.
 
 ### Fixed
 

--- a/secant/Resources/Localizable.xcstrings
+++ b/secant/Resources/Localizable.xcstrings
@@ -23831,23 +23831,6 @@
         }
       }
     },
-    "transaction.sentAwaitingConfirmation" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sent · awaiting confirmation"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviado · esperando confirmación"
-          }
-        }
-      }
-    },
     "transaction.shieldedFunds" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
+++ b/secant/Sources/Dependencies/SDKSynchronizer/SDKSynchronizerLive.swift
@@ -857,15 +857,6 @@ extension SDKSynchronizerClient {
                 currentChainTip: currentChainTip
             )
 
-            // MOB-1863: a `.sending` row can already be accepted by a server for broadcast even
-            // though this device's own scan hasn't caught up yet. Only look this up for rows
-            // that need it, so mined/received rows don't pay for an extra query.
-            if transaction.status == .sending {
-                if case .accepted = await synchronizer.transactionSubmissionStatus(for: clearedTransaction.rawID) {
-                    transaction.isAcceptedBySubmitter = true
-                }
-            }
-
             // MOB-1856: the SDK's `getRecipients(for:)` is itself just
             // `getTransactionOutputs(for:).map { $0.recipient }` -- reuse the `outputs` already read
             // above instead of a second call that re-reads the exact same rows from the database.

--- a/secant/Sources/Models/TransactionState.swift
+++ b/secant/Sources/Models/TransactionState.swift
@@ -47,10 +47,6 @@ struct TransactionState: Equatable, Identifiable {
     var zecAmount: Zatoshi
     var isMarkedAsRead = false
     var isInAddressBook = false
-    /// A sent, unmined transaction that a server has already accepted for broadcast (SDK
-    /// `TransactionSubmissionStatus.accepted`). Lets a `.sending` row read "awaiting
-    /// confirmation" instead of "Sending" once the network has it, not just this device.
-    var isAcceptedBySubmitter = false
     var hasTransparentOutputs = false
     var totalSpent: Zatoshi?
     var totalReceived: Zatoshi?
@@ -189,9 +185,7 @@ struct TransactionState: Equatable, Identifiable {
             case .receiving:
                 return String(localizable: .transactionReceiving)
             case .sending:
-                return isAcceptedBySubmitter
-                ? String(localizable: .transactionSentAwaitingConfirmation)
-                : String(localizable: .transactionSending)
+                return String(localizable: .transactionSending)
             case .shielding:
                 return String(localizable: .transactionShieldingFunds)
             case .shielded:

--- a/zodlTests/ModelsTests/TransactionStateTests.swift
+++ b/zodlTests/ModelsTests/TransactionStateTests.swift
@@ -348,30 +348,4 @@ import Foundation
         state.status = .failed
         #expect(state.daysAgo.isEmpty)
     }
-
-    // MARK: - Submission acceptance (MOB-1863)
-
-    /// Once a server has accepted a sent, unmined transaction for broadcast, the row must read
-    /// "Sent · awaiting confirmation" rather than the generic "Sending" - the wallet's own scan
-    /// catching up is not the same as the network not having the transaction yet.
-    @Test func sendingTransactionAcceptedBySubmitterShowsAwaitingConfirmation() {
-        var state = TransactionState(fee: Zatoshi(10), id: "s", status: .sending, zecAmount: Zatoshi(-10))
-        state.isAcceptedBySubmitter = true
-        #expect(state.title() == String(localizable: .transactionSentAwaitingConfirmation))
-    }
-
-    /// Without server acceptance, a sending transaction keeps today's generic "Sending" label.
-    @Test func sendingTransactionNotYetAcceptedShowsSending() {
-        var state = TransactionState(fee: Zatoshi(10), id: "s", status: .sending, zecAmount: Zatoshi(-10))
-        state.isAcceptedBySubmitter = false
-        #expect(state.title() == String(localizable: .transactionSending))
-    }
-
-    /// The flag only matters while a transaction is still `.sending` - a mined (`.paid`)
-    /// transaction ignores it and keeps its regular label.
-    @Test func minedTransactionIgnoresTheAcceptedFlag() {
-        var state = TransactionState(fee: Zatoshi(10), id: "m", status: .paid, zecAmount: Zatoshi(-10))
-        state.isAcceptedBySubmitter = true
-        #expect(state.title() == String(localizable: .transactionSent))
-    }
 }


### PR DESCRIPTION
Linear: MOB-1863 (part of MOB-1848).

## What

Removes the app-side change that showed a sent, unmined transaction as "Sent · awaiting confirmation" once a server had accepted it. This is the exact inverse of 81b2d0c9:

- `TransactionState` loses the `isAcceptedBySubmitter` flag; a `.sending` row reads "Sending" until it is mined, as it did before.
- The live synchronizer mapping no longer asks the SDK for a transaction's submission status when it maps a `.sending` row.
- The two localized strings (en, es) and the three label tests are removed.
- The Unreleased changelog bullet for the label is removed; nothing about it ever shipped.

## Why

The label was not a requested change. The SDK's `transactionSubmissionStatus(for:)` API (MOB-1851) is untouched and simply unused by the app now.

## Test plan

- Build for testing succeeds (the generated string accessor for the removed entry disappears with it).
- `TransactionStateTests` is back to its pre-change set, including the test that a `.sending` row shows "Sending"; the Root transaction suites pass.
- Manual: with a wallet that has a just-sent transaction, the Activity row shows "Sending" until the transaction is mined; no "awaiting confirmation" text anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
