### PR TITLE
[MOB-1909] Start the splash once per manager and invalidate its timer when it finishes

### DIFF
--- a/secant/Sources/UIComponents/Overlays/SplashView.swift
+++ b/secant/Sources/UIComponents/Overlays/SplashView.swift
@@ -40,16 +40,22 @@ final class SplashManager: ObservableObject {
         self.isHidden = isHidden
         self.screenSize = UIScreen.main.bounds.size
         self.completion = completion
-        
-        if !isHidden {
-            preparePoints()
-            if featureFlags.appLaunchBiometric {
-                authenticate()
-            } else {
-                Task {
-                    self.spinTheWheel()
-                }
-            }
+    }
+
+    // MOB-1909: `SplashModifier` constructs a manager on every body evaluation and `@StateObject`
+    // keeps only the first, so anything `init` did ran once per re-render — an authentication
+    // request and a 60 Hz timer per orphan. The side effects now live here, run once per manager,
+    // from `SplashView.onAppear`; an orphan is one allocation that does nothing.
+    private var hasStarted = false
+
+    @MainActor func start() {
+        guard !hasStarted, !isHidden else { return }
+        hasStarted = true
+        preparePoints()
+        if featureFlags.appLaunchBiometric {
+            authenticate()
+        } else {
+            spinTheWheel()
         }
     }
 
@@ -58,7 +64,7 @@ final class SplashManager: ObservableObject {
 
         authenticationDidntSucceed = false
 
-        Task {
+        task = Task {
             if await !localAuthentication.authenticate() {
                 self.authenticationFailed()
             } else {
@@ -147,7 +153,12 @@ final class SplashManager: ObservableObject {
     }
     
     @MainActor func finished() {
-        self.isOn.toggle()
+        guard isOn else { return }
+        // MOB-1909: the timer's block retains `self`; without this the wheel kept ticking
+        // (and this manager kept living) for the rest of the session.
+        timer?.invalidate()
+        timer = nil
+        isOn = false
         completion()
     }
 }
@@ -206,6 +217,7 @@ struct SplashView: View {
                 lockedIcons()
             }
             .ignoresSafeArea(.keyboard)
+            .onAppear { splashManager.start() }
         }
     }
     

--- a/zodlTests/SplashTests/SplashManagerTests.swift
+++ b/zodlTests/SplashTests/SplashManagerTests.swift
@@ -1,0 +1,127 @@
+//
+//  SplashManagerTests.swift
+//  zodlTests
+//
+//  MOB-1909 — `SplashModifier` builds a `SplashManager` on every body evaluation and `@StateObject`
+//  keeps only the first. Anything the initializer does therefore runs once per re-render of the
+//  root view while the splash is up: it used to request Face ID and start a 60 Hz timer per orphan,
+//  and `finished()` never invalidated the timer whose block retained the manager. These tests pin
+//  the repaired contract: `init` is inert, `start()` does the work exactly once, a failed
+//  authentication shows the retry state without spinning, and `finished()` invalidates and
+//  completes once.
+//
+
+import Foundation
+import Testing
+import ComposableArchitecture
+@testable import zodl_internal
+
+@Suite(.serialized) @MainActor struct SplashManagerTests {
+    @MainActor private struct Harness {
+        let authenticationCalls = LockIsolated(0)
+        let completions = LockIsolated(0)
+
+        func manager(isHidden: Bool = false) -> SplashManager {
+            SplashManager(isHidden) { completions.withValue { $0 += 1 } }
+        }
+
+        /// Runs `body` with `localAuthentication.authenticate` answering `succeeds`, counting calls.
+        func withAuthentication<R>(succeeding succeeds: Bool, _ body: () throws -> R) rethrows -> R {
+            try withDependencies(
+                {
+                    $0.localAuthentication.authenticate = {
+                        authenticationCalls.withValue { $0 += 1 }
+                        return succeeds
+                    }
+                },
+                operation: body
+            )
+        }
+    }
+
+    private func setBiometricFlag(_ isOn: Bool) {
+        @Shared(.inMemory(.featureFlags)) var featureFlags: FeatureFlags = .initial
+        $featureFlags.withLock { $0 = FeatureFlags(appLaunchBiometric: isOn) }
+    }
+
+    @Test func initHasNoSideEffects() {
+        let harness = Harness()
+        setBiometricFlag(true)
+
+        let manager = harness.withAuthentication(succeeding: true) { harness.manager() }
+
+        #expect(harness.authenticationCalls.value == 0)
+        #expect(manager.timer == nil)
+        #expect(manager.points.isEmpty)
+    }
+
+    @Test func startRequestsAuthenticationOnceAndThenSpins() async {
+        let harness = Harness()
+        setBiometricFlag(true)
+        let manager = harness.manager()
+
+        harness.withAuthentication(succeeding: true) {
+            manager.start()
+            manager.start()
+        }
+        await manager.task?.value
+
+        #expect(harness.authenticationCalls.value == 1)
+        #expect(!manager.points.isEmpty)
+        #expect(manager.timer != nil)
+        manager.finished()
+    }
+
+    @Test func startSpinsWithoutAuthenticationWhenTheFlagIsOff() {
+        let harness = Harness()
+        setBiometricFlag(false)
+        let manager = harness.manager()
+
+        harness.withAuthentication(succeeding: true) { manager.start() }
+
+        #expect(harness.authenticationCalls.value == 0)
+        #expect(manager.timer != nil)
+        manager.finished()
+    }
+
+    @Test func aFailedAuthenticationShowsTheRetryStateWithoutSpinning() async {
+        let harness = Harness()
+        setBiometricFlag(true)
+        let manager = harness.manager()
+
+        harness.withAuthentication(succeeding: false) { manager.start() }
+        await manager.task?.value
+
+        #expect(manager.authenticationDidntSucceed)
+        #expect(manager.timer == nil)
+        #expect(harness.completions.value == 0)
+    }
+
+    @Test func finishedInvalidatesTheTimerAndCompletesOnce() {
+        let harness = Harness()
+        setBiometricFlag(false)
+        let manager = harness.manager()
+        harness.withAuthentication(succeeding: true) { manager.start() }
+        let timer = manager.timer
+
+        manager.finished()
+        manager.finished()
+
+        #expect(timer?.isValid == false)
+        #expect(manager.timer == nil)
+        #expect(!manager.isOn)
+        #expect(harness.completions.value == 1)
+    }
+
+    @Test func aHiddenManagerNeverStarts() {
+        let harness = Harness()
+        setBiometricFlag(true)
+        let manager = harness.manager(isHidden: true)
+
+        harness.withAuthentication(succeeding: true) { manager.start() }
+
+        #expect(harness.authenticationCalls.value == 0)
+        #expect(manager.timer == nil)
+        #expect(manager.points.isEmpty)
+    }
+}


### PR DESCRIPTION
Refs #2112 (MOB-1909). One of the issue's four items; the rest is deliberately not in this PR — see the end.

## What
`SplashModifier` builds a `SplashManager` on every body evaluation and hands it to `@StateObject`, which keeps only the first. The initializer did the work — prepare the wipe, request Face ID, start a 60 Hz timer — so every re-render of the root view while the splash was up produced an orphan that authenticated and ticked anyway, and `finished()` never invalidated the timer whose block retained the manager for the rest of the session.

Now `init` only stores; `start()`, called from `SplashView.onAppear`, does the work once per manager; `finished()` invalidates the timer and completes once; the authentication task is kept in the existing `task` property. An orphan manager is one allocation that does nothing. The 15-minute re-auth path is unchanged: a foreground that flips `splashAppeared` still gets a fresh view identity, hence a fresh manager and a fresh prompt.

## What the code says about the "stuck on hi" reports (corrections to the issue text)
- A hung `start()` does **not** hold "hi": `.home` is dispatched 0.5 s after the wallet is read, independent of the SDK effect. It leaves Home with dead sync — a different symptom.
- The only way to see "hi" for seconds is a blocked main thread before HomeView's first paint. Which step blocks is unmeasured: two observations, no telemetry.

## Not in this PR, on purpose
- A launch timeline in the log was built and dropped: `walletLogger` is installed only under `#if DEBUG`, so every Release build (production, internal, testnet) logs nothing and the timeline could never reach a field report without changing that policy.
- Keychain/seed derivation off the main thread, hi-screen liveness, early Face ID, a UI-acting start watchdog — all wait for a reproducible case or a policy decision on logging in internal builds.

## History
The branch was force-pushed once: the timeline commit and its review-round commit were dropped, and this commit was rebuilt on `main` without the four `launchTimeline` lines the earlier version carried in `SplashView.swift`. `git range-diff` against the earlier splash commit: `1: 7f285789 ! 1: db05f624` — same patch; the only differences are the removed `launchTimeline` context lines.

## Tests
`SplashManagerTests` (6 — inert `init`, `start()` authenticates once then spins, no auth when the flag is off, failed auth shows retry without spinning, `finished()` invalidates and completes once, hidden manager never starts). A red run against the old type is not possible — it has no `start()` — so the `init` side effects are documented in the diff rather than by a failing test.

Full `zodl-internal` suite on a dedicated simulator: `** TEST SUCCEEDED **` — `━ Test run with 1862 tests in 249 suites passed after 47.139 seconds with 5 known issues.` (the 5 are the pre-existing `withKnownIssue` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
